### PR TITLE
feat(6): 로그아웃 및 토큰 삭제

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/auth/controller/AuthController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/auth/controller/AuthController.java
@@ -63,7 +63,7 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<String> logout(HttpServletRequest request, HttpServletResponse response) {
+    public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response) {
         String refreshToken = null;
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
@@ -86,7 +86,7 @@ public class AuthController {
         cookie.setPath("/");
         response.addCookie(cookie);
 
-        return ResponseEntity.ok("성공적으로 로그아웃되었습니다.");
+        return ResponseEntity.noContent().build();
     }
 
     private Cookie createCookie(String key, String value) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/auth/service/RefreshTokenService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/auth/service/RefreshTokenService.java
@@ -1,17 +1,14 @@
 package kr.co.awesomelead.groupware_backend.auth.service;
 
+import java.time.LocalDateTime;
 import kr.co.awesomelead.groupware_backend.auth.entity.RefreshToken;
 import kr.co.awesomelead.groupware_backend.auth.repository.RefreshTokenRepository;
 import kr.co.awesomelead.groupware_backend.auth.util.JWTUtil;
 import kr.co.awesomelead.groupware_backend.global.CustomException;
 import kr.co.awesomelead.groupware_backend.global.ErrorCode;
-
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -23,40 +20,48 @@ public class RefreshTokenService {
     // Refresh Token의 유효 기간 (초 단위, 예: 7일)
     private static final long REFRESH_TOKEN_VALIDITY_IN_SECONDS = 7 * 24 * 60 * 60;
 
-    /** 새로운 Refresh Token을 생성하고 DB에 저장하는 메소드 */
+    /**
+     * 새로운 Refresh Token을 생성하고 DB에 저장하는 메소드
+     */
     @Transactional
     public String createAndSaveRefreshToken(String email, String role) {
         // 1. 새로운 토큰 값 생성
         String newRefreshTokenValue =
-                jwtUtil.createJwt(email, role, REFRESH_TOKEN_VALIDITY_IN_SECONDS * 1000);
+            jwtUtil.createJwt(email, role, REFRESH_TOKEN_VALIDITY_IN_SECONDS * 1000);
 
         // 2. 만료 시간 계산
         LocalDateTime expiration =
-                LocalDateTime.now().plusSeconds(REFRESH_TOKEN_VALIDITY_IN_SECONDS);
+            LocalDateTime.now().plusSeconds(REFRESH_TOKEN_VALIDITY_IN_SECONDS);
 
         // 3. 해당 사용자의 기존 Refresh Token이 있다면 삭제
         refreshTokenRepository.findByEmail(email).ifPresent(refreshTokenRepository::delete);
 
         // 4. 새로운 Refresh Token 엔티티 생성 및 저장
         RefreshToken newRefreshToken =
-                RefreshToken.builder()
-                        .email(email)
-                        .tokenValue(newRefreshTokenValue)
-                        .expirationDate(expiration)
-                        .build();
+            RefreshToken.builder()
+                .email(email)
+                .tokenValue(newRefreshTokenValue)
+                .expirationDate(expiration)
+                .build();
         refreshTokenRepository.save(newRefreshToken);
 
         return newRefreshTokenValue;
     }
 
-    /** DB에서 토큰을 찾아 유효성을 검증하는 메소드 */
+    @Transactional
+    public void deleteRefreshToken(String refreshTokenValue) {
+        // 전달받은 토큰 값으로 DB에서 해당 토큰을 찾아 존재하면 삭제
+        refreshTokenRepository.findByTokenValue(refreshTokenValue)
+            .ifPresent(refreshTokenRepository::delete);
+    }
+
     @Transactional(readOnly = true)
     public RefreshToken validateRefreshToken(String tokenValue) {
         // DB에서 토큰을 찾지 못하면 예외 발생
         RefreshToken token =
-                refreshTokenRepository
-                        .findByTokenValue(tokenValue)
-                        .orElseThrow(() -> new CustomException(ErrorCode.INVALID_TOKEN));
+            refreshTokenRepository
+                .findByTokenValue(tokenValue)
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_TOKEN));
 
         // DB에 저장된 만료 시간으로 유효성 검사
         if (token.isExpired()) {

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/RefreshTokenServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/RefreshTokenServiceTest.java
@@ -10,13 +10,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
 import kr.co.awesomelead.groupware_backend.auth.entity.RefreshToken;
 import kr.co.awesomelead.groupware_backend.auth.repository.RefreshTokenRepository;
 import kr.co.awesomelead.groupware_backend.auth.service.RefreshTokenService;
 import kr.co.awesomelead.groupware_backend.auth.util.JWTUtil;
 import kr.co.awesomelead.groupware_backend.global.CustomException;
 import kr.co.awesomelead.groupware_backend.global.ErrorCode;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,20 +26,20 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDateTime;
-import java.util.Optional;
-
 @ExtendWith(MockitoExtension.class)
 class RefreshTokenServiceTest {
 
-    @Mock private RefreshTokenRepository refreshTokenRepository;
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
 
-    @Mock private JWTUtil jwtUtil;
+    @Mock
+    private JWTUtil jwtUtil;
 
-    @InjectMocks private RefreshTokenService refreshTokenService;
+    @InjectMocks
+    private RefreshTokenService refreshTokenService;
 
     @Test
-    @DisplayName("새로운 Refresh Token 생성 및 저장 성공 (기존 토큰 없음)")
+    @DisplayName("Refresh Token 생성 성공 - 기존 토큰 없음")
     void createAndSaveRefreshToken_Success_NoExistingToken() {
         // given
         String email = "test@example.com";
@@ -46,7 +47,7 @@ class RefreshTokenServiceTest {
         String generatedTokenValue = "new-refresh-token";
 
         when(jwtUtil.createJwt(anyString(), anyString(), anyLong()))
-                .thenReturn(generatedTokenValue);
+            .thenReturn(generatedTokenValue);
         when(refreshTokenRepository.findByEmail(email)).thenReturn(Optional.empty());
 
         // when
@@ -69,7 +70,7 @@ class RefreshTokenServiceTest {
     }
 
     @Test
-    @DisplayName("새로운 Refresh Token 생성 및 저장 성공 (기존 토큰 존재 시 삭제)")
+    @DisplayName("Refresh Token 생성 성공 - 기존 토큰 존재 시 삭제 후 생성")
     void createAndSaveRefreshToken_Success_WithExistingToken() {
         // given
         String email = "test@example.com";
@@ -78,7 +79,7 @@ class RefreshTokenServiceTest {
         RefreshToken existingToken = RefreshToken.builder().email(email).build();
 
         when(jwtUtil.createJwt(anyString(), anyString(), anyLong()))
-                .thenReturn(generatedTokenValue);
+            .thenReturn(generatedTokenValue);
         when(refreshTokenRepository.findByEmail(email)).thenReturn(Optional.of(existingToken));
 
         // when
@@ -94,18 +95,58 @@ class RefreshTokenServiceTest {
     }
 
     @Test
+    @DisplayName("로그아웃 성공 - 토큰 존재 시 삭제")
+    void deleteRefreshToken_Success_WhenTokenExists() {
+        // given
+        String tokenValue = "existing-token";
+        RefreshToken existingToken = RefreshToken.builder().tokenValue(tokenValue).build();
+
+        // findByTokenValue가 호출되면, existingToken을 포함한 Optional을 반환하도록 설정
+        when(refreshTokenRepository.findByTokenValue(tokenValue)).thenReturn(
+            Optional.of(existingToken));
+
+        // when
+        refreshTokenService.deleteRefreshToken(tokenValue);
+
+        // then
+        // findByTokenValue가 1번 호출되었는지 확인
+        verify(refreshTokenRepository, times(1)).findByTokenValue(tokenValue);
+        // delete 메소드가 existingToken 객체를 인자로 하여 1번 호출되었는지 확인
+        verify(refreshTokenRepository, times(1)).delete(existingToken);
+    }
+
+    @Test
+    @DisplayName("로그아웃 성공 - 토큰이 존재하지 않아도 에러 없음")
+    void deleteRefreshToken_Success_WhenTokenDoesNotExist() {
+        // given
+        String tokenValue = "non-existent-token";
+
+        // findByTokenValue가 호출되면, 비어있는 Optional을 반환하도록 설정
+        when(refreshTokenRepository.findByTokenValue(tokenValue)).thenReturn(Optional.empty());
+
+        // when
+        refreshTokenService.deleteRefreshToken(tokenValue);
+
+        // then
+        // findByTokenValue는 호출되지만,
+        verify(refreshTokenRepository, times(1)).findByTokenValue(tokenValue);
+        // ifPresent의 조건이 거짓이므로 delete 메소드는 절대 호출되지 않았는지 확인
+        verify(refreshTokenRepository, never()).delete(any(RefreshToken.class));
+    }
+
+    @Test
     @DisplayName("Refresh Token 검증 성공")
     void validateRefreshToken_Success() {
         // given
         String tokenValue = "valid-token";
         RefreshToken validToken =
-                RefreshToken.builder()
-                        .tokenValue(tokenValue)
-                        .expirationDate(LocalDateTime.now().plusDays(1)) // 만료되지 않음
-                        .build();
+            RefreshToken.builder()
+                .tokenValue(tokenValue)
+                .expirationDate(LocalDateTime.now().plusDays(1)) // 만료되지 않음
+                .build();
 
         when(refreshTokenRepository.findByTokenValue(tokenValue))
-                .thenReturn(Optional.of(validToken));
+            .thenReturn(Optional.of(validToken));
         // RefreshToken 클래스의 isExpired()가 false를 반환한다고 가정
 
         // when
@@ -126,9 +167,9 @@ class RefreshTokenServiceTest {
 
         // when & then
         CustomException exception =
-                assertThrows(
-                        CustomException.class,
-                        () -> refreshTokenService.validateRefreshToken(tokenValue));
+            assertThrows(
+                CustomException.class,
+                () -> refreshTokenService.validateRefreshToken(tokenValue));
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_TOKEN);
     }
 
@@ -139,19 +180,19 @@ class RefreshTokenServiceTest {
         String tokenValue = "expired-token";
         // isExpired() 메서드가 true를 반환하도록 expirationDate를 과거로 설정
         RefreshToken expiredToken =
-                RefreshToken.builder()
-                        .tokenValue(tokenValue)
-                        .expirationDate(LocalDateTime.now().minusDays(1))
-                        .build();
+            RefreshToken.builder()
+                .tokenValue(tokenValue)
+                .expirationDate(LocalDateTime.now().minusDays(1))
+                .build();
 
         when(refreshTokenRepository.findByTokenValue(tokenValue))
-                .thenReturn(Optional.of(expiredToken));
+            .thenReturn(Optional.of(expiredToken));
 
         // when & then
         CustomException exception =
-                assertThrows(
-                        CustomException.class,
-                        () -> refreshTokenService.validateRefreshToken(tokenValue));
+            assertThrows(
+                CustomException.class,
+                () -> refreshTokenService.validateRefreshToken(tokenValue));
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.EXPIRED_TOKEN);
 
         // 만료된 토큰이므로 delete 메서드가 호출되었는지 검증


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #이슈 번호
#6 

## 📝작업 내용
- 로그아웃 API 추가
- 로그아웃 API에 대해 204 반환
- 로그인시 기존 토큰이 있으면 갱신, 없으면 생성으로 변경

## 📸 스크린샷 (선택)
<img width="2710" height="682" alt="image" src="https://github.com/user-attachments/assets/192976ed-c529-4589-ada6-5ad525a86f2b" />
<img width="2024" height="784" alt="image" src="https://github.com/user-attachments/assets/d0d2ac63-dc2d-475c-b09b-85f3d3c438aa" />



## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X