### PR TITLE
feat(24): 내방객 사전 접수 구현

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/controller/VisitController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/controller/VisitController.java
@@ -1,16 +1,18 @@
 package kr.co.awesomelead.groupware_backend.domain.visit.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+
 import jakarta.validation.Valid;
-import java.net.URI;
-import java.util.List;
+
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.request.VisitCreateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.request.VisitSearchRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.response.MyVisitResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.response.VisitResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.response.VisitSummaryResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.service.VisitService;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -19,6 +21,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,37 +36,36 @@ public class VisitController {
     @Operation(summary = "사전 방문 접수", description = "내방객이 온라인으로 사전방문접수를 수행합니다.")
     @PostMapping("/pre-registration")
     public ResponseEntity<VisitResponseDto> createPreVisit(
-        @RequestBody @Valid VisitCreateRequestDto requestDto) {
+            @RequestBody @Valid VisitCreateRequestDto requestDto) {
 
         VisitResponseDto responseDto = visitService.createPreVisit(requestDto);
 
         return ResponseEntity.created(URI.create("/api/visits/" + responseDto.getId()))
-            .body(responseDto);
+                .body(responseDto);
     }
 
     // 현장 방문 접수
     @Operation(summary = "현장 방문 접수", description = "내방객이 현장에서 방문접수를 수행합니다.")
     @PostMapping("/on-site")
     public ResponseEntity<VisitResponseDto> createOnSiteVisit(
-        @RequestBody @Valid VisitCreateRequestDto requestDto) {
+            @RequestBody @Valid VisitCreateRequestDto requestDto) {
 
         VisitResponseDto responseDto = visitService.createOnSiteVisit(requestDto);
 
         return ResponseEntity.created(URI.create("/api/visits/" + responseDto.getId()))
-            .body(responseDto);
+                .body(responseDto);
     }
 
     @Operation(summary = "내 방문 정보 조회 ", description = "내방객이 사전등록 정보를 조회합니다.")
     @GetMapping("/visitor")
     public ResponseEntity<List<VisitSummaryResponseDto>> getMyVisits(
-        @RequestBody @Valid VisitSearchRequestDto requestDto) {
+            @RequestBody @Valid VisitSearchRequestDto requestDto) {
 
         return ResponseEntity.ok(visitService.getMyVisits(requestDto));
     }
 
     @GetMapping("/visitor/{visitId}")
-    public ResponseEntity<MyVisitResponseDto> getMyVisitDetail(
-        @PathVariable Long visitId) {
+    public ResponseEntity<MyVisitResponseDto> getMyVisitDetail(@PathVariable Long visitId) {
 
         return ResponseEntity.ok(visitService.getMyVisitDetail(visitId));
     }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/request/VisitSearchRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/request/VisitSearchRequestDto.java
@@ -3,6 +3,7 @@ package kr.co.awesomelead.groupware_backend.domain.visit.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,8 +15,7 @@ import lombok.Setter;
 @AllArgsConstructor
 public class VisitSearchRequestDto {
 
-    @NotBlank
-    private String name;
+    @NotBlank private String name;
 
     @NotBlank
     @Pattern(regexp = "^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$", message = "올바른 전화번호 형식이 아닙니다.")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/response/MyVisitResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/response/MyVisitResponseDto.java
@@ -1,10 +1,12 @@
 package kr.co.awesomelead.groupware_backend.domain.visit.dto.response;
 
-import java.time.LocalDateTime;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitPurpose;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -15,7 +17,7 @@ public class MyVisitResponseDto {
     private String visitorCompany;
     private String visitorName;
     private VisitPurpose purpose;
-    private String hostDepartment; //담당 부서
+    private String hostDepartment; // 담당 부서
     private String phoneNumber; // 내방객휴대전화 번호
     private LocalDateTime visitStartDate;
     private LocalDateTime visitEndDate;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/response/VisitSummaryResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/response/VisitSummaryResponseDto.java
@@ -1,9 +1,10 @@
 package kr.co.awesomelead.groupware_backend.domain.visit.dto.response;
 
-import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -14,5 +15,4 @@ public class VisitSummaryResponseDto {
     private String visitorName;
     private String visitorCompany;
     private LocalDateTime visitStartDate;
-
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/entity/Visit.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/entity/Visit.java
@@ -2,6 +2,7 @@ package kr.co.awesomelead.groupware_backend.domain.visit.entity;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -14,18 +15,21 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
+
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitPurpose;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitType;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Setter
 @Getter
@@ -104,13 +108,13 @@ public class Visit {
     }
 
     public static Visit createBaseVisit(
-        User host,
-        Visitor visitor,
-        String hostCompany,
-        String visitorCompany,
-        VisitPurpose purpose,
-        String carNumber,
-        LocalDateTime start) {
+            User host,
+            Visitor visitor,
+            String hostCompany,
+            String visitorCompany,
+            VisitPurpose purpose,
+            String carNumber,
+            LocalDateTime start) {
         Visit visit = new Visit();
         visit.user = host;
         visit.visitor = visitor;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/mapper/VisitMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/mapper/VisitMapper.java
@@ -1,6 +1,5 @@
 package kr.co.awesomelead.groupware_backend.domain.visit.mapper;
 
-import java.util.List;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.request.CompanionRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.request.VisitCreateRequestDto;
@@ -11,8 +10,11 @@ import kr.co.awesomelead.groupware_backend.domain.visit.entity.Companion;
 import kr.co.awesomelead.groupware_backend.domain.visit.entity.Visit;
 import kr.co.awesomelead.groupware_backend.domain.visit.entity.Visitor;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitType;
+
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+
+import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface VisitMapper {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/repository/VisitRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/repository/VisitRepository.java
@@ -1,9 +1,11 @@
 package kr.co.awesomelead.groupware_backend.domain.visit.repository;
 
-import java.util.List;
 import kr.co.awesomelead.groupware_backend.domain.visit.entity.Visit;
 import kr.co.awesomelead.groupware_backend.domain.visit.entity.Visitor;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface VisitRepository extends JpaRepository<Visit, Long> {
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/CustomException.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/CustomException.java
@@ -11,5 +11,4 @@ public class CustomException extends RuntimeException {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
-
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/ErrorCode.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/ErrorCode.java
@@ -2,6 +2,7 @@ package kr.co.awesomelead.groupware_backend.global;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 
 @Getter
@@ -15,7 +16,7 @@ public enum ErrorCode {
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     VISIT_ALREADY_CHECKED_OUT(HttpStatus.BAD_REQUEST, "이미 체크아웃된 방문정보입니다."),
     VISITOR_PASSWORD_REQUIRED_FOR_PRE_REGISTRATION(
-        HttpStatus.BAD_REQUEST, "사전 방문 예약 시 내방객 비밀번호가 필요합니다."),
+            HttpStatus.BAD_REQUEST, "사전 방문 예약 시 내방객 비밀번호가 필요합니다."),
 
     // 401 Unauthorized
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/GlobalExceptionHandler.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/GlobalExceptionHandler.java
@@ -1,12 +1,13 @@
 package kr.co.awesomelead.groupware_backend.global;
 
-import java.util.HashMap;
-import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -14,11 +15,11 @@ public class GlobalExceptionHandler {
     // DTO 유효성 검사
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, String>> handleValidationExceptions(
-        MethodArgumentNotValidException ex) {
+            MethodArgumentNotValidException ex) {
         Map<String, String> errors = new HashMap<>();
-        ex.getBindingResult().getFieldErrors().forEach(error ->
-            errors.put(error.getField(), error.getDefaultMessage())
-        );
+        ex.getBindingResult()
+                .getFieldErrors()
+                .forEach(error -> errors.put(error.getField(), error.getDefaultMessage()));
         return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #24 

## 📝작업 내용
- 내방객 사전 등록 구현
- 이름, 전화번호, 비밀번호를 통한 내방객 방문 정보 조회 및 방문처리
- 사전 등록정보에 대한 현장 방문처리시 방문 시작시간을 현재 시간으로 갱신
- 퇴실처리 구현 (차후 해당 로직에 대한 접근권한 필요)

## 📸 스크린샷 (선택)
<img width="1490" height="690" alt="image" src="https://github.com/user-attachments/assets/5932a834-f2af-4726-980a-b1decf278f73" />
<img width="1490" height="648" alt="image" src="https://github.com/user-attachments/assets/148a3ae6-d9c2-4e9f-8f39-2533307b42fc" />


## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [ ] 테스트를 수행함

## 💬리뷰 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?