### PR TITLE
refactor(49): 공통 ApiResponse 공지사항 도메인 적용

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/controller/NoticeController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/controller/NoticeController.java
@@ -1,10 +1,9 @@
 package kr.co.awesomelead.groupware_backend.domain.notice.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+
 import jakarta.validation.Valid;
-import java.io.IOException;
-import java.net.URI;
-import java.util.List;
+
 import kr.co.awesomelead.groupware_backend.domain.notice.dto.request.NoticeCreateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.notice.dto.request.NoticeUpdateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.notice.dto.response.NoticeDetailDto;
@@ -13,7 +12,9 @@ import kr.co.awesomelead.groupware_backend.domain.notice.enums.NoticeType;
 import kr.co.awesomelead.groupware_backend.domain.notice.service.NoticeService;
 import kr.co.awesomelead.groupware_backend.domain.user.dto.CustomUserDetails;
 import kr.co.awesomelead.groupware_backend.global.common.response.ApiResponse;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -29,6 +30,10 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/notices")
 @RequiredArgsConstructor
@@ -39,18 +44,18 @@ public class NoticeController {
     @Operation(summary = "공지 생성", description = "새로운 공지를 생성합니다.")
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Long>> createNotice(
-        @RequestPart("requestDto") @Valid NoticeCreateRequestDto requestDto,
-        @RequestPart(value = "files", required = false) List<MultipartFile> files,
-        @AuthenticationPrincipal CustomUserDetails userDetails)
-        throws IOException {
+            @RequestPart("requestDto") @Valid NoticeCreateRequestDto requestDto,
+            @RequestPart(value = "files", required = false) List<MultipartFile> files,
+            @AuthenticationPrincipal CustomUserDetails userDetails)
+            throws IOException {
 
         Long noticeId = noticeService.createNotice(requestDto, files, userDetails.getId());
 
         URI location =
-            ServletUriComponentsBuilder.fromCurrentRequest()
-                .path("/{id}")
-                .buildAndExpand(noticeId)
-                .toUri();
+                ServletUriComponentsBuilder.fromCurrentRequest()
+                        .path("/{id}")
+                        .buildAndExpand(noticeId)
+                        .toUri();
 
         return ResponseEntity.created(location).body(ApiResponse.onCreated(noticeId));
     }
@@ -58,7 +63,7 @@ public class NoticeController {
     @Operation(summary = "공지 목록 조회", description = "특정 유형의 공지 목록을 조회합니다.")
     @GetMapping
     public ResponseEntity<ApiResponse<List<NoticeSummaryDto>>> getNotices(
-        @RequestParam NoticeType type) {
+            @RequestParam NoticeType type) {
         List<NoticeSummaryDto> notices = noticeService.getNoticesByType(type);
         return ResponseEntity.ok(ApiResponse.onSuccess(notices));
     }
@@ -73,7 +78,7 @@ public class NoticeController {
     @Operation(summary = "공지 삭제", description = "특정 공지를 삭제합니다.")
     @DeleteMapping("/{noticeId}")
     public ResponseEntity<ApiResponse<Void>> deleteNotice(
-        @PathVariable Long noticeId, @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @PathVariable Long noticeId, @AuthenticationPrincipal CustomUserDetails userDetails) {
         noticeService.deleteNotice(userDetails.getId(), noticeId);
         return ResponseEntity.ok(ApiResponse.onNoContent());
     }
@@ -81,11 +86,11 @@ public class NoticeController {
     @Operation(summary = "공지 수정", description = "특정 공지를 수정합니다.")
     @PatchMapping("/{noticeId}")
     public ResponseEntity<ApiResponse<Long>> updateNotice(
-        @AuthenticationPrincipal CustomUserDetails userDetails,
-        @PathVariable Long noticeId,
-        @RequestPart(value = "notice") @Valid NoticeUpdateRequestDto dto,
-        @RequestPart(value = "files", required = false) List<MultipartFile> files)
-        throws IOException {
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long noticeId,
+            @RequestPart(value = "notice") @Valid NoticeUpdateRequestDto dto,
+            @RequestPart(value = "files", required = false) List<MultipartFile> files)
+            throws IOException {
 
         Long updatedId = noticeService.updateNotice(userDetails.getId(), noticeId, dto, files);
 


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #49 

## 📝작업 내용
- NoticeController에 ApiResponse 적용

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [ ] 테스트를 수행함

## 💬리뷰 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?