### PR TITLE
refactor: SecurityConfig에 계정 삭제와 본인인증 확인 api를 permitAll로 추가

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/config/SecurityConfig.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/config/SecurityConfig.java
@@ -3,9 +3,7 @@ package kr.co.awesomelead.groupware_backend.config;
 import kr.co.awesomelead.groupware_backend.domain.auth.filter.JwtFilter;
 import kr.co.awesomelead.groupware_backend.domain.auth.util.JWTUtil;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
-
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -34,7 +32,7 @@ public class SecurityConfig {
     // AuthenticationManager Bean 등록
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration)
-            throws Exception {
+        throws Exception {
         return configuration.getAuthenticationManager();
     }
 
@@ -58,48 +56,47 @@ public class SecurityConfig {
         http.httpBasic((auth) -> auth.disable());
 
         http.authorizeHttpRequests(
-                (auth) ->
-                        auth.requestMatchers(
-                                        "/",
-                                        "/index.html",
-                                        "/api/test/**",
-                                        "/api/auth/login",
-                                        "/api/auth/signup",
-                                        "/api/auth/reissue",
-                                        "/api/auth/send-phone-code",
-                                        "/api/auth/verify-phone-code",
-                                        "/api/auth/send-email-code",
-                                        "/api/auth/verify-email-code",
-                                        "/api/auth/find-email",
-                                        "/api/auth/reset-password/email",
-                                        "/api/auth/reset-password/phone",
-                                        "/api/join",
-                                        "/api/join/send-code",
-                                        "/api/join/verify-code",
-                                        "/api/reissue",
-                                        "/api/admin/**", // 테스트용으로 어드민 경로도 열어놓음
-                                        "/api/visits/**",
-                                        "/api/edu-reports/attachments/{id}/download", // 테스트용으로 교육자료
-                                        // 다운로드 열어놓음
-                                        "/api/test/**",
-                                        "/api/departments/hierarchy",
-                                        "/api/departments/{departmentId}/users")
-                                .permitAll()
-                                .requestMatchers(
-                                        "/api/auth/logout",
-                                        "/api/auth/reset-password", // 로그인 상태에서의 비번 변경
-                                        "/api/admin/**", // 관리자 기능
-                                        "/api/visits/**" // 방문 관리
-                                        )
-                                .authenticated()
-                                .anyRequest()
-                                .authenticated());
+            (auth) ->
+                auth.requestMatchers(
+                        "/",
+                        "/index.html",
+                        "/api/test/**",
+                        "/api/auth/login",
+                        "/api/auth/signup",
+                        "/api/auth/reissue",
+                        "/api/auth/send-phone-code",
+                        "/api/auth/verify-phone-code",
+                        "/api/auth/send-email-code",
+                        "/api/auth/verify-email-code",
+                        "/api/auth/find-email",
+                        "/api/auth/reset-password/email",
+                        "/api/auth/reset-password/phone",
+                        "/api/auth/verify-identity",
+                        "/api/auth/user",
+                        "/api/reissue",
+                        "/api/admin/**", // 테스트용으로 어드민 경로도 열어놓음
+                        "/api/visits/**",
+                        "/api/edu-reports/attachments/{id}/download", // 테스트용으로 교육자료
+                        // 다운로드 열어놓음
+                        "/api/test/**",
+                        "/api/departments/hierarchy",
+                        "/api/departments/{departmentId}/users")
+                    .permitAll()
+                    .requestMatchers(
+                        "/api/auth/logout",
+                        "/api/auth/reset-password", // 로그인 상태에서의 비번 변경
+                        "/api/admin/**", // 관리자 기능
+                        "/api/visits/**" // 방문 관리
+                    )
+                    .authenticated()
+                    .anyRequest()
+                    .authenticated());
 
         http.addFilterBefore(
-                new JwtFilter(jwtUtil, userRepository), UsernamePasswordAuthenticationFilter.class);
+            new JwtFilter(jwtUtil, userRepository), UsernamePasswordAuthenticationFilter.class);
 
         http.sessionManagement(
-                (session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+            (session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         return http.build();
     }


### PR DESCRIPTION
## 📝작업 내용
- SecurityConfig에 계정 삭제와 본인인증 확인 api를 permitAll로 추가했습니다.

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [ ] 테스트를 수행함

## 💬리뷰 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?