### PR TITLE
feat(94): 내방 및 회원가입 승인로직 수정

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/dto/request/UserApprovalRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/dto/request/UserApprovalRequestDto.java
@@ -1,14 +1,18 @@
 package kr.co.awesomelead.groupware_backend.domain.admin.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import jakarta.validation.constraints.NotNull;
-import java.time.LocalDate;
+
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.JobType;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
+
 import lombok.Getter;
 import lombok.Setter;
+
+import java.time.LocalDate;
 
 @Getter
 @Setter

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
@@ -11,7 +11,9 @@ import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
 import kr.co.awesomelead.groupware_backend.global.error.CustomException;
 import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,21 +26,21 @@ public class AdminService {
 
     @Transactional
     public void approveUserRegistration(
-        Long userId, UserApprovalRequestDto requestDto, Long adminId) {
+            Long userId, UserApprovalRequestDto requestDto, Long adminId) {
         //  관리자 권한 확인
         User admin =
-            userRepository
-                .findById(adminId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                userRepository
+                        .findById(adminId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         if (admin.getRole() != Role.ADMIN) {
             throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_REGISTRATION);
         }
 
         // userId로 PENDING 상태의 사용자를 조회
         User user =
-            userRepository
-                .findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         if (user.getStatus() != Status.PENDING) {
             throw new CustomException(ErrorCode.DUPLICATED_SIGNUP_REQUEST);
@@ -61,9 +63,9 @@ public class AdminService {
         }
 
         Department department =
-            departmentRepository
-                .findById(requestDto.getDepartmentId())
-                .orElseThrow(() -> new CustomException(ErrorCode.DEPARTMENT_NOT_FOUND));
+                departmentRepository
+                        .findById(requestDto.getDepartmentId())
+                        .orElseThrow(() -> new CustomException(ErrorCode.DEPARTMENT_NOT_FOUND));
 
         // DTO의 정보로 사용자 엔티티를 설정
         user.setWorkLocation(requestDto.getWorkLocation());
@@ -99,18 +101,18 @@ public class AdminService {
     public void updateUserRole(Long userId, Role role, Long adminId) {
 
         User admin =
-            userRepository
-                .findById(adminId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                userRepository
+                        .findById(adminId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         if (admin.getRole() != Role.ADMIN && admin.getRole() != Role.MASTER_ADMIN) {
             throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_ROLE_UPDATE);
         }
         // 1. 대상 사용자 조회
         User targetUser =
-            userRepository
-                .findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // 2. 역할 업데이트
         targetUser.setRole(role);
@@ -130,9 +132,9 @@ public class AdminService {
     public void updateUserAuthority(Long userId, Authority authority, String action, Long adminId) {
         // 1. 관리자 권한 확인 (ADMIN 또는 MASTER_ADMIN만 가능)
         User admin =
-            userRepository
-                .findById(adminId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                userRepository
+                        .findById(adminId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         if (admin.getRole() != Role.ADMIN && admin.getRole() != Role.MASTER_ADMIN) {
             throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_ROLE_UPDATE);
@@ -140,9 +142,9 @@ public class AdminService {
 
         // 2. 대상 사용자 조회
         User targetUser =
-            userRepository
-                .findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // 3. 동작(Action)에 따른 권한 처리
         if ("ADD".equalsIgnoreCase(action)) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/entity/Notice.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/entity/Notice.java
@@ -1,6 +1,7 @@
 package kr.co.awesomelead.groupware_backend.domain.notice.entity;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -17,22 +18,26 @@ import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
+
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.notice.enums.NoticeType;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.global.util.CompanyListConverter;
 import kr.co.awesomelead.groupware_backend.global.util.LongListConverter;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.util.StringUtils;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Builder
@@ -71,8 +76,7 @@ public class Notice {
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdDate;
 
-    @LastModifiedDate
-    private LocalDateTime updatedDate;
+    @LastModifiedDate private LocalDateTime updatedDate;
 
     // 조회수
     @Builder.Default

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/entity/User.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/entity/User.java
@@ -2,6 +2,7 @@ package kr.co.awesomelead.groupware_backend.domain.user.entity;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
@@ -21,16 +22,7 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+
 import kr.co.awesomelead.groupware_backend.domain.annualleave.entity.AnnualLeave;
 import kr.co.awesomelead.groupware_backend.domain.checksheet.entity.CheckSheet;
 import kr.co.awesomelead.groupware_backend.domain.department.entity.Department;
@@ -46,11 +38,23 @@ import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
 import kr.co.awesomelead.groupware_backend.domain.visit.entity.Visit;
 import kr.co.awesomelead.groupware_backend.global.encryption.PhoneNumberEncryptor;
 import kr.co.awesomelead.groupware_backend.global.encryption.RegistrationNumberEncryptor;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -124,10 +128,10 @@ public class User {
     private LocalDate birthDate; // 생년월일
 
     @OneToOne(
-        mappedBy = "user",
-        cascade = CascadeType.ALL,
-        orphanRemoval = true,
-        fetch = FetchType.LAZY)
+            mappedBy = "user",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY)
     @JsonManagedReference
     private AnnualLeave annualLeave;
 
@@ -239,12 +243,12 @@ public class User {
 
         // 3. 세기 판단 (그룹화)
         String century =
-            switch (genderDigit) {
-                case '1', '2', '5', '6' -> "19";
-                case '3', '4', '7', '8' -> "20";
-                case '9', '0' -> "18"; // 혹시 모를 1800년대생 대비
-                default -> "20"; // 기본값
-            };
+                switch (genderDigit) {
+                    case '1', '2', '5', '6' -> "19";
+                    case '3', '4', '7', '8' -> "20";
+                    case '9', '0' -> "18"; // 혹시 모를 1800년대생 대비
+                    default -> "20"; // 기본값
+                };
 
         // 4. LocalDate로 변환
         return LocalDate.parse(century + birthPart, DateTimeFormatter.ofPattern("yyyyMMdd"));

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/controller/VisitController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/controller/VisitController.java
@@ -6,10 +6,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
 import jakarta.validation.Valid;
-import java.io.IOException;
-import java.net.URI;
-import java.util.List;
+
 import kr.co.awesomelead.groupware_backend.domain.user.dto.CustomUserDetails;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.request.CheckInRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.request.CheckOutRequestDto;
@@ -27,7 +26,9 @@ import kr.co.awesomelead.groupware_backend.domain.visit.dto.response.VisitListRe
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitStatus;
 import kr.co.awesomelead.groupware_backend.domain.visit.service.VisitService;
 import kr.co.awesomelead.groupware_backend.global.common.response.ApiResponse;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -42,13 +43,17 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/visits")
 @Tag(
-    name = "Visit",
-    description =
-        """
+        name = "Visit",
+        description =
+                """
             ## 방문 관리 API
 
             내방객의 사전 예약 및 현장 방문 접수, 방문 정보 조회, 입/퇴실 처리 등을 수행합니다.
@@ -65,12 +70,12 @@ public class VisitController {
     @Operation(summary = "사전 하루 방문 신청", description = "방문 전 내방객이 하루 방문을 사전에 신청합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200",
-            description = "신청 성공")
+                responseCode = "200",
+                description = "신청 성공")
     })
     @PostMapping("/pre-registration/one-day")
     public ResponseEntity<ApiResponse<Long>> registerOneDayPreVisit(
-        @Parameter(description = "하루 방문 신청 정보") @Valid @RequestBody OneDayVisitRequestDto dto) {
+            @Parameter(description = "하루 방문 신청 정보") @Valid @RequestBody OneDayVisitRequestDto dto) {
 
         Long visitId = visitService.registerOneDayPreVisit(dto);
         return ResponseEntity.ok(ApiResponse.onSuccess(visitId));
@@ -79,51 +84,51 @@ public class VisitController {
     @Operation(summary = "사전 장기 방문 신청", description = "방문 전 내방객이 장기 방문을 사전에 신청합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200",
-            description = "신청 성공"),
+                responseCode = "200",
+                description = "신청 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "400",
-            description = "날짜 범위 오류",
-            content =
-            @Content(
-                examples =
-                @ExampleObject(
-                    value =
-                        "{\"isSuccess\": false, \"code\":"
-                            + " \"LONG_TERM_PERIOD_EXCEEDED\","
-                            + " \"message\": \"장기 방문은 최대 3개월까지"
-                            + " 가능합니다.\"}")))
+                responseCode = "400",
+                description = "날짜 범위 오류",
+                content =
+                        @Content(
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        "{\"isSuccess\": false, \"code\":"
+                                                                + " \"LONG_TERM_PERIOD_EXCEEDED\","
+                                                                + " \"message\": \"장기 방문은 최대 3개월까지"
+                                                                + " 가능합니다.\"}")))
     })
     @PostMapping("/pre-registration/long-term")
     public ResponseEntity<ApiResponse<Long>> registerLongTermPreVisit(
-        @Parameter(description = "장기 방문 신청 정보") @Valid @RequestBody
-        LongTermVisitRequestDto dto) {
+            @Parameter(description = "장기 방문 신청 정보") @Valid @RequestBody
+                    LongTermVisitRequestDto dto) {
 
         Long visitId = visitService.registerLongTermPreVisit(dto);
         return ResponseEntity.ok(ApiResponse.onSuccess(visitId));
     }
 
     @Operation(
-        summary = "현장 방문 신청 및 즉시 입실",
-        description = "안내 데스크에서 현장 방문객 정보를 입력하고 서명을 받아 즉시 입실 처리합니다.")
+            summary = "현장 방문 신청 및 즉시 입실",
+            description = "안내 데스크에서 현장 방문객 정보를 입력하고 서명을 받아 즉시 입실 처리합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "201",
-            description = "생성 및 입실 성공")
+                responseCode = "201",
+                description = "생성 및 입실 성공")
     })
     @PostMapping(value = "/on-site", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Long>> createOnSiteVisit(
-        @Parameter(description = "현장 방문 정보 및 서명 파일") @Valid @ModelAttribute
-        OnSiteVisitRequestDto requestDto)
-        throws IOException {
+            @Parameter(description = "현장 방문 정보 및 서명 파일") @Valid @ModelAttribute
+                    OnSiteVisitRequestDto requestDto)
+            throws IOException {
 
         Long visitId = visitService.registerOnSiteVisit(requestDto);
 
         URI location =
-            ServletUriComponentsBuilder.fromCurrentContextPath()
-                .path("/api/visits/{id}")
-                .buildAndExpand(visitId)
-                .toUri();
+                ServletUriComponentsBuilder.fromCurrentContextPath()
+                        .path("/api/visits/{id}")
+                        .buildAndExpand(visitId)
+                        .toUri();
 
         return ResponseEntity.created(location).body(ApiResponse.onCreated(visitId));
     }
@@ -131,31 +136,31 @@ public class VisitController {
     @Operation(summary = "사전 예약자 입실 처리", description = "사전 신청한 내방객이 도착했을 때 서명을 받고 입실을 완료합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200",
-            description = "입실 성공"),
+                responseCode = "200",
+                description = "입실 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "400",
-            description = "입실 불가",
-            content =
-            @Content(
-                examples = {
-                    @ExampleObject(
-                        name = "날짜 아님",
-                        value =
-                            "{\"isSuccess\": false, \"code\":"
-                                + " \"NOT_VISIT_DATE\", \"message\": \"방문"
-                                + " 예정일이 아닙니다.\"}"),
-                    @ExampleObject(
-                        name = "이미 입실함",
-                        value =
-                            "{\"isSuccess\": false, \"code\":"
-                                + " \"VISIT_ALREADY_CHECKED_OUT\","
-                                + " \"message\": \"이미 체크아웃된 방문정보입니다.\"}")
-                }))
+                responseCode = "400",
+                description = "입실 불가",
+                content =
+                        @Content(
+                                examples = {
+                                    @ExampleObject(
+                                            name = "날짜 아님",
+                                            value =
+                                                    "{\"isSuccess\": false, \"code\":"
+                                                        + " \"NOT_VISIT_DATE\", \"message\": \"방문"
+                                                        + " 예정일이 아닙니다.\"}"),
+                                    @ExampleObject(
+                                            name = "이미 입실함",
+                                            value =
+                                                    "{\"isSuccess\": false, \"code\":"
+                                                        + " \"VISIT_ALREADY_CHECKED_OUT\","
+                                                        + " \"message\": \"이미 체크아웃된 방문정보입니다.\"}")
+                                }))
     })
     @PostMapping(value = "/check-in", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Long>> checkIn(
-        @Valid @ModelAttribute CheckInRequestDto requestDto) throws IOException {
+            @Valid @ModelAttribute CheckInRequestDto requestDto) throws IOException {
 
         Long visitId = visitService.checkIn(requestDto);
         return ResponseEntity.ok(ApiResponse.onSuccess(visitId));
@@ -164,8 +169,8 @@ public class VisitController {
     @Operation(summary = "방문자 퇴실 처리", description = "입실 중인 내방객의 퇴실 시간을 기록하고 방문 상태를 업데이트합니다.")
     @PatchMapping("/check-out")
     public ResponseEntity<ApiResponse<Long>> checkOut(
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
-        @Parameter(description = "퇴실 정보") @Valid @RequestBody CheckOutRequestDto dto) {
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "퇴실 정보") @Valid @RequestBody CheckOutRequestDto dto) {
         Long response = visitService.checkOut(userDetails.getId(), dto);
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
@@ -173,8 +178,8 @@ public class VisitController {
     @Operation(summary = "내 방문 목록 조회", description = "성함, 전화번호, 비밀번호를 입력하여 신청한 방문 내역 목록을 확인합니다.")
     @PostMapping("/my")
     public ResponseEntity<ApiResponse<List<MyVisitListResponseDto>>> getMyVisitList(
-        @Parameter(description = "목록 조회를 위한 인증 정보") @Valid @RequestBody
-        VisitSearchRequestDto dto) {
+            @Parameter(description = "목록 조회를 위한 인증 정보") @Valid @RequestBody
+                    VisitSearchRequestDto dto) {
         List<MyVisitListResponseDto> response = visitService.getMyVisitList(dto);
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
@@ -182,73 +187,75 @@ public class VisitController {
     @Operation(summary = "내 방문 상세 조회", description = "방문 ID와 목록 조회 시 사용한 비밀번호를 통해 상세 정보를 확인합니다.")
     @PostMapping("/{visitId}/detail")
     public ResponseEntity<ApiResponse<MyVisitDetailResponseDto>> getMyVisitDetail(
-        @Parameter(description = "조회할 방문 ID", example = "1") @PathVariable("visitId")
-        Long visitId,
-        @Parameter(description = "상세 조회를 위한 비밀번호") @Valid @RequestBody
-        MyVisitDetailRequestDto dto) {
+            @Parameter(description = "조회할 방문 ID", example = "1") @PathVariable("visitId")
+                    Long visitId,
+            @Parameter(description = "상세 조회를 위한 비밀번호") @Valid @RequestBody
+                    MyVisitDetailRequestDto dto) {
         MyVisitDetailResponseDto response = visitService.getMyVisitDetail(visitId, dto);
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
     @Operation(
-        summary = "내 방문 정보 수정",
-        description =
-            "방문 ID와 비밀번호를 통해 정보를 수정합니다. 입실 전 상태에서만 가능하며, 장기 방문 수정 시 다시 승인 대기 상태로 변경됩니다.")
+            summary = "내 방문 정보 수정",
+            description =
+                    "방문 ID와 비밀번호를 통해 정보를 수정합니다. 입실 전 상태에서만 가능하며, 장기 방문 수정 시 다시 승인 대기 상태로 변경됩니다.")
     @PatchMapping("/{visitId}")
     public ResponseEntity<ApiResponse<Void>> updateMyVisit(
-        @Parameter(description = "수정할 방문 ID", example = "1") @PathVariable("visitId")
-        Long visitId,
-        @Parameter(description = "수정할 방문 정보") @Valid @RequestBody MyVisitUpdateRequestDto dto) {
+            @Parameter(description = "수정할 방문 ID", example = "1") @PathVariable("visitId")
+                    Long visitId,
+            @Parameter(description = "수정할 방문 정보") @Valid @RequestBody MyVisitUpdateRequestDto dto) {
         visitService.updateMyVisit(visitId, dto);
         return ResponseEntity.ok(ApiResponse.onNoContent("방문 정보가 수정되었습니다."));
     }
 
     @Operation(
-        summary = "직원용 내방객 목록 조회",
-        description = "관리 직군이 전체 내방객 목록을 조회합니다. 부서 및 상태별 필터링이 가능합니다.")
+            summary = "직원용 내방객 목록 조회",
+            description = "관리 직군이 전체 내방객 목록을 조회합니다. 부서 및 상태별 필터링이 가능합니다.")
     @GetMapping("/admin/list")
     public ResponseEntity<ApiResponse<List<VisitListResponseDto>>> getAdminVisitList(
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
-        @Parameter(description = "필터링할 부서 ID", example = "10")
-        @RequestParam(name = "departmentId", required = false)
-        Long departmentId,
-        @Parameter(description = "필터링할 방문 상태", example = "IN_PROGRESS")
-        @RequestParam(name = "status", required = false)
-        VisitStatus status) {
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "필터링할 부서 ID", example = "10")
+                    @RequestParam(name = "departmentId", required = false)
+                    Long departmentId,
+            @Parameter(description = "필터링할 방문 상태", example = "IN_PROGRESS")
+                    @RequestParam(name = "status", required = false)
+                    VisitStatus status) {
         List<VisitListResponseDto> response =
-            visitService.getVisitsForAdmin(userDetails.getId(), departmentId, status);
+                visitService.getVisitsForAdmin(userDetails.getId(), departmentId, status);
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
     @Operation(
-        summary = "직원용 내방객 상세 조회",
-        description = "관리 직군이 특정 내방객의 상세 정보, 서명 이미지 및 모든 입퇴실 기록을 조회합니다.")
+            summary = "직원용 내방객 상세 조회",
+            description = "관리 직군이 특정 내방객의 상세 정보, 서명 이미지 및 모든 입퇴실 기록을 조회합니다.")
     @GetMapping("/admin/{visitId}")
     public ResponseEntity<ApiResponse<VisitDetailResponseDto>> getAdminVisitDetail(
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
-        @Parameter(description = "조회할 방문 ID", example = "1") @PathVariable("visitId")
-        Long visitId) {
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "조회할 방문 ID", example = "1") @PathVariable("visitId")
+                    Long visitId) {
         VisitDetailResponseDto response =
-            visitService.getVisitDetailForAdmin(userDetails.getId(), visitId);
+                visitService.getVisitDetailForAdmin(userDetails.getId(), visitId);
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
     @Operation(summary = "장기 방문 신청 처리", description = "관리 직군이 PENDING 상태인 장기 방문 신청을 승인 혹은 반려합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200",
-            description = "승인 완료"),
+                responseCode = "200",
+                description = "승인 완료"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "403",
-            description = "권한 부족")
+                responseCode = "403",
+                description = "권한 부족")
     })
     @PostMapping("/admin/{visitId}/process")
     public ResponseEntity<ApiResponse<Void>> processVisit(
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
-        @Parameter(description = "처리할 방문 ID", example = "1") @PathVariable("visitId") Long visitId,
-        @Parameter(description = "처리 요청 정보") @Valid @RequestBody VisitProcessRequestDto dto) {
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "처리할 방문 ID", example = "1") @PathVariable("visitId")
+                    Long visitId,
+            @Parameter(description = "처리 요청 정보") @Valid @RequestBody VisitProcessRequestDto dto) {
         visitService.processVisit(userDetails.getId(), visitId, dto);
-        return ResponseEntity.ok(ApiResponse.onNoContent(
-            "방문 신청에 대한 " + dto.getStatus().getDescription() + " 처리가 완료되었습니다."));
+        return ResponseEntity.ok(
+                ApiResponse.onNoContent(
+                        "방문 신청에 대한 " + dto.getStatus().getDescription() + " 처리가 완료되었습니다."));
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/request/VisitProcessRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/request/VisitProcessRequestDto.java
@@ -1,8 +1,11 @@
 package kr.co.awesomelead.groupware_backend.domain.visit.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import jakarta.validation.constraints.NotNull;
+
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitStatus;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,5 +24,4 @@ public class VisitProcessRequestDto {
 
     @Schema(description = "반려 사유 (반려 시 필수)", example = "방문 목적이 불분명합니다.")
     private String rejectionReason;
-
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/response/MyVisitDetailResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/response/MyVisitDetailResponseDto.java
@@ -1,15 +1,18 @@
 package kr.co.awesomelead.groupware_backend.domain.visit.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
+
 import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitPurpose;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitStatus;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Builder

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/response/VisitDetailResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/response/VisitDetailResponseDto.java
@@ -1,15 +1,18 @@
 package kr.co.awesomelead.groupware_backend.domain.visit.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDate;
-import java.util.List;
+
 import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.AdditionalPermissionType;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitPurpose;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitStatus;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @Builder

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/entity/Visit.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/entity/Visit.java
@@ -2,6 +2,7 @@ package kr.co.awesomelead.groupware_backend.domain.visit.entity;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -17,6 +18,22 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
+
+import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
+import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
+import kr.co.awesomelead.groupware_backend.domain.visit.enums.AdditionalPermissionType;
+import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitPurpose;
+import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitStatus;
+import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitType;
+import kr.co.awesomelead.groupware_backend.global.encryption.PhoneNumberEncryptor;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -25,19 +42,6 @@ import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
-import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
-import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
-import kr.co.awesomelead.groupware_backend.domain.visit.enums.AdditionalPermissionType;
-import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitPurpose;
-import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitStatus;
-import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitType;
-import kr.co.awesomelead.groupware_backend.global.encryption.PhoneNumberEncryptor;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Setter
 @Getter
@@ -87,11 +91,9 @@ public class Visit {
     @Column(nullable = false)
     private LocalDate endDate; // 종료일 (하루면 시작일과 동일)
 
-    @Column
-    private LocalTime plannedEntryTime; // 신청 시 입실 예정 시간
+    @Column private LocalTime plannedEntryTime; // 신청 시 입실 예정 시간
 
-    @Column
-    private LocalTime plannedExitTime; // 신청 시 퇴실 예정 시간
+    @Column private LocalTime plannedExitTime; // 신청 시 퇴실 예정 시간
 
     @Column(nullable = false)
     private boolean isLongTerm; // 장기 여부 (DTO 분리 시 활용)

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/enums/VisitStatus.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/enums/VisitStatus.java
@@ -1,6 +1,7 @@
 package kr.co.awesomelead.groupware_backend.domain.visit.enums;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/mapper/VisitMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/mapper/VisitMapper.java
@@ -1,7 +1,5 @@
 package kr.co.awesomelead.groupware_backend.domain.visit.mapper;
 
-import java.time.LocalDateTime;
-import java.util.List;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.request.LongTermVisitRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.request.MyVisitUpdateRequestDto;
@@ -14,16 +12,20 @@ import kr.co.awesomelead.groupware_backend.domain.visit.dto.response.VisitListRe
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.response.VisitRecordResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.entity.Visit;
 import kr.co.awesomelead.groupware_backend.domain.visit.entity.VisitRecord;
+
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.NullValuePropertyMappingStrategy;
 import org.mapstruct.ReportingPolicy;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Mapper(
-    componentModel = "spring",
-    unmappedTargetPolicy = ReportingPolicy.IGNORE,
-    nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE) // null은 무시!
+        componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE,
+        nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE) // null은 무시!
 public interface VisitMapper {
 
     @Mapping(target = "id", ignore = true) // 생성 시 ID는 자동 생성되므로 무시
@@ -39,13 +41,13 @@ public interface VisitMapper {
     @Mapping(target = "plannedEntryTime", source = "dto.entryTime") // 추가
     @Mapping(target = "plannedExitTime", source = "dto.exitTime") // 추가
     @Mapping(
-        target = "status",
-        expression =
-            "java(kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitStatus.NOT_VISITED)")
+            target = "status",
+            expression =
+                    "java(kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitStatus.NOT_VISITED)")
     @Mapping(
-        target = "visitType",
-        expression =
-            "java(kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitType.PRE_REGISTRATION)")
+            target = "visitType",
+            expression =
+                    "java(kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitType.PRE_REGISTRATION)")
     @Mapping(target = "isLongTerm", constant = "false")
     @Mapping(target = "visited", constant = "false")
     @Mapping(target = "records", ignore = true)
@@ -65,14 +67,14 @@ public interface VisitMapper {
     @Mapping(target = "plannedEntryTime", ignore = true)
     @Mapping(target = "plannedExitTime", ignore = true)
     @Mapping(
-        target = "status",
-        expression =
-            "java(kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitStatus.PENDING)")
+            target = "status",
+            expression =
+                    "java(kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitStatus.PENDING)")
     // 장기는 보통 '승인 대기'
     @Mapping(
-        target = "visitType",
-        expression =
-            "java(kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitType.PRE_REGISTRATION)")
+            target = "visitType",
+            expression =
+                    "java(kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitType.PRE_REGISTRATION)")
     @Mapping(target = "records", ignore = true)
     @Mapping(target = "phoneNumberHash", ignore = true)
     @Mapping(target = "visited", constant = "false")
@@ -83,13 +85,13 @@ public interface VisitMapper {
     @Mapping(target = "user", source = "host")
     @Mapping(target = "password", source = "encodedPassword")
     @Mapping(
-        target = "visitType",
-        expression =
-            "java(kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitType.ON_SITE)")
+            target = "visitType",
+            expression =
+                    "java(kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitType.ON_SITE)")
     @Mapping(
-        target = "status",
-        expression =
-            "java(kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitStatus.IN_PROGRESS)")
+            target = "status",
+            expression =
+                    "java(kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitStatus.IN_PROGRESS)")
     @Mapping(target = "visited", constant = "true") // 즉시 방문 처리
     @Mapping(target = "isLongTerm", constant = "false")
     @Mapping(target = "startDate", expression = "java(java.time.LocalDate.now())")
@@ -162,11 +164,11 @@ public interface VisitMapper {
     @Mapping(target = "hostDepartmentName", source = "user.department.name")
     @Mapping(target = "hostName", source = "user.nameKor")
     @Mapping(target = "records", source = "records")
-        // VisitRecord -> VisitRecordResponseDto 변환 필요
+    // VisitRecord -> VisitRecordResponseDto 변환 필요
     VisitDetailResponseDto toVisitDetailResponseDto(Visit visit);
 
     @Mapping(target = "signatureUrl", source = "signatureKey")
-        // 키값을 URL로 변환하는 로직은 서비스나 커스텀 매퍼에서 처리 가능
+    // 키값을 URL로 변환하는 로직은 서비스나 커스텀 매퍼에서 처리 가능
     VisitRecordResponseDto toRecordResponseDto(VisitRecord record);
 
     List<VisitListResponseDto> toVisitListResponseDtos(List<Visit> visits);

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
@@ -2,10 +2,6 @@ package kr.co.awesomelead.groupware_backend.domain.visit.service;
 
 import static kr.co.awesomelead.groupware_backend.domain.visit.entity.Visit.hashValue;
 
-import java.io.IOException;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
 import kr.co.awesomelead.groupware_backend.domain.department.repository.DepartmentRepository;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Authority;
@@ -35,12 +31,19 @@ import kr.co.awesomelead.groupware_backend.domain.visit.repository.VisitReposito
 import kr.co.awesomelead.groupware_backend.global.error.CustomException;
 import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
 import kr.co.awesomelead.groupware_backend.global.infra.s3.S3Service;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -58,9 +61,9 @@ public class VisitService {
     public Long registerOneDayPreVisit(OneDayVisitRequestDto dto) {
 
         User host =
-            userRepository
-                .findById(dto.getHostId())
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                userRepository
+                        .findById(dto.getHostId())
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         String encodedPassword = passwordEncoder.encode(dto.getPassword());
 
@@ -76,9 +79,9 @@ public class VisitService {
         validateLongTermPeriod(dto.getStartDate(), dto.getEndDate());
 
         User host =
-            userRepository
-                .findById(dto.getHostId())
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                userRepository
+                        .findById(dto.getHostId())
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         String encodedPassword = passwordEncoder.encode(dto.getPassword());
 
@@ -92,9 +95,9 @@ public class VisitService {
     public Long registerOnSiteVisit(OnSiteVisitRequestDto dto) throws IOException {
 
         User host =
-            userRepository
-                .findById(dto.getHostId())
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                userRepository
+                        .findById(dto.getHostId())
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         String encodedPassword = passwordEncoder.encode(dto.getPassword());
         String signatureKey = s3Service.uploadFile(dto.getSignatureFile());
@@ -103,13 +106,13 @@ public class VisitService {
         syncAndValidatePermissions(visit, dto);
 
         VisitRecord record =
-            VisitRecord.builder()
-                .visit(visit)
-                .visitDate(LocalDate.now())
-                .entryTime(LocalDateTime.now())
-                .exitTime(null) // 현장 방문 시점에는 퇴실 시간이 없음
-                .signatureKey(signatureKey)
-                .build();
+                VisitRecord.builder()
+                        .visit(visit)
+                        .visitDate(LocalDate.now())
+                        .entryTime(LocalDateTime.now())
+                        .exitTime(null) // 현장 방문 시점에는 퇴실 시간이 없음
+                        .signatureKey(signatureKey)
+                        .build();
 
         visit.getRecords().add(record);
 
@@ -136,7 +139,7 @@ public class VisitService {
         // 규칙 1: 시설공사는 보충적 허가 필수
         if (visit.getPurpose() == VisitPurpose.FACILITY_CONSTRUCTION) {
             if (visit.getPermissionType() == null
-                || visit.getPermissionType() == AdditionalPermissionType.NONE) {
+                    || visit.getPermissionType() == AdditionalPermissionType.NONE) {
                 throw new CustomException(ErrorCode.ADDITIONAL_PERMISSION_REQUIRED);
             }
         }
@@ -165,9 +168,9 @@ public class VisitService {
     public Long checkIn(CheckInRequestDto dto) throws IOException {
         // 1. 방문 신청 건 조회
         Visit visit =
-            visitRepository
-                .findById(dto.getVisitId())
-                .orElseThrow(() -> new CustomException(ErrorCode.VISIT_NOT_FOUND));
+                visitRepository
+                        .findById(dto.getVisitId())
+                        .orElseThrow(() -> new CustomException(ErrorCode.VISIT_NOT_FOUND));
 
         // 2. 비밀번호 검증
         if (!passwordEncoder.matches(dto.getPassword(), visit.getPassword())) {
@@ -188,12 +191,12 @@ public class VisitService {
 
         // 6. 입실 기록(VisitRecord) 생성
         VisitRecord record =
-            VisitRecord.builder()
-                .visit(visit)
-                .visitDate(LocalDate.now())
-                .entryTime(LocalDateTime.now())
-                .signatureKey(signatureKey)
-                .build();
+                VisitRecord.builder()
+                        .visit(visit)
+                        .visitDate(LocalDate.now())
+                        .entryTime(LocalDateTime.now())
+                        .signatureKey(signatureKey)
+                        .build();
 
         visit.getRecords().add(record);
 
@@ -209,15 +212,15 @@ public class VisitService {
         validateAdminAuthority(userId);
 
         Visit visit =
-            visitRepository
-                .findById(dto.getVisitId())
-                .orElseThrow(() -> new CustomException(ErrorCode.VISIT_NOT_FOUND));
+                visitRepository
+                        .findById(dto.getVisitId())
+                        .orElseThrow(() -> new CustomException(ErrorCode.VISIT_NOT_FOUND));
 
         VisitRecord record =
-            visit.getRecords().stream()
-                .filter(r -> r.getId().equals(dto.getVisitRecordId()))
-                .findFirst()
-                .orElseThrow(() -> new CustomException(ErrorCode.RECORD_NOT_FOUND));
+                visit.getRecords().stream()
+                        .filter(r -> r.getId().equals(dto.getVisitRecordId()))
+                        .findFirst()
+                        .orElseThrow(() -> new CustomException(ErrorCode.RECORD_NOT_FOUND));
 
         boolean isInitialCheckOut = (record.getExitTime() == null);
 
@@ -236,7 +239,7 @@ public class VisitService {
 
         if (dto.getCheckOutTime().isBefore(record.getEntryTime())) {
             throw new CustomException(
-                ErrorCode.INVALID_CHECKOUT_TIME); // "퇴실 시간은 입실 시간보다 빠를 수 없습니다."
+                    ErrorCode.INVALID_CHECKOUT_TIME); // "퇴실 시간은 입실 시간보다 빠를 수 없습니다."
         }
 
         record.setExitTime(dto.getCheckOutTime());
@@ -250,19 +253,19 @@ public class VisitService {
         String inputPhoneHash = hashValue(dto.getPhoneNumber());
 
         List<Visit> visits =
-            visitRepository.findByVisitorNameAndPhoneNumberHash(dto.getName(), inputPhoneHash);
+                visitRepository.findByVisitorNameAndPhoneNumberHash(dto.getName(), inputPhoneHash);
 
         return visits.stream()
-            .filter(
-                visit ->
-                    StringUtils.hasText(
-                        visit.getPassword())) // 비밀번호가 있는 건만 대상 (현장 내방 제외)
-            .filter(
-                visit ->
-                    passwordEncoder.matches(
-                        dto.getPassword(), visit.getPassword())) // 비번 일치 확인
-            .map(visitMapper::toMyVisitListResponseDto)
-            .toList();
+                .filter(
+                        visit ->
+                                StringUtils.hasText(
+                                        visit.getPassword())) // 비밀번호가 있는 건만 대상 (현장 내방 제외)
+                .filter(
+                        visit ->
+                                passwordEncoder.matches(
+                                        dto.getPassword(), visit.getPassword())) // 비번 일치 확인
+                .map(visitMapper::toMyVisitListResponseDto)
+                .toList();
     }
 
     // 내 방문 상세 조회
@@ -270,9 +273,9 @@ public class VisitService {
     public MyVisitDetailResponseDto getMyVisitDetail(Long visitId, MyVisitDetailRequestDto dto) {
         // 1. 존재 여부 확인
         Visit visit =
-            visitRepository
-                .findById(visitId)
-                .orElseThrow(() -> new CustomException(ErrorCode.VISIT_NOT_FOUND));
+                visitRepository
+                        .findById(visitId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.VISIT_NOT_FOUND));
 
         // 2. 비밀번호 검증
         if (!passwordEncoder.matches(dto.getPassword(), visit.getPassword())) {
@@ -284,14 +287,14 @@ public class VisitService {
 
         if (responseDto.getRecords() != null) {
             responseDto
-                .getRecords()
-                .forEach(
-                    record -> {
-                        if (StringUtils.hasText(record.getSignatureUrl())) {
-                            record.setSignatureUrl(
-                                s3Service.getFileUrl(record.getSignatureUrl()));
-                        }
-                    });
+                    .getRecords()
+                    .forEach(
+                            record -> {
+                                if (StringUtils.hasText(record.getSignatureUrl())) {
+                                    record.setSignatureUrl(
+                                            s3Service.getFileUrl(record.getSignatureUrl()));
+                                }
+                            });
         }
         return responseDto;
     }
@@ -300,9 +303,9 @@ public class VisitService {
     public void updateMyVisit(Long visitId, MyVisitUpdateRequestDto dto) {
 
         Visit visit =
-            visitRepository
-                .findById(visitId)
-                .orElseThrow(() -> new CustomException(ErrorCode.VISIT_NOT_FOUND));
+                visitRepository
+                        .findById(visitId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.VISIT_NOT_FOUND));
 
         if (!passwordEncoder.matches(dto.getPassword(), visit.getPassword())) {
             throw new CustomException(ErrorCode.INVALID_PASSWORD);
@@ -314,9 +317,9 @@ public class VisitService {
         if (visit.isLongTerm()) {
 
             LocalDate effectiveStart =
-                (dto.getStartDate() != null) ? dto.getStartDate() : visit.getStartDate();
+                    (dto.getStartDate() != null) ? dto.getStartDate() : visit.getStartDate();
             LocalDate effectiveEnd =
-                (dto.getEndDate() != null) ? dto.getEndDate() : visit.getEndDate();
+                    (dto.getEndDate() != null) ? dto.getEndDate() : visit.getEndDate();
 
             validateLongTermPeriod(effectiveStart, effectiveEnd);
             // 장기 방문은 수정 후 다시 승인 대기 상태로 변경
@@ -343,7 +346,7 @@ public class VisitService {
 
         if (visit.isLongTerm()) {
             if (visit.getStatus() != VisitStatus.PENDING
-                && visit.getStatus() != VisitStatus.APPROVED) {
+                    && visit.getStatus() != VisitStatus.APPROVED) {
                 throw new CustomException(ErrorCode.INVALID_VISIT_STATUS);
             }
         } else {
@@ -357,7 +360,7 @@ public class VisitService {
     // 직용원 방문 목록 조회
     @Transactional(readOnly = true)
     public List<VisitListResponseDto> getVisitsForAdmin(
-        Long userId, Long departmentId, VisitStatus status) {
+            Long userId, Long departmentId, VisitStatus status) {
         // 관리 권한 확인
         validateAdminAuthority(userId);
 
@@ -373,22 +376,22 @@ public class VisitService {
         validateAdminAuthority(userId);
 
         Visit visit =
-            visitRepository
-                .findById(visitId)
-                .orElseThrow(() -> new CustomException(ErrorCode.VISIT_NOT_FOUND));
+                visitRepository
+                        .findById(visitId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.VISIT_NOT_FOUND));
 
         VisitDetailResponseDto responseDto = visitMapper.toVisitDetailResponseDto(visit);
 
         if (responseDto.getRecords() != null) {
             responseDto
-                .getRecords()
-                .forEach(
-                    recordDto -> {
-                        if (StringUtils.hasText(recordDto.getSignatureUrl())) {
-                            recordDto.setSignatureUrl(
-                                s3Service.getFileUrl(recordDto.getSignatureUrl()));
-                        }
-                    });
+                    .getRecords()
+                    .forEach(
+                            recordDto -> {
+                                if (StringUtils.hasText(recordDto.getSignatureUrl())) {
+                                    recordDto.setSignatureUrl(
+                                            s3Service.getFileUrl(recordDto.getSignatureUrl()));
+                                }
+                            });
         }
 
         return responseDto;
@@ -396,9 +399,9 @@ public class VisitService {
 
     private void validateAdminAuthority(Long userId) {
         User user =
-            userRepository
-                .findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // MANAGEMENT 직군이고 방문 관리 권한이 있는지 확인
         if (user.getJobType() != JobType.MANAGEMENT || !user.hasAuthority(Authority.ACCESS_VISIT)) {
@@ -414,9 +417,9 @@ public class VisitService {
 
         // 2. 방문 신청 건 조회
         Visit visit =
-            visitRepository
-                .findById(visitId)
-                .orElseThrow(() -> new CustomException(ErrorCode.VISIT_NOT_FOUND));
+                visitRepository
+                        .findById(visitId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.VISIT_NOT_FOUND));
 
         // 3. 승인 가능한 상태인지 검증
         // - 장기 방문이어야 함
@@ -430,8 +433,8 @@ public class VisitService {
         }
 
         // 4. 반려 시 사유 필수 검증
-        if (dto.getStatus() == VisitStatus.REJECTED && !StringUtils.hasText(
-            dto.getRejectionReason())) {
+        if (dto.getStatus() == VisitStatus.REJECTED
+                && !StringUtils.hasText(dto.getRejectionReason())) {
             throw new CustomException(ErrorCode.REJECTION_REASON_REQUIRED);
         }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
@@ -2,6 +2,7 @@ package kr.co.awesomelead.groupware_backend.global.error;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 
 @Getter
@@ -16,7 +17,7 @@ public enum ErrorCode {
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     VISIT_ALREADY_CHECKED_OUT(HttpStatus.BAD_REQUEST, "이미 체크아웃된 방문정보입니다."),
     VISITOR_PASSWORD_REQUIRED_FOR_PRE_REGISTRATION(
-        HttpStatus.BAD_REQUEST, "사전 방문 예약 시 내방객 비밀번호가 필요합니다."),
+            HttpStatus.BAD_REQUEST, "사전 방문 예약 시 내방객 비밀번호가 필요합니다."),
     DEPARTMENT_ID_REQUIRED(HttpStatus.BAD_REQUEST, "부서교육인 경우 부서 ID가 필요합니다."),
     ALREADY_MARKED_ATTENDANCE(HttpStatus.BAD_REQUEST, "이미 출석이 체크된 교육입니다."),
     NO_SIGNATURE_PROVIDED(HttpStatus.BAD_REQUEST, "서명이 제공되지 않았습니다."),
@@ -45,9 +46,7 @@ public enum ErrorCode {
     LONG_TERM_PERIOD_EXCEEDED(HttpStatus.BAD_REQUEST, "장기 방문은 최대 3개월까지만 신청 가능합니다."),
     INVALID_CHECKOUT_TIME(HttpStatus.BAD_REQUEST, "퇴실 시간은 입실 시간보다 빠를 수 없습니다."),
     INVALID_JOB_TYPE_FOR_ADMIN_ROLE(HttpStatus.BAD_REQUEST, "관리자 역할에는 관리직 직군만 할당할 수 있습니다."),
-    REJECTION_REASON_REQUIRED(
-        HttpStatus.BAD_REQUEST, "반려 시 반려 사유가 반드시 필요합니다."
-    ),
+    REJECTION_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "반려 시 반려 사유가 반드시 필요합니다."),
 
     // 401 Unauthorized
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
@@ -6,8 +6,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.time.LocalDate;
-import java.util.Optional;
 import kr.co.awesomelead.groupware_backend.domain.admin.dto.request.UserApprovalRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.admin.service.AdminService;
 import kr.co.awesomelead.groupware_backend.domain.department.entity.Department;
@@ -22,6 +20,7 @@ import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
 import kr.co.awesomelead.groupware_backend.global.error.CustomException;
 import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -32,16 +31,16 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
+import java.util.Optional;
+
 @ExtendWith(MockitoExtension.class)
 @DisplayName("AdminService 클래스의")
 class AdminServiceTest {
 
-    @Mock
-    private UserRepository userRepository;
-    @Mock
-    private DepartmentRepository departmentRepository;
-    @InjectMocks
-    private AdminService adminService;
+    @Mock private UserRepository userRepository;
+    @Mock private DepartmentRepository departmentRepository;
+    @InjectMocks private AdminService adminService;
     private final Long adminId = 100L;
     private final Long userId = 1L;
     private final UserApprovalRequestDto requestDto = createRequestDto();
@@ -67,7 +66,7 @@ class AdminServiceTest {
             void it_updates_user_info_and_status() {
                 // given
                 Department department =
-                    Department.builder().id(1L).name(DepartmentName.SALES_DEPT).build();
+                        Department.builder().id(1L).name(DepartmentName.SALES_DEPT).build();
                 User pendingUser = new User();
                 pendingUser.setId(userId);
                 pendingUser.setStatus(Status.PENDING);
@@ -97,7 +96,7 @@ class AdminServiceTest {
             void it_throws_invalid_job_type_for_admin_role_exception() {
                 // given
                 Department department =
-                    Department.builder().id(1L).name(DepartmentName.SALES_DEPT).build();
+                        Department.builder().id(1L).name(DepartmentName.SALES_DEPT).build();
                 User pendingUser = new User();
                 pendingUser.setStatus(Status.PENDING);
 
@@ -110,12 +109,12 @@ class AdminServiceTest {
 
                 // when & then
                 assertThatThrownBy(
-                    () ->
-                        adminService.approveUserRegistration(
-                            userId, invalidRequestDto, adminId))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorCode")
-                    .isEqualTo(ErrorCode.INVALID_JOB_TYPE_FOR_ADMIN_ROLE);
+                                () ->
+                                        adminService.approveUserRegistration(
+                                                userId, invalidRequestDto, adminId))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode")
+                        .isEqualTo(ErrorCode.INVALID_JOB_TYPE_FOR_ADMIN_ROLE);
             }
         }
 
@@ -133,12 +132,12 @@ class AdminServiceTest {
 
                 // when & then
                 assertThatThrownBy(
-                    () ->
-                        adminService.approveUserRegistration(
-                            userId, requestDto, adminId))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorCode")
-                    .isEqualTo(ErrorCode.DUPLICATED_SIGNUP_REQUEST);
+                                () ->
+                                        adminService.approveUserRegistration(
+                                                userId, requestDto, adminId))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode")
+                        .isEqualTo(ErrorCode.DUPLICATED_SIGNUP_REQUEST);
             }
         }
 
@@ -154,12 +153,12 @@ class AdminServiceTest {
 
                 // when & then
                 assertThatThrownBy(
-                    () ->
-                        adminService.approveUserRegistration(
-                            userId, requestDto, adminId))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorCode")
-                    .isEqualTo(ErrorCode.USER_NOT_FOUND);
+                                () ->
+                                        adminService.approveUserRegistration(
+                                                userId, requestDto, adminId))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode")
+                        .isEqualTo(ErrorCode.USER_NOT_FOUND);
             }
         }
 
@@ -177,12 +176,12 @@ class AdminServiceTest {
 
                 // when & then
                 assertThatThrownBy(
-                    () ->
-                        adminService.approveUserRegistration(
-                            userId, requestDto, adminId))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorCode")
-                    .isEqualTo(ErrorCode.NO_AUTHORITY_FOR_REGISTRATION);
+                                () ->
+                                        adminService.approveUserRegistration(
+                                                userId, requestDto, adminId))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode")
+                        .isEqualTo(ErrorCode.NO_AUTHORITY_FOR_REGISTRATION);
             }
         }
     }
@@ -236,9 +235,9 @@ class AdminServiceTest {
 
                 // when & then
                 assertThatThrownBy(() -> adminService.updateUserRole(1L, Role.ADMIN, adminId))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorCode")
-                    .isEqualTo(ErrorCode.NO_AUTHORITY_FOR_ROLE_UPDATE);
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode")
+                        .isEqualTo(ErrorCode.NO_AUTHORITY_FOR_ROLE_UPDATE);
             }
         }
 
@@ -254,9 +253,9 @@ class AdminServiceTest {
 
                 // when & then
                 assertThatThrownBy(() -> adminService.updateUserRole(1L, Role.ADMIN, adminId))
-                    .isInstanceOf(CustomException.class)
-                    .extracting("errorCode")
-                    .isEqualTo(ErrorCode.USER_NOT_FOUND);
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode")
+                        .isEqualTo(ErrorCode.USER_NOT_FOUND);
             }
         }
     }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
@@ -9,12 +9,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import java.io.IOException;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.Optional;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Authority;
@@ -38,6 +32,7 @@ import kr.co.awesomelead.groupware_backend.domain.visit.repository.VisitReposito
 import kr.co.awesomelead.groupware_backend.domain.visit.service.VisitService;
 import kr.co.awesomelead.groupware_backend.global.error.CustomException;
 import kr.co.awesomelead.groupware_backend.global.infra.s3.S3Service;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -51,6 +46,13 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Optional;
+
 @ExtendWith(MockitoExtension.class)
 @ActiveProfiles("test")
 public class VisitServiceTest {
@@ -58,17 +60,12 @@ public class VisitServiceTest {
     @Spy
     private VisitMapper visitMapper = org.mapstruct.factory.Mappers.getMapper(VisitMapper.class);
 
-    @InjectMocks
-    private VisitService visitService;
+    @InjectMocks private VisitService visitService;
 
-    @Mock
-    private VisitRepository visitRepository;
-    @Mock
-    private UserRepository userRepository;
-    @Mock
-    private S3Service s3Service;
-    @Mock
-    private PasswordEncoder passwordEncoder;
+    @Mock private VisitRepository visitRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private S3Service s3Service;
+    @Mock private PasswordEncoder passwordEncoder;
 
     private static final Long HOST_ID = 1L;
     private static final Long VISIT_ID = 100L;
@@ -77,24 +74,24 @@ public class VisitServiceTest {
 
     private User createHost() {
         User host =
-            User.builder()
-                .id(HOST_ID)
-                .nameKor("담당자")
-                .workLocation(Company.AWESOME)
-                .jobType(JobType.MANAGEMENT)
-                .build();
+                User.builder()
+                        .id(HOST_ID)
+                        .nameKor("담당자")
+                        .workLocation(Company.AWESOME)
+                        .jobType(JobType.MANAGEMENT)
+                        .build();
         host.addAuthority(Authority.ACCESS_VISIT);
         return host;
     }
 
     private Visit createBaseVisit(VisitStatus status, boolean isLongTerm) {
         return Visit.builder()
-            .id(VISIT_ID)
-            .password(ENCODED_PASSWORD)
-            .status(status)
-            .isLongTerm(isLongTerm)
-            .records(new ArrayList<>())
-            .build();
+                .id(VISIT_ID)
+                .password(ENCODED_PASSWORD)
+                .status(status)
+                .isLongTerm(isLongTerm)
+                .records(new ArrayList<>())
+                .build();
     }
 
     @Nested
@@ -115,11 +112,11 @@ public class VisitServiceTest {
             @DisplayName("ADDITIONAL_PERMISSION_REQUIRED 예외를 던진다.")
             void it_throws_additional_permission_required_exception() {
                 OneDayVisitRequestDto dto =
-                    createOneDayDto(VisitPurpose.FACILITY_CONSTRUCTION, null, null);
+                        createOneDayDto(VisitPurpose.FACILITY_CONSTRUCTION, null, null);
 
                 assertThatThrownBy(() -> visitService.registerOneDayPreVisit(dto))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage("시설공사 목적의 방문 시 추가 허가가 필요합니다.");
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage("시설공사 목적의 방문 시 추가 허가가 필요합니다.");
             }
         }
 
@@ -131,14 +128,14 @@ public class VisitServiceTest {
             @DisplayName("PERMISSION_DETAIL_REQUIRED 예외를 던진다.")
             void it_throws_permission_detail_required_exception() {
                 OneDayVisitRequestDto dto =
-                    createOneDayDto(
-                        VisitPurpose.FACILITY_CONSTRUCTION,
-                        AdditionalPermissionType.OTHER_PERMISSION,
-                        null);
+                        createOneDayDto(
+                                VisitPurpose.FACILITY_CONSTRUCTION,
+                                AdditionalPermissionType.OTHER_PERMISSION,
+                                null);
 
                 assertThatThrownBy(() -> visitService.registerOneDayPreVisit(dto))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage("기타 허가 선택 시 요구사항 작성이 필요합니다.");
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage("기타 허가 선택 시 요구사항 작성이 필요합니다.");
             }
         }
 
@@ -151,7 +148,7 @@ public class VisitServiceTest {
             void it_registers_visit_successfully() {
                 // given
                 OneDayVisitRequestDto dto =
-                    createOneDayDto(VisitPurpose.MEETING, AdditionalPermissionType.NONE, null);
+                        createOneDayDto(VisitPurpose.MEETING, AdditionalPermissionType.NONE, null);
 
                 User mockHost = User.builder().id(dto.getHostId()).build();
                 String encodedPassword = "encoded_password_1234";
@@ -176,20 +173,20 @@ public class VisitServiceTest {
         }
 
         private OneDayVisitRequestDto createOneDayDto(
-            VisitPurpose purpose, AdditionalPermissionType type, String detail) {
+                VisitPurpose purpose, AdditionalPermissionType type, String detail) {
             return OneDayVisitRequestDto.builder()
-                .visitorName("홍길동")
-                .visitorPhoneNumber("01012345678")
-                .visitorCompany("테스트컴퍼니")
-                .purpose(purpose)
-                .permissionType(type)
-                .permissionDetail(detail)
-                .visitDate(LocalDate.now().plusDays(1))
-                .entryTime(LocalTime.of(10, 0))
-                .exitTime(LocalTime.of(18, 0))
-                .hostId(1L)
-                .password("1234")
-                .build();
+                    .visitorName("홍길동")
+                    .visitorPhoneNumber("01012345678")
+                    .visitorCompany("테스트컴퍼니")
+                    .purpose(purpose)
+                    .permissionType(type)
+                    .permissionDetail(detail)
+                    .visitDate(LocalDate.now().plusDays(1))
+                    .entryTime(LocalTime.of(10, 0))
+                    .exitTime(LocalTime.of(18, 0))
+                    .hostId(1L)
+                    .password("1234")
+                    .build();
         }
     }
 
@@ -206,15 +203,15 @@ public class VisitServiceTest {
             void it_throws_invalid_visit_date_range() {
                 // given: 시작일 1월 22일, 종료일 1월 21일 (과거)
                 LongTermVisitRequestDto dto =
-                    LongTermVisitRequestDto.builder()
-                        .startDate(LocalDate.of(2026, 1, 22))
-                        .endDate(LocalDate.of(2026, 1, 21))
-                        .build();
+                        LongTermVisitRequestDto.builder()
+                                .startDate(LocalDate.of(2026, 1, 22))
+                                .endDate(LocalDate.of(2026, 1, 21))
+                                .build();
 
                 // when & then
                 assertThatThrownBy(() -> visitService.registerLongTermPreVisit(dto))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage("종료일은 시작일보다 빠를 수 없습니다.");
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage("종료일은 시작일보다 빠를 수 없습니다.");
             }
 
             @Test
@@ -223,15 +220,15 @@ public class VisitServiceTest {
                 // given: 3개월에서 딱 하루 더 신청 (1/22 ~ 4/23)
                 LocalDate startDate = LocalDate.of(2026, 1, 22);
                 LongTermVisitRequestDto dto =
-                    LongTermVisitRequestDto.builder()
-                        .startDate(startDate)
-                        .endDate(startDate.plusMonths(3).plusDays(1))
-                        .build();
+                        LongTermVisitRequestDto.builder()
+                                .startDate(startDate)
+                                .endDate(startDate.plusMonths(3).plusDays(1))
+                                .build();
 
                 // when & then
                 assertThatThrownBy(() -> visitService.registerLongTermPreVisit(dto))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage("장기 방문은 최대 3개월까지만 신청 가능합니다.");
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage("장기 방문은 최대 3개월까지만 신청 가능합니다.");
             }
         }
 
@@ -245,20 +242,20 @@ public class VisitServiceTest {
                 // given: 1/22 ~ 4/22 (딱 3개월)
                 LocalDate startDate = LocalDate.of(2026, 1, 22);
                 LongTermVisitRequestDto dto =
-                    LongTermVisitRequestDto.builder()
-                        .hostId(1L)
-                        .password("1234")
-                        .startDate(startDate)
-                        .endDate(startDate.plusMonths(3))
-                        .purpose(VisitPurpose.MEETING)
-                        .build();
+                        LongTermVisitRequestDto.builder()
+                                .hostId(1L)
+                                .password("1234")
+                                .startDate(startDate)
+                                .endDate(startDate.plusMonths(3))
+                                .purpose(VisitPurpose.MEETING)
+                                .build();
 
                 // Mocking (정상 저장을 위해 필요한 최소한의 세팅)
                 given(userRepository.findById(any()))
-                    .willReturn(Optional.of(User.builder().id(1L).build()));
+                        .willReturn(Optional.of(User.builder().id(1L).build()));
                 given(passwordEncoder.encode(any())).willReturn("hash");
                 given(visitMapper.toLongTermVisit(any(), any(), any()))
-                    .willReturn(Visit.builder().id(1L).build());
+                        .willReturn(Visit.builder().id(1L).build());
                 given(visitRepository.save(any())).willReturn(Visit.builder().id(1L).build());
 
                 // when & then
@@ -276,20 +273,20 @@ public class VisitServiceTest {
         void it_creates_visit_with_initial_record() throws IOException {
             // given
             OnSiteVisitRequestDto dto =
-                OnSiteVisitRequestDto.builder()
-                    .visitorName("현장방문객")
-                    .hostId(1L)
-                    .password("1234")
-                    .signatureFile(
-                        new MockMultipartFile(
-                            "file", "sig.png", "image/png", "test".getBytes()))
-                    .purpose(VisitPurpose.MEETING)
-                    .permissionType(AdditionalPermissionType.NONE)
-                    .build();
+                    OnSiteVisitRequestDto.builder()
+                            .visitorName("현장방문객")
+                            .hostId(1L)
+                            .password("1234")
+                            .signatureFile(
+                                    new MockMultipartFile(
+                                            "file", "sig.png", "image/png", "test".getBytes()))
+                            .purpose(VisitPurpose.MEETING)
+                            .permissionType(AdditionalPermissionType.NONE)
+                            .build();
 
             User mockHost = User.builder().id(1L).build();
             Visit mockVisit =
-                Visit.builder().id(100L).visited(true).records(new ArrayList<>()).build();
+                    Visit.builder().id(100L).visited(true).records(new ArrayList<>()).build();
 
             given(userRepository.findById(any())).willReturn(Optional.of(mockHost));
             given(passwordEncoder.encode(any())).willReturn("hash");
@@ -302,14 +299,14 @@ public class VisitServiceTest {
 
             // then
             verify(visitRepository)
-                .save(
-                    argThat(
-                        visit -> {
-                            assertThat(visit.getRecords()).hasSize(1);
-                            assertThat(visit.getRecords().get(0).getSignatureKey())
-                                .isEqualTo("s3-key-123");
-                            return true;
-                        }));
+                    .save(
+                            argThat(
+                                    visit -> {
+                                        assertThat(visit.getRecords()).hasSize(1);
+                                        assertThat(visit.getRecords().get(0).getSignatureKey())
+                                                .isEqualTo("s3-key-123");
+                                        return true;
+                                    }));
         }
     }
 
@@ -326,13 +323,13 @@ public class VisitServiceTest {
             void it_throws_visit_not_found() {
                 // given
                 MyVisitUpdateRequestDto dto =
-                    MyVisitUpdateRequestDto.builder().password(PLAIN_PASSWORD).build();
+                        MyVisitUpdateRequestDto.builder().password(PLAIN_PASSWORD).build();
                 given(visitRepository.findById(VISIT_ID)).willReturn(Optional.empty());
 
                 // when & then
                 assertThatThrownBy(() -> visitService.updateMyVisit(VISIT_ID, dto))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage("해당 방문정보를 찾을 수 없습니다.");
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage("해당 방문정보를 찾을 수 없습니다.");
             }
         }
 
@@ -345,7 +342,7 @@ public class VisitServiceTest {
             void it_throws_invalid_password() {
                 // given
                 MyVisitUpdateRequestDto dto =
-                    MyVisitUpdateRequestDto.builder().password(PLAIN_PASSWORD).build();
+                        MyVisitUpdateRequestDto.builder().password(PLAIN_PASSWORD).build();
                 Visit visit = createBaseVisit(VisitStatus.NOT_VISITED, false);
 
                 given(visitRepository.findById(VISIT_ID)).willReturn(Optional.of(visit));
@@ -353,8 +350,8 @@ public class VisitServiceTest {
 
                 // when & then
                 assertThatThrownBy(() -> visitService.updateMyVisit(VISIT_ID, dto))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage("유효하지 않은 비밀번호입니다.");
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage("유효하지 않은 비밀번호입니다.");
             }
         }
 
@@ -367,7 +364,7 @@ public class VisitServiceTest {
             void it_throws_invalid_status() {
                 // given
                 MyVisitUpdateRequestDto dto =
-                    MyVisitUpdateRequestDto.builder().password(PLAIN_PASSWORD).build();
+                        MyVisitUpdateRequestDto.builder().password(PLAIN_PASSWORD).build();
                 Visit visit = createBaseVisit(VisitStatus.COMPLETED, false);
 
                 given(visitRepository.findById(VISIT_ID)).willReturn(Optional.of(visit));
@@ -375,8 +372,8 @@ public class VisitServiceTest {
 
                 // when & then
                 assertThatThrownBy(() -> visitService.updateMyVisit(VISIT_ID, dto))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage("승인 가능한 상태가 아닙니다.");
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage("승인 가능한 상태가 아닙니다.");
             }
         }
 
@@ -390,11 +387,11 @@ public class VisitServiceTest {
                 // given
                 LocalDate newDate = LocalDate.now().plusDays(5);
                 MyVisitUpdateRequestDto dto =
-                    MyVisitUpdateRequestDto.builder()
-                        .password(PLAIN_PASSWORD)
-                        .startDate(newDate)
-                        .visitorName("수정된이름")
-                        .build();
+                        MyVisitUpdateRequestDto.builder()
+                                .password(PLAIN_PASSWORD)
+                                .startDate(newDate)
+                                .visitorName("수정된이름")
+                                .build();
 
                 Visit visit = createBaseVisit(VisitStatus.NOT_VISITED, false);
                 visit.setStartDate(newDate);
@@ -421,10 +418,10 @@ public class VisitServiceTest {
             void it_updates_and_resets_status_when_no_records() {
                 // given
                 MyVisitUpdateRequestDto dto =
-                    MyVisitUpdateRequestDto.builder()
-                        .password(PLAIN_PASSWORD)
-                        .visitorName("이름수정")
-                        .build();
+                        MyVisitUpdateRequestDto.builder()
+                                .password(PLAIN_PASSWORD)
+                                .visitorName("이름수정")
+                                .build();
 
                 Visit visit = createBaseVisit(VisitStatus.APPROVED, true);
                 visit.setStartDate(LocalDate.now());
@@ -447,7 +444,7 @@ public class VisitServiceTest {
             void it_throws_exception_when_already_visited() {
                 // given
                 MyVisitUpdateRequestDto dto =
-                    MyVisitUpdateRequestDto.builder().password(PLAIN_PASSWORD).build();
+                        MyVisitUpdateRequestDto.builder().password(PLAIN_PASSWORD).build();
 
                 Visit visit = createBaseVisit(VisitStatus.APPROVED, true);
                 visit.setVisited(true); // ★ 핵심: 이미 한 번이라도 입실했던 상태
@@ -457,8 +454,8 @@ public class VisitServiceTest {
 
                 // when & then
                 assertThatThrownBy(() -> visitService.updateMyVisit(VISIT_ID, dto))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage("승인 가능한 상태가 아닙니다."); // ErrorCode.INVALID_VISIT_STATUS
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage("승인 가능한 상태가 아닙니다."); // ErrorCode.INVALID_VISIT_STATUS
             }
         }
     }
@@ -467,8 +464,7 @@ public class VisitServiceTest {
     @DisplayName("checkIn 메서드는")
     class Describe_checkIn {
 
-        @Mock
-        private MockMultipartFile signatureFile;
+        @Mock private MockMultipartFile signatureFile;
 
         @Nested
         @DisplayName("비밀번호가 일치하지 않으면")
@@ -486,8 +482,8 @@ public class VisitServiceTest {
 
                 // when & then
                 assertThatThrownBy(() -> visitService.checkIn(dto))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage("유효하지 않은 비밀번호입니다.");
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage("유효하지 않은 비밀번호입니다.");
             }
         }
 
@@ -509,8 +505,8 @@ public class VisitServiceTest {
 
                 // when & then
                 assertThatThrownBy(() -> visitService.checkIn(dto))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage("오늘 방문 일정이 아닙니다.");
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage("오늘 방문 일정이 아닙니다.");
             }
         }
 
@@ -532,8 +528,8 @@ public class VisitServiceTest {
 
                 // when & then
                 assertThatThrownBy(() -> visitService.checkIn(dto))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage("이미 체크아웃된 방문정보입니다.");
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage("이미 체크아웃된 방문정보입니다.");
             }
         }
 
@@ -562,7 +558,7 @@ public class VisitServiceTest {
                 assertThat(visit.isVisited()).isTrue();
                 assertThat(visit.getRecords()).hasSize(1);
                 assertThat(visit.getRecords().get(0).getSignatureKey())
-                    .isEqualTo("s3-signature-key");
+                        .isEqualTo("s3-signature-key");
 
                 verify(s3Service, times(1)).uploadFile(any());
             }
@@ -600,12 +596,12 @@ public class VisitServiceTest {
 
                 given(visitRepository.findById(VISIT_ID)).willReturn(Optional.of(visit));
                 CheckOutRequestDto dto =
-                    new CheckOutRequestDto(VISIT_ID, RECORD_ID, CHECK_OUT_TIME);
+                        new CheckOutRequestDto(VISIT_ID, RECORD_ID, CHECK_OUT_TIME);
 
                 // when & then
                 assertThatThrownBy(() -> visitService.checkOut(ADMIN_ID, dto))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage("현재 방문 상태가 '방문 중'이 아닙니다.");
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage("현재 방문 상태가 '방문 중'이 아닙니다.");
             }
 
             @Test
@@ -613,18 +609,18 @@ public class VisitServiceTest {
             void it_changes_status_to_completed_for_one_day_visit() {
                 // given
                 VisitRecord record =
-                    VisitRecord.builder()
-                        .id(RECORD_ID)
-                        .entryTime(ENTRY_TIME)
-                        .exitTime(null)
-                        .build();
+                        VisitRecord.builder()
+                                .id(RECORD_ID)
+                                .entryTime(ENTRY_TIME)
+                                .exitTime(null)
+                                .build();
 
                 Visit visit = createBaseVisit(VisitStatus.IN_PROGRESS, false);
                 visit.getRecords().add(record);
 
                 given(visitRepository.findById(VISIT_ID)).willReturn(Optional.of(visit));
                 CheckOutRequestDto dto =
-                    new CheckOutRequestDto(VISIT_ID, RECORD_ID, CHECK_OUT_TIME);
+                        new CheckOutRequestDto(VISIT_ID, RECORD_ID, CHECK_OUT_TIME);
 
                 // when
                 visitService.checkOut(ADMIN_ID, dto);
@@ -639,17 +635,17 @@ public class VisitServiceTest {
             void it_changes_status_to_approved_for_long_term_visit() {
                 // given
                 VisitRecord record =
-                    VisitRecord.builder()
-                        .id(RECORD_ID)
-                        .entryTime(ENTRY_TIME)
-                        .exitTime(null)
-                        .build();
+                        VisitRecord.builder()
+                                .id(RECORD_ID)
+                                .entryTime(ENTRY_TIME)
+                                .exitTime(null)
+                                .build();
                 Visit visit = createBaseVisit(VisitStatus.IN_PROGRESS, true);
                 visit.getRecords().add(record);
 
                 given(visitRepository.findById(VISIT_ID)).willReturn(Optional.of(visit));
                 CheckOutRequestDto dto =
-                    new CheckOutRequestDto(VISIT_ID, RECORD_ID, CHECK_OUT_TIME);
+                        new CheckOutRequestDto(VISIT_ID, RECORD_ID, CHECK_OUT_TIME);
 
                 // when
                 visitService.checkOut(ADMIN_ID, dto);
@@ -672,11 +668,11 @@ public class VisitServiceTest {
                 LocalDateTime newExitTime = LocalDateTime.of(2026, 1, 22, 19, 0);
 
                 VisitRecord record =
-                    VisitRecord.builder()
-                        .id(RECORD_ID)
-                        .entryTime(ENTRY_TIME)
-                        .exitTime(oldExitTime)
-                        .build();
+                        VisitRecord.builder()
+                                .id(RECORD_ID)
+                                .entryTime(ENTRY_TIME)
+                                .exitTime(oldExitTime)
+                                .build();
                 Visit visit = createBaseVisit(VisitStatus.COMPLETED, false);
                 visit.getRecords().add(record);
 
@@ -702,11 +698,11 @@ public class VisitServiceTest {
                 // given: 입실은 10시인데 퇴실을 09시로 요청한 경우
                 LocalDateTime invalidTime = ENTRY_TIME.minusHours(1);
                 VisitRecord record =
-                    VisitRecord.builder()
-                        .id(RECORD_ID)
-                        .entryTime(ENTRY_TIME)
-                        .exitTime(null)
-                        .build();
+                        VisitRecord.builder()
+                                .id(RECORD_ID)
+                                .entryTime(ENTRY_TIME)
+                                .exitTime(null)
+                                .build();
                 Visit visit = createBaseVisit(VisitStatus.IN_PROGRESS, false);
                 visit.getRecords().add(record);
 
@@ -715,8 +711,8 @@ public class VisitServiceTest {
 
                 // when & then
                 assertThatThrownBy(() -> visitService.checkOut(ADMIN_ID, dto))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage("퇴실 시간은 입실 시간보다 빠를 수 없습니다.");
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage("퇴실 시간은 입실 시간보다 빠를 수 없습니다.");
             }
         }
     }
@@ -742,8 +738,8 @@ public class VisitServiceTest {
 
                 // when & then
                 assertThatThrownBy(() -> visitService.processVisit(1L, 100L, dto))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage("장기 방문 건이 아닙니다.");
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage("장기 방문 건이 아닙니다.");
             }
         }
 
@@ -782,8 +778,8 @@ public class VisitServiceTest {
                 User admin = createHost();
                 Visit pendingVisit = createBaseVisit(VisitStatus.PENDING, true);
                 String reason = "방문 목적 부적합";
-                VisitProcessRequestDto dto = new VisitProcessRequestDto(VisitStatus.REJECTED,
-                    reason);
+                VisitProcessRequestDto dto =
+                        new VisitProcessRequestDto(VisitStatus.REJECTED, reason);
 
                 given(userRepository.findById(any())).willReturn(Optional.of(admin));
                 given(visitRepository.findById(any())).willReturn(Optional.of(pendingVisit));
@@ -807,16 +803,16 @@ public class VisitServiceTest {
                 // given
                 User admin = createHost();
                 Visit approvedVisit = createBaseVisit(VisitStatus.APPROVED, true);
-                VisitProcessRequestDto dto = new VisitProcessRequestDto(VisitStatus.REJECTED,
-                    "뒤늦은 반려");
+                VisitProcessRequestDto dto =
+                        new VisitProcessRequestDto(VisitStatus.REJECTED, "뒤늦은 반려");
 
                 given(userRepository.findById(any())).willReturn(Optional.of(admin));
                 given(visitRepository.findById(any())).willReturn(Optional.of(approvedVisit));
 
                 // when & then
                 assertThatThrownBy(() -> visitService.processVisit(1L, 100L, dto))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessage("승인 가능한 상태가 아닙니다.");
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage("승인 가능한 상태가 아닙니다.");
             }
         }
     }
@@ -841,8 +837,8 @@ public class VisitServiceTest {
 
                 // when & then
                 assertThatThrownBy(() -> visitService.getMyVisitDetail(100L, dto))
-                    .isInstanceOf(CustomException.class)
-                    .hasMessageContaining("유효하지 않은 비밀번호입니다.");
+                        .isInstanceOf(CustomException.class)
+                        .hasMessageContaining("유효하지 않은 비밀번호입니다.");
             }
         }
     }


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #94 

## 📝작업 내용
- 내방 상태에 대해 반려 추가
    - VisitStatus에 REJECT 추가 및 Visit과 각 DetailResponse에 String rejectionReason 추가
    - '내방객 방문 승인' 기능은 '내방객 방문 승인 및 반려 (방문 처리)' 기능으로 변경
    - 반려 시 반려 사유를 꼭 동반하도록 강제
 - 관리자의 회원가입 승인로직 수정
     - 관리자는 회원가입 승인 시 직원의 ROLE을 설정 가능
     - 기본값은 USER이며, 근무 직종이 관리직인 경우 ADMIN으로 설정 가능
     - ADMIN 설정 시 모든 권한이 추가된 상태로 가입 승인됨

## 📸 스크린샷 (선택)
<img width="2022" height="1190" alt="image" src="https://github.com/user-attachments/assets/9221d8d1-81fa-494b-b27e-3ee763864232" />

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?