### PR TITLE
feat(148): 공통 코드 API 구현 및 UserApprovalRequestDto 리팩터링

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
@@ -50,7 +50,10 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/admin")
 @RequiredArgsConstructor
-@Tag(name = "Admin", description = """
+@Tag(
+        name = "Admin",
+        description =
+                """
                 ## 관리자 전용 API
 
                 시스템 관리 권한이 필요한 기능을 제공합니다. 주로 사용자 승인 및 권한 관리를 담당합니다.
@@ -61,11 +64,21 @@ import java.util.List;
                 """)
 public class AdminController {
 
-        private final AdminService adminService;
+    private final AdminService adminService;
 
-        @Operation(summary = "직원 목록 조회", description = "직원 관리 화면용 사용자 목록을 조회합니다.")
-        @ApiResponses(value = {
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+    @Operation(summary = "직원 목록 조회", description = "직원 관리 화면용 사용자 목록을 조회합니다.")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "조회 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                         {
                                           "isSuccess": true,
                                           "code": "COMMON200",
@@ -83,7 +96,16 @@ public class AdminController {
                                           ]
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "403",
+                        description = "권한 없음",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                         {
                                           "isSuccess": false,
                                           "code": "NO_AUTHORITY_FOR_REGISTRATION",
@@ -91,32 +113,53 @@ public class AdminController {
                                           "result": null
                                         }
                                         """)))
-        })
-        @GetMapping("/users")
-        public ResponseEntity<ApiResponse<Page<AdminUserSummaryResponseDto>>> getUsers(
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
-                        @Parameter(description = "한글/영어 이름 or 이메일 검색어", required = false, example = "홍길동") @RequestParam(required = false) String keyword,
-                        @Parameter(description = "직급 필터", required = false, example = "사원") @RequestParam(required = false) Position position,
-                        @Parameter(description = "부서 ID 필터", required = false, example = "11") @RequestParam(required = false) Long departmentId,
-                        @Parameter(description = "근무직종 필터", required = false, example = "관리직") @RequestParam(required = false) JobType jobType,
-                        @Parameter(description = "역할 필터", required = false, example = "일반 사용자") @RequestParam(required = false) Role role,
-                        @ParameterObject @PageableDefault(page = 0, size = 20) Pageable pageable) {
+            })
+    @GetMapping("/users")
+    public ResponseEntity<ApiResponse<Page<AdminUserSummaryResponseDto>>> getUsers(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "한글/영어 이름 or 이메일 검색어", required = false, example = "홍길동")
+                    @RequestParam(required = false)
+                    String keyword,
+            @Parameter(description = "직급 필터", required = false, example = "사원")
+                    @RequestParam(required = false)
+                    Position position,
+            @Parameter(description = "부서 ID 필터", required = false, example = "11")
+                    @RequestParam(required = false)
+                    Long departmentId,
+            @Parameter(description = "근무직종 필터", required = false, example = "관리직")
+                    @RequestParam(required = false)
+                    JobType jobType,
+            @Parameter(description = "역할 필터", required = false, example = "일반 사용자")
+                    @RequestParam(required = false)
+                    Role role,
+            @ParameterObject @PageableDefault(page = 0, size = 20) Pageable pageable) {
 
-                Page<AdminUserSummaryResponseDto> result = adminService.getUsers(
-                                userDetails.getId(),
-                                keyword,
-                                position,
-                                departmentId,
-                                jobType,
-                                role,
-                                pageable);
+        Page<AdminUserSummaryResponseDto> result =
+                adminService.getUsers(
+                        userDetails.getId(),
+                        keyword,
+                        position,
+                        departmentId,
+                        jobType,
+                        role,
+                        pageable);
 
-                return ResponseEntity.ok(ApiResponse.onSuccess(result));
-        }
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
+    }
 
-        @Operation(summary = "직원 상세 조회", description = "직원 관리 화면용 사용자 상세 정보를 조회합니다.")
-        @ApiResponses(value = {
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+    @Operation(summary = "직원 상세 조회", description = "직원 관리 화면용 사용자 상세 정보를 조회합니다.")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "조회 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                         {
                                           "isSuccess": true,
                                           "code": "COMMON200",
@@ -150,7 +193,16 @@ public class AdminController {
                                           }
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "403",
+                        description = "권한 없음",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                         {
                                           "isSuccess": false,
                                           "code": "NO_AUTHORITY_FOR_REGISTRATION",
@@ -158,7 +210,16 @@ public class AdminController {
                                           "result": null
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "404",
+                        description = "사용자 없음",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                         {
                                           "isSuccess": false,
                                           "code": "USER_NOT_FOUND",
@@ -166,18 +227,29 @@ public class AdminController {
                                           "result": null
                                         }
                                         """)))
-        })
-        @GetMapping("/users/{userId}")
-        public ResponseEntity<ApiResponse<AdminUserDetailResponseDto>> getUserDetail(
-                        @Parameter(description = "상세 조회할 사용자 ID", required = true, example = "17") @PathVariable Long userId,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-                AdminUserDetailResponseDto result = adminService.getUserDetail(userDetails.getId(), userId);
-                return ResponseEntity.ok(ApiResponse.onSuccess(result));
-        }
+            })
+    @GetMapping("/users/{userId}")
+    public ResponseEntity<ApiResponse<AdminUserDetailResponseDto>> getUserDetail(
+            @Parameter(description = "상세 조회할 사용자 ID", required = true, example = "17") @PathVariable
+                    Long userId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        AdminUserDetailResponseDto result = adminService.getUserDetail(userDetails.getId(), userId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
+    }
 
-        @Operation(summary = "직원 정보 수정", description = "관리자가 직원 정보를 수정합니다. 이메일은 수정할 수 없습니다.")
-        @ApiResponses(value = {
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+    @Operation(summary = "직원 정보 수정", description = "관리자가 직원 정보를 수정합니다. 이메일은 수정할 수 없습니다.")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "수정 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                         {
                                           "isSuccess": true,
                                           "code": "COMMON200",
@@ -185,8 +257,17 @@ public class AdminController {
                                           "result": "직원 정보가 성공적으로 수정되었습니다."
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(mediaType = "application/json", examples = {
-                                        @ExampleObject(name = "전화번호 인증 필요", value = """
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "400",
+                        description = "잘못된 요청",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples = {
+                                            @ExampleObject(
+                                                    name = "전화번호 인증 필요",
+                                                    value =
+                                                            """
                                                         {
                                                           "isSuccess": false,
                                                           "code": "PHONE_NOT_VERIFIED",
@@ -194,7 +275,10 @@ public class AdminController {
                                                           "result": null
                                                         }
                                                         """),
-                                        @ExampleObject(name = "잘못된 직무/역할 조합", value = """
+                                            @ExampleObject(
+                                                    name = "잘못된 직무/역할 조합",
+                                                    value =
+                                                            """
                                                         {
                                                           "isSuccess": false,
                                                           "code": "INVALID_JOB_TYPE_FOR_ADMIN_ROLE",
@@ -202,8 +286,17 @@ public class AdminController {
                                                           "result": null
                                                         }
                                                         """)
-                        })),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                                        })),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "403",
+                        description = "권한 없음",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                         {
                                           "isSuccess": false,
                                           "code": "NO_AUTHORITY_FOR_REGISTRATION",
@@ -211,8 +304,17 @@ public class AdminController {
                                           "result": null
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자/부서 없음", content = @Content(mediaType = "application/json", examples = {
-                                        @ExampleObject(name = "사용자 없음", value = """
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "404",
+                        description = "사용자/부서 없음",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples = {
+                                            @ExampleObject(
+                                                    name = "사용자 없음",
+                                                    value =
+                                                            """
                                                         {
                                                           "isSuccess": false,
                                                           "code": "USER_NOT_FOUND",
@@ -220,7 +322,10 @@ public class AdminController {
                                                           "result": null
                                                         }
                                                         """),
-                                        @ExampleObject(name = "부서 없음", value = """
+                                            @ExampleObject(
+                                                    name = "부서 없음",
+                                                    value =
+                                                            """
                                                         {
                                                           "isSuccess": false,
                                                           "code": "DEPARTMENT_NOT_FOUND",
@@ -228,20 +333,31 @@ public class AdminController {
                                                           "result": null
                                                         }
                                                         """)
-                        }))
-        })
-        @PatchMapping("/users/{userId}")
-        public ResponseEntity<ApiResponse<String>> updateUserInfo(
-                        @Parameter(description = "수정할 사용자 ID", required = true, example = "17") @PathVariable Long userId,
-                        @Valid @RequestBody AdminUserUpdateRequestDto requestDto,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-                adminService.updateUserInfo(userId, requestDto, userDetails.getId());
-                return ResponseEntity.ok(ApiResponse.onSuccess("직원 정보가 성공적으로 수정되었습니다."));
-        }
+                                        }))
+            })
+    @PatchMapping("/users/{userId}")
+    public ResponseEntity<ApiResponse<String>> updateUserInfo(
+            @Parameter(description = "수정할 사용자 ID", required = true, example = "17") @PathVariable
+                    Long userId,
+            @Valid @RequestBody AdminUserUpdateRequestDto requestDto,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        adminService.updateUserInfo(userId, requestDto, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess("직원 정보가 성공적으로 수정되었습니다."));
+    }
 
-        @Operation(summary = "회원가입 승인 대기 목록 조회", description = "승인 대기(PENDING) 사용자 목록을 조회합니다.")
-        @ApiResponses(value = {
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+    @Operation(summary = "회원가입 승인 대기 목록 조회", description = "승인 대기(PENDING) 사용자 목록을 조회합니다.")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "조회 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                         {
                                           "isSuccess": true,
                                           "code": "COMMON200",
@@ -272,7 +388,16 @@ public class AdminController {
                                           ]
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "401",
+                        description = "인증 실패",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                         {
                                           "isSuccess": false,
                                           "code": "USER_NOT_FOUND",
@@ -280,7 +405,16 @@ public class AdminController {
                                           "result": null
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "403",
+                        description = "권한 없음",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                         {
                                           "isSuccess": false,
                                           "code": "NO_AUTHORITY_FOR_REGISTRATION",
@@ -288,17 +422,31 @@ public class AdminController {
                                           "result": null
                                         }
                                         """)))
-        })
-        @GetMapping("/users/pending")
-        public ResponseEntity<ApiResponse<List<PendingUserSummaryResponseDto>>> getPendingUsers(
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-                List<PendingUserSummaryResponseDto> result = adminService.getPendingSignupUsers(userDetails.getId());
-                return ResponseEntity.ok(ApiResponse.onSuccess(result));
-        }
+            })
+    @GetMapping("/users/pending")
+    public ResponseEntity<ApiResponse<List<PendingUserSummaryResponseDto>>> getPendingUsers(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<PendingUserSummaryResponseDto> result =
+                adminService.getPendingSignupUsers(userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
+    }
 
-        @Operation(summary = "회원가입 승인", description = "대기 상태(PENDING)인 사용자의 부서 및 직급을 설정하고 최종 승인(AVAILABLE) 처리합니다.")
-        @ApiResponses(value = {
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "승인 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class), examples = @ExampleObject(value = """
+    @Operation(
+            summary = "회원가입 승인",
+            description = "대기 상태(PENDING)인 사용자의 부서 및 직급을 설정하고 최종 승인(AVAILABLE) 처리합니다.")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "승인 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = ApiResponse.class),
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                         {
                                         "isSuccess": true,
                                         "code": "COMMON200",
@@ -306,8 +454,17 @@ public class AdminController {
                                         "result": "1번 사용자의 회원가입이 성공적으로 승인되었습니다."
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(mediaType = "application/json", examples = {
-                                        @ExampleObject(name = "이미 승인된 사용자", value = """
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "400",
+                        description = "잘못된 요청",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples = {
+                                            @ExampleObject(
+                                                    name = "이미 승인된 사용자",
+                                                    value =
+                                                            """
                                                         {
                                                           "isSuccess": false,
                                                           "code": "DUPLICATED_SIGNUP_REQUEST",
@@ -315,7 +472,10 @@ public class AdminController {
                                                           "result": null
                                                         }
                                                         """),
-                                        @ExampleObject(name = "입력값 검증 실패", value = """
+                                            @ExampleObject(
+                                                    name = "입력값 검증 실패",
+                                                    value =
+                                                            """
                                                         {
                                                           "isSuccess": false,
                                                           "code": "COMMON400",
@@ -326,9 +486,18 @@ public class AdminController {
                                                           }
                                                         }
                                                         """)
-                        })),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "대상 없음", content = @Content(mediaType = "application/json", examples = {
-                                        @ExampleObject(name = "사용자 없음", value = """
+                                        })),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "404",
+                        description = "대상 없음",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples = {
+                                            @ExampleObject(
+                                                    name = "사용자 없음",
+                                                    value =
+                                                            """
                                                         {
                                                           "isSuccess": false,
                                                           "code": "USER_NOT_FOUND",
@@ -336,7 +505,10 @@ public class AdminController {
                                                           "result": null
                                                         }
                                                         """),
-                                        @ExampleObject(name = "부서 없음", value = """
+                                            @ExampleObject(
+                                                    name = "부서 없음",
+                                                    value =
+                                                            """
                                                         {
                                                           "isSuccess": false,
                                                           "code": "DEPARTMENT_NOT_FOUND",
@@ -344,13 +516,28 @@ public class AdminController {
                                                           "result": null
                                                         }
                                                         """)
-                        }))
-        })
-        @PatchMapping("/users/{userId}/approve")
-        public ResponseEntity<ApiResponse<String>> approveUser(
-                        @Parameter(description = "승인할 사용자의 ID", example = "1", required = true) @PathVariable("userId") Long userId,
-                        @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "사용자 승인 정보", required = true, content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserApprovalRequestDto.class), examples = {
-                                        @ExampleObject(name = "권한 1개 선택 예시", value = """
+                                        }))
+            })
+    @PatchMapping("/users/{userId}/approve")
+    public ResponseEntity<ApiResponse<String>> approveUser(
+            @Parameter(description = "승인할 사용자의 ID", example = "1", required = true)
+                    @PathVariable("userId")
+                    Long userId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            description = "사용자 승인 정보",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema =
+                                                    @Schema(
+                                                            implementation =
+                                                                    UserApprovalRequestDto.class),
+                                            examples = {
+                                                @ExampleObject(
+                                                        name = "권한 1개 선택 예시",
+                                                        value =
+                                                                """
                                                         {
                                                           "nameKor": "홍길동",
                                                           "nameEng": "HONG GILDONG",
@@ -371,7 +558,10 @@ public class AdminController {
                                                           "role": "일반 사용자"
                                                         }
                                                         """),
-                                        @ExampleObject(name = "권한 5개 선택 예시", value = """
+                                                @ExampleObject(
+                                                        name = "권한 5개 선택 예시",
+                                                        value =
+                                                                """
                                                         {
                                                           "nameKor": "홍길동",
                                                           "nameEng": "HONG GILDONG",
@@ -398,17 +588,34 @@ public class AdminController {
                                                           "role": "일반 사용자"
                                                         }
                                                         """)
-                        })) @Parameter(description = "사용자 승인 정보 (부서 ID, 직급 등)", required = true) @Valid @RequestBody UserApprovalRequestDto requestDto,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+                                            }))
+                    @Parameter(description = "사용자 승인 정보 (부서 ID, 직급 등)", required = true)
+                    @Valid
+                    @RequestBody
+                    UserApprovalRequestDto requestDto,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-                adminService.approveUserRegistration(userId, requestDto, userDetails.getId());
+        adminService.approveUserRegistration(userId, requestDto, userDetails.getId());
 
-                return ResponseEntity.ok(ApiResponse.onSuccess(userId + "번 사용자의 회원가입이 성공적으로 승인되었습니다."));
-        }
+        return ResponseEntity.ok(ApiResponse.onSuccess(userId + "번 사용자의 회원가입이 성공적으로 승인되었습니다."));
+    }
 
-        @Operation(summary = "사용자 역할(Role) 변경", description = "특정 사용자의 역할을 변경합니다. 관리자(`ADMIN`) 또는 마스터 관리자(`MASTER_ADMIN`) 권한이 필요합니다.")
-        @ApiResponses(value = {
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "역할 변경 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class), examples = @ExampleObject(value = """
+    @Operation(
+            summary = "사용자 역할(Role) 변경",
+            description = "특정 사용자의 역할을 변경합니다. 관리자(`ADMIN`) 또는 마스터 관리자(`MASTER_ADMIN`) 권한이 필요합니다.")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "역할 변경 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = ApiResponse.class),
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                         {
                                         "isSuccess": true,
                                         "code": "COMMON200",
@@ -416,7 +623,17 @@ public class AdminController {
                                         "result": "5번 사용자의 역할이 관리자(으)로 성공적으로 변경되었습니다."
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 부족", content = @Content(mediaType = "application/json", examples = @ExampleObject(name = "역할 변경 권한 없음", value = """
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "403",
+                        description = "권한 부족",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        name = "역할 변경 권한 없음",
+                                                        value =
+                                                                """
                                         {
                                         "isSuccess": false,
                                         "code": "NO_AUTHORITY_FOR_ROLE_UPDATE",
@@ -424,7 +641,16 @@ public class AdminController {
                                         "result": null
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "404",
+                        description = "사용자 없음",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                         {
                                         "isSuccess": false,
                                         "code": "USER_NOT_FOUND",
@@ -432,24 +658,38 @@ public class AdminController {
                                         "result": null
                                         }
                                         """)))
-        })
-        @PatchMapping("/users/{userId}/role")
-        @PreAuthorize("hasAnyRole('ADMIN', 'MASTER_ADMIN')")
-        public ResponseEntity<ApiResponse<String>> updateUserRole(
-                        @Parameter(description = "역할을 변경할 사용자 ID", example = "5") @PathVariable Long userId,
-                        @Parameter(description = "변경할 역할 (USER, ADMIN 등)", example = "ADMIN") @RequestParam Role role,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+            })
+    @PatchMapping("/users/{userId}/role")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MASTER_ADMIN')")
+    public ResponseEntity<ApiResponse<String>> updateUserRole(
+            @Parameter(description = "역할을 변경할 사용자 ID", example = "5") @PathVariable Long userId,
+            @Parameter(description = "변경할 역할 (USER, ADMIN 등)", example = "ADMIN") @RequestParam
+                    Role role,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-                adminService.updateUserRole(userId, role, userDetails.getId());
-                return ResponseEntity.ok(
-                                ApiResponse.onSuccess(
-                                                userId + "번 사용자의 역할이 " + role.getDescription()
-                                                                + "(으)로 성공적으로 변경되었습니다."));
-        }
+        adminService.updateUserRole(userId, role, userDetails.getId());
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(
+                        userId + "번 사용자의 역할이 " + role.getDescription() + "(으)로 성공적으로 변경되었습니다."));
+    }
 
-        @Operation(summary = "사용자 세부 권한 변경", description = "특정 사용자에게 여러 권한을 일괄 추가(ADD)하거나 제거(REMOVE)합니다. ADMIN 또는 MASTER_ADMIN만 가능합니다.")
-        @ApiResponses(value = {
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "권한 변경 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class), examples = @ExampleObject(value = """
+    @Operation(
+            summary = "사용자 세부 권한 변경",
+            description =
+                    "특정 사용자에게 여러 권한을 일괄 추가(ADD)하거나 제거(REMOVE)합니다. ADMIN 또는 MASTER_ADMIN만 가능합니다.")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "권한 변경 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema = @Schema(implementation = ApiResponse.class),
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                         {
                                         "isSuccess": true,
                                         "code": "COMMON200",
@@ -457,8 +697,17 @@ public class AdminController {
                                         "result": "권한이 성공적으로 변경되었습니다."
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터", content = @Content(mediaType = "application/json", examples = {
-                                        @ExampleObject(name = "입력값 검증 실패", value = """
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "400",
+                        description = "잘못된 요청 파라미터",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples = {
+                                            @ExampleObject(
+                                                    name = "입력값 검증 실패",
+                                                    value =
+                                                            """
                                                         {
                                                         "isSuccess": false,
                                                         "code": "COMMON400",
@@ -466,7 +715,10 @@ public class AdminController {
                                                         "result": null
                                                         }
                                                         """),
-                                        @ExampleObject(name = "이미 부여된 권한 추가", value = """
+                                            @ExampleObject(
+                                                    name = "이미 부여된 권한 추가",
+                                                    value =
+                                                            """
                                                         {
                                                         "isSuccess": false,
                                                         "code": "AUTHORITY_ALREADY_ASSIGNED",
@@ -474,7 +726,10 @@ public class AdminController {
                                                         "result": null
                                                         }
                                                         """),
-                                        @ExampleObject(name = "없는 권한 제거", value = """
+                                            @ExampleObject(
+                                                    name = "없는 권한 제거",
+                                                    value =
+                                                            """
                                                         {
                                                         "isSuccess": false,
                                                         "code": "AUTHORITY_NOT_ASSIGNED",
@@ -482,8 +737,17 @@ public class AdminController {
                                                         "result": null
                                                         }
                                                         """)
-                        })),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 부족", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                                        })),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "403",
+                        description = "권한 부족",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                         {
                                         "isSuccess": false,
                                         "code": "NO_AUTHORITY_FOR_ROLE_UPDATE",
@@ -491,7 +755,16 @@ public class AdminController {
                                         "result": null
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "404",
+                        description = "사용자 없음",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                         {
                                         "isSuccess": false,
                                         "code": "USER_NOT_FOUND",
@@ -499,21 +772,47 @@ public class AdminController {
                                         "result": null
                                         }
                                         """)))
-        })
-        @PatchMapping("/users/{userId}/authority")
-        public ResponseEntity<ApiResponse<String>> updateUserAuthority(
-                        @Parameter(description = "권한 변경 대상 사용자 ID", example = "22", required = true) @PathVariable Long userId,
-                        @Parameter(name = "authorities", description = "변경할 권한 목록 (복수 선택 가능, 영문/한글 설명값 모두 입력 가능)", style = ParameterStyle.FORM, explode = Explode.TRUE) @RequestParam List<Authority> authorities,
-                        @Parameter(description = "권한 변경 동작 (ADD/REMOVE 또는 추가/제거)", example = "추가", required = true, schema = @Schema(implementation = AuthorityAction.class)) @RequestParam AuthorityAction action,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+            })
+    @PatchMapping("/users/{userId}/authority")
+    public ResponseEntity<ApiResponse<String>> updateUserAuthority(
+            @Parameter(description = "권한 변경 대상 사용자 ID", example = "22", required = true)
+                    @PathVariable
+                    Long userId,
+            @Parameter(
+                            name = "authorities",
+                            description = "변경할 권한 목록 (복수 선택 가능, 영문/한글 설명값 모두 입력 가능)",
+                            style = ParameterStyle.FORM,
+                            explode = Explode.TRUE)
+                    @RequestParam
+                    List<Authority> authorities,
+            @Parameter(
+                            description = "권한 변경 동작 (ADD/REMOVE 또는 추가/제거)",
+                            example = "추가",
+                            required = true,
+                            schema = @Schema(implementation = AuthorityAction.class))
+                    @RequestParam
+                    AuthorityAction action,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-                adminService.updateUserAuthority(userId, authorities, action, userDetails.getId());
-                return ResponseEntity.ok(ApiResponse.onSuccess("권한이 성공적으로 변경되었습니다."));
-        }
+        adminService.updateUserAuthority(userId, authorities, action, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess("권한이 성공적으로 변경되었습니다."));
+    }
 
-        @Operation(summary = "내 정보 수정 요청 승인", description = "해당 사용자(userId)의 최신 PENDING 개인정보 수정 요청 1건을 승인하고 실제 사용자 정보에 반영합니다.")
-        @ApiResponses(value = {
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "승인 성공", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+    @Operation(
+            summary = "내 정보 수정 요청 승인",
+            description = "해당 사용자(userId)의 최신 PENDING 개인정보 수정 요청 1건을 승인하고 실제 사용자 정보에 반영합니다.")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "승인 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                         {
                                           "isSuccess": true,
                                           "code": "COMMON200",
@@ -521,7 +820,16 @@ public class AdminController {
                                           "result": "22번 사용자의 개인정보 수정 요청이 승인되었습니다."
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "403",
+                        description = "권한 없음",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                         {
                                           "isSuccess": false,
                                           "code": "NO_AUTHORITY_FOR_MY_INFO_UPDATE_APPROVAL",
@@ -529,8 +837,17 @@ public class AdminController {
                                           "result": null
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "요청 또는 사용자 없음", content = @Content(mediaType = "application/json", examples = {
-                                        @ExampleObject(name = "사용자 없음", value = """
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "404",
+                        description = "요청 또는 사용자 없음",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples = {
+                                            @ExampleObject(
+                                                    name = "사용자 없음",
+                                                    value =
+                                                            """
                                                         {
                                                           "isSuccess": false,
                                                           "code": "USER_NOT_FOUND",
@@ -538,7 +855,10 @@ public class AdminController {
                                                           "result": null
                                                         }
                                                         """),
-                                        @ExampleObject(name = "요청 없음", value = """
+                                            @ExampleObject(
+                                                    name = "요청 없음",
+                                                    value =
+                                                            """
                                                         {
                                                           "isSuccess": false,
                                                           "code": "MY_INFO_UPDATE_REQUEST_NOT_FOUND",
@@ -546,19 +866,32 @@ public class AdminController {
                                                           "result": null
                                                         }
                                                         """)
-                        }))
-        })
-        @PatchMapping("/users/{userId}/my-info/approve")
-        public ResponseEntity<ApiResponse<String>> approveMyInfoUpdate(
-                        @Parameter(description = "승인 대상 사용자 ID", required = true, example = "22") @PathVariable Long userId,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-                adminService.approveMyInfoUpdate(userId, userDetails.getId());
-                return ResponseEntity.ok(ApiResponse.onSuccess(userId + "번 사용자의 개인정보 수정 요청이 승인되었습니다."));
-        }
+                                        }))
+            })
+    @PatchMapping("/users/{userId}/my-info/approve")
+    public ResponseEntity<ApiResponse<String>> approveMyInfoUpdate(
+            @Parameter(description = "승인 대상 사용자 ID", required = true, example = "22") @PathVariable
+                    Long userId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        adminService.approveMyInfoUpdate(userId, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(userId + "번 사용자의 개인정보 수정 요청이 승인되었습니다."));
+    }
 
-        @Operation(summary = "내 정보 수정 요청 반려", description = "해당 사용자(userId)의 최신 PENDING 개인정보 수정 요청 1건을 반려합니다.")
-        @ApiResponses(value = {
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "반려 성공", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+    @Operation(
+            summary = "내 정보 수정 요청 반려",
+            description = "해당 사용자(userId)의 최신 PENDING 개인정보 수정 요청 1건을 반려합니다.")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "반려 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                         {
                                           "isSuccess": true,
                                           "code": "COMMON200",
@@ -566,7 +899,16 @@ public class AdminController {
                                           "result": "22번 사용자의 개인정보 수정 요청이 반려되었습니다."
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "400",
+                        description = "잘못된 요청",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                         {
                                           "isSuccess": false,
                                           "code": "MY_INFO_UPDATE_REJECT_REASON_REQUIRED",
@@ -574,7 +916,16 @@ public class AdminController {
                                           "result": null
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "403",
+                        description = "권한 없음",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                         {
                                           "isSuccess": false,
                                           "code": "NO_AUTHORITY_FOR_MY_INFO_UPDATE_APPROVAL",
@@ -582,8 +933,17 @@ public class AdminController {
                                           "result": null
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "요청 또는 사용자 없음", content = @Content(mediaType = "application/json", examples = {
-                                        @ExampleObject(name = "사용자 없음", value = """
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "404",
+                        description = "요청 또는 사용자 없음",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples = {
+                                            @ExampleObject(
+                                                    name = "사용자 없음",
+                                                    value =
+                                                            """
                                                         {
                                                           "isSuccess": false,
                                                           "code": "USER_NOT_FOUND",
@@ -591,7 +951,10 @@ public class AdminController {
                                                           "result": null
                                                         }
                                                         """),
-                                        @ExampleObject(name = "요청 없음", value = """
+                                            @ExampleObject(
+                                                    name = "요청 없음",
+                                                    value =
+                                                            """
                                                         {
                                                           "isSuccess": false,
                                                           "code": "MY_INFO_UPDATE_REQUEST_NOT_FOUND",
@@ -599,20 +962,33 @@ public class AdminController {
                                                           "result": null
                                                         }
                                                         """)
-                        }))
-        })
-        @PatchMapping("/users/{userId}/my-info/reject")
-        public ResponseEntity<ApiResponse<String>> rejectMyInfoUpdate(
-                        @Parameter(description = "반려 대상 사용자 ID", required = true, example = "22") @PathVariable Long userId,
-                        @Valid @RequestBody MyInfoUpdateRejectRequestDto requestDto,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-                adminService.rejectMyInfoUpdate(userId, requestDto.getReason(), userDetails.getId());
-                return ResponseEntity.ok(ApiResponse.onSuccess(userId + "번 사용자의 개인정보 수정 요청이 반려되었습니다."));
-        }
+                                        }))
+            })
+    @PatchMapping("/users/{userId}/my-info/reject")
+    public ResponseEntity<ApiResponse<String>> rejectMyInfoUpdate(
+            @Parameter(description = "반려 대상 사용자 ID", required = true, example = "22") @PathVariable
+                    Long userId,
+            @Valid @RequestBody MyInfoUpdateRejectRequestDto requestDto,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        adminService.rejectMyInfoUpdate(userId, requestDto.getReason(), userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(userId + "번 사용자의 개인정보 수정 요청이 반려되었습니다."));
+    }
 
-        @Operation(summary = "개인정보 수정 대기 요청 목록 조회", description = "승인 대기(PENDING) 개인정보 수정 요청 목록을 조회합니다.")
-        @ApiResponses(value = {
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+    @Operation(
+            summary = "개인정보 수정 대기 요청 목록 조회",
+            description = "승인 대기(PENDING) 개인정보 수정 요청 목록을 조회합니다.")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "조회 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                         {
                                           "isSuccess": true,
                                           "code": "COMMON200",
@@ -634,7 +1010,16 @@ public class AdminController {
                                           ]
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "403",
+                        description = "권한 없음",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                         {
                                           "isSuccess": false,
                                           "code": "NO_AUTHORITY_FOR_MY_INFO_UPDATE_APPROVAL",
@@ -642,12 +1027,14 @@ public class AdminController {
                                           "result": null
                                         }
                                         """)))
-        })
-        @GetMapping("/users/my-info/requests/pending")
-        public ResponseEntity<ApiResponse<List<MyInfoUpdateRequestSummaryResponseDto>>> getPendingMyInfoUpdateRequests(
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-                List<MyInfoUpdateRequestSummaryResponseDto> result = adminService
-                                .getPendingMyInfoUpdateRequests(userDetails.getId());
-                return ResponseEntity.ok(ApiResponse.onSuccess(result));
-        }
+            })
+    @GetMapping("/users/my-info/requests/pending")
+    public ResponseEntity<ApiResponse<List<MyInfoUpdateRequestSummaryResponseDto>>>
+            getPendingMyInfoUpdateRequests(
+                    @Parameter(hidden = true) @AuthenticationPrincipal
+                            CustomUserDetails userDetails) {
+        List<MyInfoUpdateRequestSummaryResponseDto> result =
+                adminService.getPendingMyInfoUpdateRequests(userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
+    }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/dto/request/UserApprovalRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/dto/request/UserApprovalRequestDto.java
@@ -65,7 +65,9 @@ public class UserApprovalRequestDto {
     @NotNull(message = "직무 유형은 필수 항목입니다.")
     private JobType jobType;
 
-    @ArraySchema(schema = @Schema(implementation = Authority.class), arraySchema = @Schema(description = "권한부여 목록 (반드시 배열 형태로 전달)"))
+    @ArraySchema(
+            schema = @Schema(implementation = Authority.class),
+            arraySchema = @Schema(description = "권한부여 목록 (반드시 배열 형태로 전달)"))
     private List<Authority> authorities;
 
     @Schema(description = "입사일", example = "2025-09-22")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
@@ -51,15 +51,17 @@ public class AdminService {
     public void approveUserRegistration(
             Long userId, UserApprovalRequestDto requestDto, Long adminId) {
         // 관리자 권한 확인
-        User admin = userRepository
-                .findById(adminId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User admin =
+                userRepository
+                        .findById(adminId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         validateRegistrationAuthority(admin);
 
         // userId로 PENDING 상태의 사용자를 조회
-        User user = userRepository
-                .findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         if (user.getStatus() != Status.PENDING) {
             throw new CustomException(ErrorCode.DUPLICATED_SIGNUP_REQUEST);
@@ -112,9 +114,10 @@ public class AdminService {
             }
         }
 
-        Department department = departmentRepository
-                .findByName(requestDto.getDepartmentName())
-                .orElseThrow(() -> new CustomException(ErrorCode.DEPARTMENT_NOT_FOUND));
+        Department department =
+                departmentRepository
+                        .findByName(requestDto.getDepartmentName())
+                        .orElseThrow(() -> new CustomException(ErrorCode.DEPARTMENT_NOT_FOUND));
 
         // DTO의 정보로 사용자 엔티티를 설정
         user.setWorkLocation(requestDto.getWorkLocation());
@@ -157,9 +160,10 @@ public class AdminService {
 
     @Transactional(readOnly = true)
     public List<PendingUserSummaryResponseDto> getPendingSignupUsers(Long adminId) {
-        User admin = userRepository
-                .findById(adminId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User admin =
+                userRepository
+                        .findById(adminId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         validateRegistrationAuthority(admin);
 
         return userRepository.findAllByStatusWithDepartment(Status.PENDING).stream()
@@ -176,15 +180,17 @@ public class AdminService {
             JobType jobType,
             Role role,
             Pageable pageable) {
-        User admin = userRepository
-                .findById(adminId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User admin =
+                userRepository
+                        .findById(adminId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         validateRegistrationAuthority(admin);
 
-        Set<Long> pendingMyInfoUserIds = myInfoUpdateRequestRepository
-                .findDistinctUserIdsByStatus(MyInfoUpdateRequestStatus.PENDING)
-                .stream()
-                .collect(Collectors.toSet());
+        Set<Long> pendingMyInfoUserIds =
+                myInfoUpdateRequestRepository
+                        .findDistinctUserIdsByStatus(MyInfoUpdateRequestStatus.PENDING)
+                        .stream()
+                        .collect(Collectors.toSet());
 
         String normalizedKeyword = hasText(keyword) ? keyword.trim() : null;
 
@@ -192,37 +198,43 @@ public class AdminService {
                 .findAllWithDepartmentAndKeyword(
                         normalizedKeyword, position, departmentId, jobType, role, pageable)
                 .map(
-                        u -> AdminUserSummaryResponseDto.from(
-                                u, pendingMyInfoUserIds.contains(u.getId())));
+                        u ->
+                                AdminUserSummaryResponseDto.from(
+                                        u, pendingMyInfoUserIds.contains(u.getId())));
     }
 
     @Transactional(readOnly = true)
     public AdminUserDetailResponseDto getUserDetail(Long adminId, Long userId) {
-        User admin = userRepository
-                .findById(adminId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User admin =
+                userRepository
+                        .findById(adminId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         validateRegistrationAuthority(admin);
 
-        User user = userRepository
-                .findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        boolean hasPendingMyInfoRequest = myInfoUpdateRequestRepository.existsByUserIdAndStatus(
-                userId, MyInfoUpdateRequestStatus.PENDING);
+        boolean hasPendingMyInfoRequest =
+                myInfoUpdateRequestRepository.existsByUserIdAndStatus(
+                        userId, MyInfoUpdateRequestStatus.PENDING);
 
         return AdminUserDetailResponseDto.from(user, hasPendingMyInfoRequest);
     }
 
     @Transactional
     public void updateUserInfo(Long userId, AdminUserUpdateRequestDto requestDto, Long adminId) {
-        User admin = userRepository
-                .findById(adminId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User admin =
+                userRepository
+                        .findById(adminId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         validateRegistrationAuthority(admin);
 
-        User user = userRepository
-                .findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         if (requestDto.getNameKor() != null) {
             user.setNameKor(requestDto.getNameKor());
@@ -275,9 +287,10 @@ public class AdminService {
             user.setWorkLocation(requestDto.getWorkLocation());
         }
         if (requestDto.getDepartmentId() != null) {
-            Department department = departmentRepository
-                    .findById(requestDto.getDepartmentId())
-                    .orElseThrow(() -> new CustomException(ErrorCode.DEPARTMENT_NOT_FOUND));
+            Department department =
+                    departmentRepository
+                            .findById(requestDto.getDepartmentId())
+                            .orElseThrow(() -> new CustomException(ErrorCode.DEPARTMENT_NOT_FOUND));
             user.setDepartment(department);
         }
         if (requestDto.getPosition() != null) {
@@ -314,17 +327,19 @@ public class AdminService {
     @Transactional
     public void updateUserRole(Long userId, Role role, Long adminId) {
 
-        User admin = userRepository
-                .findById(adminId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User admin =
+                userRepository
+                        .findById(adminId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         if (admin.getRole() != Role.ADMIN && admin.getRole() != Role.MASTER_ADMIN) {
             throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_ROLE_UPDATE);
         }
         // 1. 대상 사용자 조회
-        User targetUser = userRepository
-                .findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User targetUser =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // 2. 역할 업데이트
         targetUser.setRole(role);
@@ -343,18 +358,20 @@ public class AdminService {
     public void updateUserAuthority(
             Long userId, List<Authority> authorities, AuthorityAction action, Long adminId) {
         // 1. 관리자 권한 확인 (ADMIN 또는 MASTER_ADMIN만 가능)
-        User admin = userRepository
-                .findById(adminId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User admin =
+                userRepository
+                        .findById(adminId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         if (admin.getRole() != Role.ADMIN && admin.getRole() != Role.MASTER_ADMIN) {
             throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_ROLE_UPDATE);
         }
 
         // 2. 대상 사용자 조회
-        User targetUser = userRepository
-                .findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User targetUser =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // 3. 요청 유효성 검사
         if (authorities == null || authorities.isEmpty()) {
@@ -386,21 +403,25 @@ public class AdminService {
 
     @Transactional
     public void approveMyInfoUpdate(Long userId, Long adminId) {
-        User admin = userRepository
-                .findById(adminId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User admin =
+                userRepository
+                        .findById(adminId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         validateMyInfoApprovalAuthority(admin);
 
-        User targetUser = userRepository
-                .findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User targetUser =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        MyInfoUpdateRequest request = myInfoUpdateRequestRepository
-                .findFirstByUserIdAndStatusOrderByCreatedAtDesc(
-                        userId, MyInfoUpdateRequestStatus.PENDING)
-                .orElseThrow(
-                        () -> new CustomException(
-                                ErrorCode.MY_INFO_UPDATE_REQUEST_NOT_FOUND));
+        MyInfoUpdateRequest request =
+                myInfoUpdateRequestRepository
+                        .findFirstByUserIdAndStatusOrderByCreatedAtDesc(
+                                userId, MyInfoUpdateRequestStatus.PENDING)
+                        .orElseThrow(
+                                () ->
+                                        new CustomException(
+                                                ErrorCode.MY_INFO_UPDATE_REQUEST_NOT_FOUND));
 
         if (request.getRequestedNameEng() != null) {
             targetUser.setNameEng(request.getRequestedNameEng());
@@ -437,9 +458,10 @@ public class AdminService {
 
     @Transactional
     public void rejectMyInfoUpdate(Long userId, String reason, Long adminId) {
-        User admin = userRepository
-                .findById(adminId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User admin =
+                userRepository
+                        .findById(adminId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         validateMyInfoApprovalAuthority(admin);
 
         if (reason == null || reason.isBlank()) {
@@ -450,12 +472,14 @@ public class AdminService {
                 .findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        MyInfoUpdateRequest request = myInfoUpdateRequestRepository
-                .findFirstByUserIdAndStatusOrderByCreatedAtDesc(
-                        userId, MyInfoUpdateRequestStatus.PENDING)
-                .orElseThrow(
-                        () -> new CustomException(
-                                ErrorCode.MY_INFO_UPDATE_REQUEST_NOT_FOUND));
+        MyInfoUpdateRequest request =
+                myInfoUpdateRequestRepository
+                        .findFirstByUserIdAndStatusOrderByCreatedAtDesc(
+                                userId, MyInfoUpdateRequestStatus.PENDING)
+                        .orElseThrow(
+                                () ->
+                                        new CustomException(
+                                                ErrorCode.MY_INFO_UPDATE_REQUEST_NOT_FOUND));
 
         request.reject(admin, reason.trim());
         myInfoUpdateRequestRepository.save(request);
@@ -472,9 +496,10 @@ public class AdminService {
     @Transactional(readOnly = true)
     public List<MyInfoUpdateRequestSummaryResponseDto> getPendingMyInfoUpdateRequests(
             Long adminId) {
-        User admin = userRepository
-                .findById(adminId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User admin =
+                userRepository
+                        .findById(adminId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         validateMyInfoApprovalAuthority(admin);
 
         return myInfoUpdateRequestRepository

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/common/controller/CommonCodeController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/common/controller/CommonCodeController.java
@@ -3,13 +3,15 @@ package kr.co.awesomelead.groupware_backend.global.common.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
 import kr.co.awesomelead.groupware_backend.global.common.dto.response.EnumCodeDto;
 import kr.co.awesomelead.groupware_backend.global.common.response.ApiResponse;
 import kr.co.awesomelead.groupware_backend.global.common.service.CommonCodeService;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,9 +27,21 @@ public class CommonCodeController {
 
     private final CommonCodeService commonCodeService;
 
-    @Operation(summary = "부서 코드 목록 조회", description = "프론트엔드 드롭다운 등에 필요한 부서(DepartmentName) 코드 목록을 조회합니다.")
-    @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+    @Operation(
+            summary = "부서 코드 목록 조회",
+            description = "프론트엔드 드롭다운 등에 필요한 부서(DepartmentName) 코드 목록을 조회합니다.")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "조회 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                     {
                       "isSuccess": true,
                       "code": "COMMON200",
@@ -38,15 +52,25 @@ public class CommonCodeController {
                       ]
                     }
                     """)))
-    })
+            })
     @GetMapping("/departments")
     public ResponseEntity<ApiResponse<List<EnumCodeDto>>> getDepartments() {
         return ResponseEntity.ok(ApiResponse.onSuccess(commonCodeService.getDepartments()));
     }
 
     @Operation(summary = "직급 코드 목록 조회", description = "직급(Position) 코드 목록을 조회합니다.")
-    @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "조회 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                     {
                       "isSuccess": true,
                       "code": "COMMON200",
@@ -57,15 +81,25 @@ public class CommonCodeController {
                       ]
                     }
                     """)))
-    })
+            })
     @GetMapping("/positions")
     public ResponseEntity<ApiResponse<List<EnumCodeDto>>> getPositions() {
         return ResponseEntity.ok(ApiResponse.onSuccess(commonCodeService.getPositions()));
     }
 
     @Operation(summary = "근무 직종 코드 목록 조회", description = "근무 직종(JobType) 코드 목록을 조회합니다.")
-    @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "조회 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                     {
                       "isSuccess": true,
                       "code": "COMMON200",
@@ -76,7 +110,7 @@ public class CommonCodeController {
                       ]
                     }
                     """)))
-    })
+            })
     @GetMapping("/job-types")
     public ResponseEntity<ApiResponse<List<EnumCodeDto>>> getJobTypes() {
         return ResponseEntity.ok(ApiResponse.onSuccess(commonCodeService.getJobTypes()));

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/common/dto/response/EnumCodeDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/common/dto/response/EnumCodeDto.java
@@ -1,6 +1,7 @@
 package kr.co.awesomelead.groupware_backend.global.common.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,9 +22,6 @@ public class EnumCodeDto {
     private String description;
 
     public static EnumCodeDto of(String code, String description) {
-        return EnumCodeDto.builder()
-                .code(code)
-                .description(description)
-                .build();
+        return EnumCodeDto.builder().code(code).description(description).build();
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/common/service/CommonCodeService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/common/service/CommonCodeService.java
@@ -4,6 +4,7 @@ import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentNam
 import kr.co.awesomelead.groupware_backend.domain.user.enums.JobType;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
 import kr.co.awesomelead.groupware_backend.global.common.dto.response.EnumCodeDto;
+
 import org.springframework.stereotype.Service;
 
 import java.util.Arrays;
@@ -12,27 +13,21 @@ import java.util.List;
 @Service
 public class CommonCodeService {
 
-    /**
-     * 부서명 공통 코드 목록을 조회합니다.
-     */
+    /** 부서명 공통 코드 목록을 조회합니다. */
     public List<EnumCodeDto> getDepartments() {
         return Arrays.stream(DepartmentName.values())
                 .map(d -> EnumCodeDto.of(d.name(), d.getDescription()))
                 .toList();
     }
 
-    /**
-     * 직급 공통 코드 목록을 조회합니다.
-     */
+    /** 직급 공통 코드 목록을 조회합니다. */
     public List<EnumCodeDto> getPositions() {
         return Arrays.stream(Position.values())
                 .map(p -> EnumCodeDto.of(p.name(), p.getDescription()))
                 .toList();
     }
 
-    /**
-     * 직무/직종 공통 코드 목록을 조회합니다.
-     */
+    /** 직무/직종 공통 코드 목록을 조회합니다. */
     public List<EnumCodeDto> getJobTypes() {
         return Arrays.stream(JobType.values())
                 .map(j -> EnumCodeDto.of(j.name(), j.getDescription()))

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
@@ -55,119 +55,115 @@ import java.util.Optional;
 @DisplayName("AdminService 클래스의")
 class AdminServiceTest {
 
-        @Mock
-        private UserRepository userRepository;
-        @Mock
-        private DepartmentRepository departmentRepository;
-        @Mock
-        private MyInfoUpdateRequestRepository myInfoUpdateRequestRepository;
-        @Mock
-        private PhoneAuthService phoneAuthService;
-        @Mock
-        private NotificationService notificationService;
-        @InjectMocks
-        private AdminService adminService;
-        private final Long adminId = 100L;
-        private final Long userId = 1L;
-        private final UserApprovalRequestDto requestDto = createRequestDto();
+    @Mock private UserRepository userRepository;
+    @Mock private DepartmentRepository departmentRepository;
+    @Mock private MyInfoUpdateRequestRepository myInfoUpdateRequestRepository;
+    @Mock private PhoneAuthService phoneAuthService;
+    @Mock private NotificationService notificationService;
+    @InjectMocks private AdminService adminService;
+    private final Long adminId = 100L;
+    private final Long userId = 1L;
+    private final UserApprovalRequestDto requestDto = createRequestDto();
 
-        @BeforeEach
-        void setup() {
-                User admin = new User();
-                admin.setId(adminId);
-                admin.setRole(Role.ADMIN);
-                when(userRepository.findById(adminId)).thenReturn(Optional.of(admin));
+    @BeforeEach
+    void setup() {
+        User admin = new User();
+        admin.setId(adminId);
+        admin.setRole(Role.ADMIN);
+        when(userRepository.findById(adminId)).thenReturn(Optional.of(admin));
+    }
+
+    @Nested
+    @DisplayName("approveUserRegistration 메서드는")
+    class Describe_approveUserRegistration {
+
+        @Nested
+        @DisplayName("올바른 관리자가 대기 중인 사용자를 승인하면")
+        class Context_with_admin_user {
+
+            @Test
+            @DisplayName("사용자 상태를 AVAILABLE로 변경하고 정보를 업데이트한다")
+            void it_updates_user_info_and_status() {
+                // given
+                Department department =
+                        Department.builder().id(1L).name(DepartmentName.SALES_DEPT).build();
+                User pendingUser = new User();
+                pendingUser.setId(userId);
+                pendingUser.setStatus(Status.PENDING);
+
+                when(userRepository.findById(userId)).thenReturn(Optional.of(pendingUser));
+                when(departmentRepository.findByName(any())).thenReturn(Optional.of(department));
+
+                // when
+                adminService.approveUserRegistration(userId, requestDto, adminId);
+
+                // then
+                ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+                verify(userRepository).save(userCaptor.capture());
+                User savedUser = userCaptor.getValue();
+
+                assertThat(savedUser.getStatus()).isEqualTo(Status.AVAILABLE);
+                assertThat(savedUser.getRole()).isEqualTo(Role.USER);
+            }
         }
 
         @Nested
-        @DisplayName("approveUserRegistration 메서드는")
-        class Describe_approveUserRegistration {
+        @DisplayName("현장직에 대해 ADMIN 권한을 주려고 하면")
+        class Context_with_field_job_and_admin_role {
 
-                @Nested
-                @DisplayName("올바른 관리자가 대기 중인 사용자를 승인하면")
-                class Context_with_admin_user {
+            @Test
+            @DisplayName("INVALID_JOB_TYPE_FOR_ADMIN_ROLE 에러를 던진다")
+            void it_throws_invalid_job_type_for_admin_role_exception() {
+                // given
+                Department department =
+                        Department.builder().id(1L).name(DepartmentName.SALES_DEPT).build();
+                User pendingUser = new User();
+                pendingUser.setStatus(Status.PENDING);
 
-                        @Test
-                        @DisplayName("사용자 상태를 AVAILABLE로 변경하고 정보를 업데이트한다")
-                        void it_updates_user_info_and_status() {
-                                // given
-                                Department department = Department.builder().id(1L).name(DepartmentName.SALES_DEPT)
-                                                .build();
-                                User pendingUser = new User();
-                                pendingUser.setId(userId);
-                                pendingUser.setStatus(Status.PENDING);
+                when(userRepository.findById(userId)).thenReturn(Optional.of(pendingUser));
+                when(departmentRepository.findByName(any())).thenReturn(Optional.of(department));
 
-                                when(userRepository.findById(userId)).thenReturn(Optional.of(pendingUser));
-                                when(departmentRepository.findByName(any())).thenReturn(Optional.of(department));
+                UserApprovalRequestDto invalidRequestDto = createRequestDto();
+                invalidRequestDto.setJobType(JobType.FIELD);
+                invalidRequestDto.setRole(Role.ADMIN);
 
-                                // when
-                                adminService.approveUserRegistration(userId, requestDto, adminId);
+                // when & then
+                assertThatThrownBy(
+                                () ->
+                                        adminService.approveUserRegistration(
+                                                userId, invalidRequestDto, adminId))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode")
+                        .isEqualTo(ErrorCode.INVALID_JOB_TYPE_FOR_ADMIN_ROLE);
+            }
+        }
 
-                                // then
-                                ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
-                                verify(userRepository).save(userCaptor.capture());
-                                User savedUser = userCaptor.getValue();
+        @Nested
+        @DisplayName("이미 승인된 유저를 다시 승인하려 하면")
+        class Context_with_already_available_user {
 
-                                assertThat(savedUser.getStatus()).isEqualTo(Status.AVAILABLE);
-                                assertThat(savedUser.getRole()).isEqualTo(Role.USER);
-                        }
-                }
+            @Test
+            @DisplayName("DUPLICATED_SIGNUP_REQUEST 에러를 던진다")
+            void it_throws_duplicated_signup_request_exception() {
+                // given
+                User availableUser = new User();
+                availableUser.setStatus(Status.AVAILABLE);
+                when(userRepository.findById(userId)).thenReturn(Optional.of(availableUser));
 
-                @Nested
-                @DisplayName("현장직에 대해 ADMIN 권한을 주려고 하면")
-                class Context_with_field_job_and_admin_role {
+                // when & then
+                assertThatThrownBy(
+                                () ->
+                                        adminService.approveUserRegistration(
+                                                userId, requestDto, adminId))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode")
+                        .isEqualTo(ErrorCode.DUPLICATED_SIGNUP_REQUEST);
+            }
+        }
 
-                        @Test
-                        @DisplayName("INVALID_JOB_TYPE_FOR_ADMIN_ROLE 에러를 던진다")
-                        void it_throws_invalid_job_type_for_admin_role_exception() {
-                                // given
-                                Department department = Department.builder().id(1L).name(DepartmentName.SALES_DEPT)
-                                                .build();
-                                User pendingUser = new User();
-                                pendingUser.setStatus(Status.PENDING);
-
-                                when(userRepository.findById(userId)).thenReturn(Optional.of(pendingUser));
-                                when(departmentRepository.findByName(any())).thenReturn(Optional.of(department));
-
-                                UserApprovalRequestDto invalidRequestDto = createRequestDto();
-                                invalidRequestDto.setJobType(JobType.FIELD);
-                                invalidRequestDto.setRole(Role.ADMIN);
-
-                                // when & then
-                                assertThatThrownBy(
-                                                () -> adminService.approveUserRegistration(
-                                                                userId, invalidRequestDto, adminId))
-                                                .isInstanceOf(CustomException.class)
-                                                .extracting("errorCode")
-                                                .isEqualTo(ErrorCode.INVALID_JOB_TYPE_FOR_ADMIN_ROLE);
-                        }
-                }
-
-                @Nested
-                @DisplayName("이미 승인된 유저를 다시 승인하려 하면")
-                class Context_with_already_available_user {
-
-                        @Test
-                        @DisplayName("DUPLICATED_SIGNUP_REQUEST 에러를 던진다")
-                        void it_throws_duplicated_signup_request_exception() {
-                                // given
-                                User availableUser = new User();
-                                availableUser.setStatus(Status.AVAILABLE);
-                                when(userRepository.findById(userId)).thenReturn(Optional.of(availableUser));
-
-                                // when & then
-                                assertThatThrownBy(
-                                                () -> adminService.approveUserRegistration(
-                                                                userId, requestDto, adminId))
-                                                .isInstanceOf(CustomException.class)
-                                                .extracting("errorCode")
-                                                .isEqualTo(ErrorCode.DUPLICATED_SIGNUP_REQUEST);
-                        }
-                }
-
-                @Nested
-                @DisplayName("존재하지 않는 유저 ID를 승인하려 하면")
-                class Context_with_non_existent_user {
+        @Nested
+        @DisplayName("존재하지 않는 유저 ID를 승인하려 하면")
+        class Context_with_non_existent_user {
 
             @Test
             @DisplayName("USER_NOT_FOUND 에러를 던진다")
@@ -184,172 +180,178 @@ class AdminServiceTest {
                         .extracting("errorCode")
                         .isEqualTo(ErrorCode.USER_NOT_FOUND);
             }
-                }
-
-                @Nested
-                @DisplayName("관리자 권한이 없는 유저가 승인을 시도하면")
-                class Context_with_normal_user {
-
-                        @Test
-                        @DisplayName("NO_AUTHORITY_FOR_REGISTRATION 에러를 던진다")
-                        void it_throws_no_authority_exception() {
-                                // given
-                                User normalUser = new User();
-                                normalUser.setRole(Role.USER);
-                                when(userRepository.findById(adminId)).thenReturn(Optional.of(normalUser));
-
-                                // when & then
-                                assertThatThrownBy(
-                                                () -> adminService.approveUserRegistration(
-                                                                userId, requestDto, adminId))
-                                                .isInstanceOf(CustomException.class)
-                                                .extracting("errorCode")
-                                                .isEqualTo(ErrorCode.NO_AUTHORITY_FOR_REGISTRATION);
-                        }
-                }
         }
 
         @Nested
-        @DisplayName("getPendingSignupUsers 메서드는")
-        class Describe_getPendingSignupUsers {
+        @DisplayName("관리자 권한이 없는 유저가 승인을 시도하면")
+        class Context_with_normal_user {
 
-                @Test
-                @DisplayName("관리자가 조회하면 PENDING 사용자 목록을 반환한다")
-                void it_returns_pending_users() {
-                        // given
-                        Department department = Department.builder().id(1L).name(DepartmentName.MANAGEMENT_SUPPORT)
-                                        .build();
-                        User pendingUser = User.builder()
-                                        .id(21L)
-                                        .nameKor("홍길동")
-                                        .status(Status.PENDING)
-                                        .department(department)
-                                        .build();
-                        when(userRepository.findAllByStatusWithDepartment(Status.PENDING))
-                                        .thenReturn(List.of(pendingUser));
+            @Test
+            @DisplayName("NO_AUTHORITY_FOR_REGISTRATION 에러를 던진다")
+            void it_throws_no_authority_exception() {
+                // given
+                User normalUser = new User();
+                normalUser.setRole(Role.USER);
+                when(userRepository.findById(adminId)).thenReturn(Optional.of(normalUser));
 
-                        // when
-                        List<PendingUserSummaryResponseDto> result = adminService.getPendingSignupUsers(adminId);
+                // when & then
+                assertThatThrownBy(
+                                () ->
+                                        adminService.approveUserRegistration(
+                                                userId, requestDto, adminId))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode")
+                        .isEqualTo(ErrorCode.NO_AUTHORITY_FOR_REGISTRATION);
+            }
+        }
+    }
 
-                        // then
-                        assertThat(result.size()).isEqualTo(1);
-                        assertThat(result.get(0).getUserId()).isEqualTo(21L);
-                        assertThat(result.get(0).getNameKor()).isEqualTo("홍길동");
-                        assertThat(result.get(0).getDepartmentName())
-                                        .isEqualTo(DepartmentName.MANAGEMENT_SUPPORT);
-                        assertThat(result.get(0).getStatus()).isEqualTo(Status.PENDING);
-                }
+    @Nested
+    @DisplayName("getPendingSignupUsers 메서드는")
+    class Describe_getPendingSignupUsers {
 
-                @Test
-                @DisplayName("관리자 권한이 없는 사용자가 조회하면 NO_AUTHORITY_FOR_REGISTRATION 에러를 던진다")
-                void it_throws_when_requester_is_not_admin() {
-                        // given
-                        User normalUser = new User();
-                        normalUser.setRole(Role.USER);
-                        when(userRepository.findById(adminId)).thenReturn(Optional.of(normalUser));
+        @Test
+        @DisplayName("관리자가 조회하면 PENDING 사용자 목록을 반환한다")
+        void it_returns_pending_users() {
+            // given
+            Department department =
+                    Department.builder().id(1L).name(DepartmentName.MANAGEMENT_SUPPORT).build();
+            User pendingUser =
+                    User.builder()
+                            .id(21L)
+                            .nameKor("홍길동")
+                            .status(Status.PENDING)
+                            .department(department)
+                            .build();
+            when(userRepository.findAllByStatusWithDepartment(Status.PENDING))
+                    .thenReturn(List.of(pendingUser));
 
-                        // when & then
-                        assertThatThrownBy(() -> adminService.getPendingSignupUsers(adminId))
-                                        .isInstanceOf(CustomException.class)
-                                        .extracting("errorCode")
-                                        .isEqualTo(ErrorCode.NO_AUTHORITY_FOR_REGISTRATION);
-                }
+            // when
+            List<PendingUserSummaryResponseDto> result =
+                    adminService.getPendingSignupUsers(adminId);
+
+            // then
+            assertThat(result.size()).isEqualTo(1);
+            assertThat(result.get(0).getUserId()).isEqualTo(21L);
+            assertThat(result.get(0).getNameKor()).isEqualTo("홍길동");
+            assertThat(result.get(0).getDepartmentName())
+                    .isEqualTo(DepartmentName.MANAGEMENT_SUPPORT);
+            assertThat(result.get(0).getStatus()).isEqualTo(Status.PENDING);
         }
 
-        @Nested
-        @DisplayName("getUsers 메서드는")
-        class Describe_getUsers {
+        @Test
+        @DisplayName("관리자 권한이 없는 사용자가 조회하면 NO_AUTHORITY_FOR_REGISTRATION 에러를 던진다")
+        void it_throws_when_requester_is_not_admin() {
+            // given
+            User normalUser = new User();
+            normalUser.setRole(Role.USER);
+            when(userRepository.findById(adminId)).thenReturn(Optional.of(normalUser));
 
-                @Test
-                @DisplayName("관리자가 조회하면 직원 목록과 수정요청 뱃지 여부를 반환한다")
-                void it_returns_users_with_pending_my_info_badge() {
-                        // given
-                        Department department = Department.builder().id(1L).name(DepartmentName.MANAGEMENT_SUPPORT)
-                                        .build();
-                        User user = User.builder().id(17L).nameKor("고영민").department(department).build();
-                        user.setStatus(Status.AVAILABLE);
+            // when & then
+            assertThatThrownBy(() -> adminService.getPendingSignupUsers(adminId))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.NO_AUTHORITY_FOR_REGISTRATION);
+        }
+    }
 
-                        Pageable pageable = PageRequest.of(0, 20);
-                        Page<User> userPage = new PageImpl<>(List.of(user), pageable, 1);
-                        when(userRepository.findAllWithDepartmentAndKeyword(
-                                        "홍길동", Position.STAFF, 11L, JobType.MANAGEMENT, Role.USER, pageable))
-                                        .thenReturn(userPage);
-                        when(myInfoUpdateRequestRepository.findDistinctUserIdsByStatus(
-                                        MyInfoUpdateRequestStatus.PENDING))
-                                        .thenReturn(List.of(17L));
+    @Nested
+    @DisplayName("getUsers 메서드는")
+    class Describe_getUsers {
 
-                        // when
-                        Page<AdminUserSummaryResponseDto> result = adminService.getUsers(
-                                        adminId,
-                                        "홍길동",
-                                        Position.STAFF,
-                                        11L,
-                                        JobType.MANAGEMENT,
-                                        Role.USER,
-                                        pageable);
+        @Test
+        @DisplayName("관리자가 조회하면 직원 목록과 수정요청 뱃지 여부를 반환한다")
+        void it_returns_users_with_pending_my_info_badge() {
+            // given
+            Department department =
+                    Department.builder().id(1L).name(DepartmentName.MANAGEMENT_SUPPORT).build();
+            User user = User.builder().id(17L).nameKor("고영민").department(department).build();
+            user.setStatus(Status.AVAILABLE);
 
-                        // then
-                        assertThat(result.getTotalElements()).isEqualTo(1L);
-                        assertThat(result.getContent().get(0).getUserId()).isEqualTo(17L);
-                        assertThat(result.getContent().get(0).isHasPendingMyInfoRequest()).isEqualTo(true);
-                        assertThat(result.getContent().get(0).getSignupStatus()).isEqualTo(Status.AVAILABLE);
-                }
+            Pageable pageable = PageRequest.of(0, 20);
+            Page<User> userPage = new PageImpl<>(List.of(user), pageable, 1);
+            when(userRepository.findAllWithDepartmentAndKeyword(
+                            "홍길동", Position.STAFF, 11L, JobType.MANAGEMENT, Role.USER, pageable))
+                    .thenReturn(userPage);
+            when(myInfoUpdateRequestRepository.findDistinctUserIdsByStatus(
+                            MyInfoUpdateRequestStatus.PENDING))
+                    .thenReturn(List.of(17L));
 
-                @Test
-                @DisplayName("권한 없는 사용자가 조회하면 NO_AUTHORITY_FOR_REGISTRATION 에러를 던진다")
-                void it_throws_when_requester_is_not_admin() {
-                        // given
-                        User normalUser = new User();
-                        normalUser.setRole(Role.USER);
-                        when(userRepository.findById(adminId)).thenReturn(Optional.of(normalUser));
+            // when
+            Page<AdminUserSummaryResponseDto> result =
+                    adminService.getUsers(
+                            adminId,
+                            "홍길동",
+                            Position.STAFF,
+                            11L,
+                            JobType.MANAGEMENT,
+                            Role.USER,
+                            pageable);
 
-                        // when & then
-                        assertThatThrownBy(
-                                        () -> adminService.getUsers(
-                                                        adminId,
-                                                        null,
-                                                        null,
-                                                        null,
-                                                        null,
-                                                        null,
-                                                        PageRequest.of(0, 20)))
-                                        .isInstanceOf(CustomException.class)
-                                        .extracting("errorCode")
-                                        .isEqualTo(ErrorCode.NO_AUTHORITY_FOR_REGISTRATION);
-                }
+            // then
+            assertThat(result.getTotalElements()).isEqualTo(1L);
+            assertThat(result.getContent().get(0).getUserId()).isEqualTo(17L);
+            assertThat(result.getContent().get(0).isHasPendingMyInfoRequest()).isEqualTo(true);
+            assertThat(result.getContent().get(0).getSignupStatus()).isEqualTo(Status.AVAILABLE);
         }
 
-        @Nested
-        @DisplayName("getUserDetail 메서드는")
-        class Describe_getUserDetail {
+        @Test
+        @DisplayName("권한 없는 사용자가 조회하면 NO_AUTHORITY_FOR_REGISTRATION 에러를 던진다")
+        void it_throws_when_requester_is_not_admin() {
+            // given
+            User normalUser = new User();
+            normalUser.setRole(Role.USER);
+            when(userRepository.findById(adminId)).thenReturn(Optional.of(normalUser));
 
-                @Test
-                @DisplayName("관리자가 조회하면 사용자 상세를 반환한다")
-                void it_returns_user_detail() {
-                        // given
-                        Department department = Department.builder().id(11L).name(DepartmentName.MANAGEMENT_SUPPORT)
-                                        .build();
-                        User user = User.builder()
-                                        .id(17L)
-                                        .nameKor("고영민")
-                                        .department(department)
-                                        .role(Role.USER)
-                                        .build();
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    adminService.getUsers(
+                                            adminId,
+                                            null,
+                                            null,
+                                            null,
+                                            null,
+                                            null,
+                                            PageRequest.of(0, 20)))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.NO_AUTHORITY_FOR_REGISTRATION);
+        }
+    }
 
-                        when(userRepository.findById(17L)).thenReturn(Optional.of(user));
-                        when(myInfoUpdateRequestRepository.existsByUserIdAndStatus(
-                                        17L, MyInfoUpdateRequestStatus.PENDING))
-                                        .thenReturn(true);
+    @Nested
+    @DisplayName("getUserDetail 메서드는")
+    class Describe_getUserDetail {
 
-                        // when
-                        AdminUserDetailResponseDto result = adminService.getUserDetail(adminId, 17L);
+        @Test
+        @DisplayName("관리자가 조회하면 사용자 상세를 반환한다")
+        void it_returns_user_detail() {
+            // given
+            Department department =
+                    Department.builder().id(11L).name(DepartmentName.MANAGEMENT_SUPPORT).build();
+            User user =
+                    User.builder()
+                            .id(17L)
+                            .nameKor("고영민")
+                            .department(department)
+                            .role(Role.USER)
+                            .build();
 
-                        // then
-                        assertThat(result.getUserId()).isEqualTo(17L);
-                        assertThat(result.getDepartmentId()).isEqualTo(11L);
-                        assertThat(result.getDepartmentName()).isEqualTo(DepartmentName.MANAGEMENT_SUPPORT);
-                        assertThat(result.isHasPendingMyInfoRequest()).isEqualTo(true);
-                }
+            when(userRepository.findById(17L)).thenReturn(Optional.of(user));
+            when(myInfoUpdateRequestRepository.existsByUserIdAndStatus(
+                            17L, MyInfoUpdateRequestStatus.PENDING))
+                    .thenReturn(true);
+
+            // when
+            AdminUserDetailResponseDto result = adminService.getUserDetail(adminId, 17L);
+
+            // then
+            assertThat(result.getUserId()).isEqualTo(17L);
+            assertThat(result.getDepartmentId()).isEqualTo(11L);
+            assertThat(result.getDepartmentName()).isEqualTo(DepartmentName.MANAGEMENT_SUPPORT);
+            assertThat(result.isHasPendingMyInfoRequest()).isEqualTo(true);
+        }
 
         @Test
         @DisplayName("상세 조회 대상이 없으면 USER_NOT_FOUND 에러를 던진다")
@@ -364,142 +366,143 @@ class AdminServiceTest {
                     .isEqualTo(ErrorCode.USER_NOT_FOUND);
         }
 
-                @Test
-                @DisplayName("권한 없는 사용자가 조회하면 NO_AUTHORITY_FOR_REGISTRATION 에러를 던진다")
-                void it_throws_when_requester_is_not_admin() {
-                        // given
-                        User normalUser = new User();
-                        normalUser.setRole(Role.USER);
-                        when(userRepository.findById(adminId)).thenReturn(Optional.of(normalUser));
+        @Test
+        @DisplayName("권한 없는 사용자가 조회하면 NO_AUTHORITY_FOR_REGISTRATION 에러를 던진다")
+        void it_throws_when_requester_is_not_admin() {
+            // given
+            User normalUser = new User();
+            normalUser.setRole(Role.USER);
+            when(userRepository.findById(adminId)).thenReturn(Optional.of(normalUser));
 
-                        // when & then
-                        assertThatThrownBy(() -> adminService.getUserDetail(adminId, 17L))
-                                        .isInstanceOf(CustomException.class)
-                                        .extracting("errorCode")
-                                        .isEqualTo(ErrorCode.NO_AUTHORITY_FOR_REGISTRATION);
-                }
+            // when & then
+            assertThatThrownBy(() -> adminService.getUserDetail(adminId, 17L))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.NO_AUTHORITY_FOR_REGISTRATION);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateUserInfo 메서드는")
+    class Describe_updateUserInfo {
+
+        @Test
+        @DisplayName("관리자가 직원 정보를 수정하면 반영된다")
+        void it_updates_user_info_successfully() {
+            // given
+            User targetUser =
+                    User.builder().id(17L).nameKor("기존이름").phoneNumber("01011112222").build();
+            targetUser.setPhoneNumberHash(User.hashValue("01011112222"));
+            Department department =
+                    Department.builder().id(11L).name(DepartmentName.MANAGEMENT_SUPPORT).build();
+
+            when(userRepository.findById(17L)).thenReturn(Optional.of(targetUser));
+            when(departmentRepository.findById(11L)).thenReturn(Optional.of(department));
+            when(phoneAuthService.isPhoneVerified("01099998888")).thenReturn(true);
+            when(userRepository.existsByPhoneNumberHash(User.hashValue("01099998888")))
+                    .thenReturn(false);
+
+            AdminUserUpdateRequestDto dto = new AdminUserUpdateRequestDto();
+            dto.setNameKor("홍길동");
+            dto.setPhoneNumber("01099998888");
+            dto.setDepartmentId(11L);
+            dto.setWorkLocation(Company.AWESOME);
+            dto.setPosition(Position.STAFF);
+            dto.setJobType(JobType.MANAGEMENT);
+            dto.setRole(Role.USER);
+            dto.setAuthorities(List.of(Authority.ACCESS_MESSAGE));
+
+            // when
+            adminService.updateUserInfo(17L, dto, adminId);
+
+            // then
+            assertThat(targetUser.getNameKor()).isEqualTo("홍길동");
+            assertThat(targetUser.getPhoneNumber()).isEqualTo("01099998888");
+            assertThat(targetUser.getDepartment().getId()).isEqualTo(11L);
+            assertThat(targetUser.getWorkLocation()).isEqualTo(Company.AWESOME);
+            assertThat(targetUser.hasAuthority(Authority.ACCESS_MESSAGE)).isEqualTo(true);
+            verify(phoneAuthService).clearVerification("01099998888");
+            verify(userRepository).save(targetUser);
+        }
+
+        @Test
+        @DisplayName("전화번호 인증이 안된 상태로 번호를 바꾸면 PHONE_NOT_VERIFIED 에러를 던진다")
+        void it_throws_when_phone_not_verified() {
+            // given
+            User targetUser = User.builder().id(17L).phoneNumber("01011112222").build();
+            targetUser.setPhoneNumberHash(User.hashValue("01011112222"));
+            when(userRepository.findById(17L)).thenReturn(Optional.of(targetUser));
+            when(phoneAuthService.isPhoneVerified("01099998888")).thenReturn(false);
+
+            AdminUserUpdateRequestDto dto = new AdminUserUpdateRequestDto();
+            dto.setPhoneNumber("01099998888");
+
+            // when & then
+            assertThatThrownBy(() -> adminService.updateUserInfo(17L, dto, adminId))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.PHONE_NOT_VERIFIED);
+        }
+    }
+
+    private UserApprovalRequestDto createRequestDto() {
+        UserApprovalRequestDto dto = new UserApprovalRequestDto();
+        dto.setJobType(JobType.MANAGEMENT);
+        dto.setDepartmentName(DepartmentName.SALES_DEPT);
+        dto.setHireDate(LocalDate.now());
+        dto.setPosition(Position.STAFF);
+        return dto;
+    }
+
+    @Nested
+    @DisplayName("updateUserRole 메서드는")
+    class Describe_updateUserRole {
+
+        @Nested
+        @DisplayName("올바른 관리자가 사용자의 역할을 업데이트하면")
+        class Context_with_admin_user {
+
+            @Test
+            @DisplayName("사용자의 역할이 업데이트된다")
+            void it_updates_user_role_successfully() {
+                // given
+                User user = User.builder().id(1L).role(Role.USER).build();
+
+                when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+                // when
+                adminService.updateUserRole(1L, Role.ADMIN, 100L);
+
+                // then
+                assertThat(user.getRole()).isEqualTo(Role.ADMIN);
+                assertThat(user.hasAuthority(Authority.ACCESS_NOTICE)).isEqualTo(true);
+                assertThat(user.hasAuthority(Authority.MANAGE_EMPLOYEE_DATA)).isEqualTo(true);
+            }
         }
 
         @Nested
-        @DisplayName("updateUserInfo 메서드는")
-        class Describe_updateUserInfo {
+        @DisplayName("관리자 권한이 없는 유저가 역할 업데이트를 시도하면")
+        class Context_with_normal_user {
 
-                @Test
-                @DisplayName("관리자가 직원 정보를 수정하면 반영된다")
-                void it_updates_user_info_successfully() {
-                        // given
-                        User targetUser = User.builder().id(17L).nameKor("기존이름").phoneNumber("01011112222").build();
-                        targetUser.setPhoneNumberHash(User.hashValue("01011112222"));
-                        Department department = Department.builder().id(11L).name(DepartmentName.MANAGEMENT_SUPPORT)
-                                        .build();
+            @Test
+            @DisplayName("NO_AUTHORITY_FOR_ROLE_UPDATE 에러를 던진다")
+            void it_throws_no_authority_exception() {
+                // given
+                User normalUser = new User();
+                normalUser.setRole(Role.USER);
+                when(userRepository.findById(adminId)).thenReturn(Optional.of(normalUser));
 
-                        when(userRepository.findById(17L)).thenReturn(Optional.of(targetUser));
-                        when(departmentRepository.findById(11L)).thenReturn(Optional.of(department));
-                        when(phoneAuthService.isPhoneVerified("01099998888")).thenReturn(true);
-                        when(userRepository.existsByPhoneNumberHash(User.hashValue("01099998888")))
-                                        .thenReturn(false);
-
-                        AdminUserUpdateRequestDto dto = new AdminUserUpdateRequestDto();
-                        dto.setNameKor("홍길동");
-                        dto.setPhoneNumber("01099998888");
-                        dto.setDepartmentId(11L);
-                        dto.setWorkLocation(Company.AWESOME);
-                        dto.setPosition(Position.STAFF);
-                        dto.setJobType(JobType.MANAGEMENT);
-                        dto.setRole(Role.USER);
-                        dto.setAuthorities(List.of(Authority.ACCESS_MESSAGE));
-
-                        // when
-                        adminService.updateUserInfo(17L, dto, adminId);
-
-                        // then
-                        assertThat(targetUser.getNameKor()).isEqualTo("홍길동");
-                        assertThat(targetUser.getPhoneNumber()).isEqualTo("01099998888");
-                        assertThat(targetUser.getDepartment().getId()).isEqualTo(11L);
-                        assertThat(targetUser.getWorkLocation()).isEqualTo(Company.AWESOME);
-                        assertThat(targetUser.hasAuthority(Authority.ACCESS_MESSAGE)).isEqualTo(true);
-                        verify(phoneAuthService).clearVerification("01099998888");
-                        verify(userRepository).save(targetUser);
-                }
-
-                @Test
-                @DisplayName("전화번호 인증이 안된 상태로 번호를 바꾸면 PHONE_NOT_VERIFIED 에러를 던진다")
-                void it_throws_when_phone_not_verified() {
-                        // given
-                        User targetUser = User.builder().id(17L).phoneNumber("01011112222").build();
-                        targetUser.setPhoneNumberHash(User.hashValue("01011112222"));
-                        when(userRepository.findById(17L)).thenReturn(Optional.of(targetUser));
-                        when(phoneAuthService.isPhoneVerified("01099998888")).thenReturn(false);
-
-                        AdminUserUpdateRequestDto dto = new AdminUserUpdateRequestDto();
-                        dto.setPhoneNumber("01099998888");
-
-                        // when & then
-                        assertThatThrownBy(() -> adminService.updateUserInfo(17L, dto, adminId))
-                                        .isInstanceOf(CustomException.class)
-                                        .extracting("errorCode")
-                                        .isEqualTo(ErrorCode.PHONE_NOT_VERIFIED);
-                }
-        }
-
-        private UserApprovalRequestDto createRequestDto() {
-                UserApprovalRequestDto dto = new UserApprovalRequestDto();
-                dto.setJobType(JobType.MANAGEMENT);
-                dto.setDepartmentName(DepartmentName.SALES_DEPT);
-                dto.setHireDate(LocalDate.now());
-                dto.setPosition(Position.STAFF);
-                return dto;
+                // when & then
+                assertThatThrownBy(() -> adminService.updateUserRole(1L, Role.ADMIN, adminId))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode")
+                        .isEqualTo(ErrorCode.NO_AUTHORITY_FOR_ROLE_UPDATE);
+            }
         }
 
         @Nested
-        @DisplayName("updateUserRole 메서드는")
-        class Describe_updateUserRole {
-
-                @Nested
-                @DisplayName("올바른 관리자가 사용자의 역할을 업데이트하면")
-                class Context_with_admin_user {
-
-                        @Test
-                        @DisplayName("사용자의 역할이 업데이트된다")
-                        void it_updates_user_role_successfully() {
-                                // given
-                                User user = User.builder().id(1L).role(Role.USER).build();
-
-                                when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-
-                                // when
-                                adminService.updateUserRole(1L, Role.ADMIN, 100L);
-
-                                // then
-                                assertThat(user.getRole()).isEqualTo(Role.ADMIN);
-                                assertThat(user.hasAuthority(Authority.ACCESS_NOTICE)).isEqualTo(true);
-                                assertThat(user.hasAuthority(Authority.MANAGE_EMPLOYEE_DATA)).isEqualTo(true);
-                        }
-                }
-
-                @Nested
-                @DisplayName("관리자 권한이 없는 유저가 역할 업데이트를 시도하면")
-                class Context_with_normal_user {
-
-                        @Test
-                        @DisplayName("NO_AUTHORITY_FOR_ROLE_UPDATE 에러를 던진다")
-                        void it_throws_no_authority_exception() {
-                                // given
-                                User normalUser = new User();
-                                normalUser.setRole(Role.USER);
-                                when(userRepository.findById(adminId)).thenReturn(Optional.of(normalUser));
-
-                                // when & then
-                                assertThatThrownBy(() -> adminService.updateUserRole(1L, Role.ADMIN, adminId))
-                                                .isInstanceOf(CustomException.class)
-                                                .extracting("errorCode")
-                                                .isEqualTo(ErrorCode.NO_AUTHORITY_FOR_ROLE_UPDATE);
-                        }
-                }
-
-                @Nested
-                @DisplayName("존재하지 않는 유저 ID로 역할 업데이트를 시도하면")
-                class Context_with_non_existent_user {
+        @DisplayName("존재하지 않는 유저 ID로 역할 업데이트를 시도하면")
+        class Context_with_non_existent_user {
 
             @Test
             @DisplayName("USER_NOT_FOUND 에러를 던진다")
@@ -513,215 +516,224 @@ class AdminServiceTest {
                         .extracting("errorCode")
                         .isEqualTo(ErrorCode.USER_NOT_FOUND);
             }
-                }
+        }
+    }
+
+    @Nested
+    @DisplayName("updateUserAuthority 메서드는")
+    class Describe_updateUserAuthority {
+
+        @Test
+        @DisplayName("관리자가 여러 권한을 ADD 하면 모두 추가된다")
+        void it_adds_multiple_authorities() {
+            // given
+            User targetUser = User.builder().id(userId).role(Role.USER).build();
+            when(userRepository.findById(userId)).thenReturn(Optional.of(targetUser));
+
+            List<Authority> authorities = List.of(Authority.ACCESS_NOTICE, Authority.ACCESS_VISIT);
+
+            // when
+            adminService.updateUserAuthority(userId, authorities, AuthorityAction.ADD, adminId);
+
+            // then
+            assertThat(targetUser.hasAuthority(Authority.ACCESS_NOTICE)).isEqualTo(true);
+            assertThat(targetUser.hasAuthority(Authority.ACCESS_VISIT)).isEqualTo(true);
+            verify(userRepository).save(targetUser);
         }
 
-        @Nested
-        @DisplayName("updateUserAuthority 메서드는")
-        class Describe_updateUserAuthority {
+        @Test
+        @DisplayName("관리자가 여러 권한을 REMOVE 하면 모두 제거된다")
+        void it_removes_multiple_authorities() {
+            // given
+            User targetUser = User.builder().id(userId).role(Role.USER).build();
+            targetUser.addAuthority(Authority.ACCESS_NOTICE);
+            targetUser.addAuthority(Authority.ACCESS_VISIT);
+            when(userRepository.findById(userId)).thenReturn(Optional.of(targetUser));
 
-                @Test
-                @DisplayName("관리자가 여러 권한을 ADD 하면 모두 추가된다")
-                void it_adds_multiple_authorities() {
-                        // given
-                        User targetUser = User.builder().id(userId).role(Role.USER).build();
-                        when(userRepository.findById(userId)).thenReturn(Optional.of(targetUser));
+            List<Authority> authorities = List.of(Authority.ACCESS_NOTICE, Authority.ACCESS_VISIT);
 
-                        List<Authority> authorities = List.of(Authority.ACCESS_NOTICE, Authority.ACCESS_VISIT);
+            // when
+            adminService.updateUserAuthority(userId, authorities, AuthorityAction.REMOVE, adminId);
 
-                        // when
-                        adminService.updateUserAuthority(userId, authorities, AuthorityAction.ADD, adminId);
-
-                        // then
-                        assertThat(targetUser.hasAuthority(Authority.ACCESS_NOTICE)).isEqualTo(true);
-                        assertThat(targetUser.hasAuthority(Authority.ACCESS_VISIT)).isEqualTo(true);
-                        verify(userRepository).save(targetUser);
-                }
-
-                @Test
-                @DisplayName("관리자가 여러 권한을 REMOVE 하면 모두 제거된다")
-                void it_removes_multiple_authorities() {
-                        // given
-                        User targetUser = User.builder().id(userId).role(Role.USER).build();
-                        targetUser.addAuthority(Authority.ACCESS_NOTICE);
-                        targetUser.addAuthority(Authority.ACCESS_VISIT);
-                        when(userRepository.findById(userId)).thenReturn(Optional.of(targetUser));
-
-                        List<Authority> authorities = List.of(Authority.ACCESS_NOTICE, Authority.ACCESS_VISIT);
-
-                        // when
-                        adminService.updateUserAuthority(userId, authorities, AuthorityAction.REMOVE, adminId);
-
-                        // then
-                        assertThat(targetUser.hasAuthority(Authority.ACCESS_NOTICE)).isEqualTo(false);
-                        assertThat(targetUser.hasAuthority(Authority.ACCESS_VISIT)).isEqualTo(false);
-                        verify(userRepository).save(targetUser);
-                }
-
-                @Test
-                @DisplayName("이미 가진 권한을 ADD 하면 AUTHORITY_ALREADY_ASSIGNED 에러를 던진다")
-                void it_throws_when_adding_already_assigned_authority() {
-                        // given
-                        User targetUser = User.builder().id(userId).role(Role.USER).build();
-                        targetUser.addAuthority(Authority.ACCESS_NOTICE);
-                        when(userRepository.findById(userId)).thenReturn(Optional.of(targetUser));
-
-                        // when & then
-                        assertThatThrownBy(
-                                        () -> adminService.updateUserAuthority(
-                                                        userId,
-                                                        List.of(Authority.ACCESS_NOTICE),
-                                                        AuthorityAction.ADD,
-                                                        adminId))
-                                        .isInstanceOf(CustomException.class)
-                                        .extracting("errorCode")
-                                        .isEqualTo(ErrorCode.AUTHORITY_ALREADY_ASSIGNED);
-                }
-
-                @Test
-                @DisplayName("없는 권한을 REMOVE 하면 AUTHORITY_NOT_ASSIGNED 에러를 던진다")
-                void it_throws_when_removing_not_assigned_authority() {
-                        // given
-                        User targetUser = User.builder().id(userId).role(Role.USER).build();
-                        when(userRepository.findById(userId)).thenReturn(Optional.of(targetUser));
-
-                        // when & then
-                        assertThatThrownBy(
-                                        () -> adminService.updateUserAuthority(
-                                                        userId,
-                                                        List.of(Authority.ACCESS_NOTICE),
-                                                        AuthorityAction.REMOVE,
-                                                        adminId))
-                                        .isInstanceOf(CustomException.class)
-                                        .extracting("errorCode")
-                                        .isEqualTo(ErrorCode.AUTHORITY_NOT_ASSIGNED);
-                }
-
-                @Test
-                @DisplayName("권한 목록이 비어 있으면 INVALID_ARGUMENT 에러를 던진다")
-                void it_throws_when_authority_list_is_empty() {
-                        // given
-                        User targetUser = User.builder().id(userId).role(Role.USER).build();
-                        when(userRepository.findById(userId)).thenReturn(Optional.of(targetUser));
-
-                        // when & then
-                        assertThatThrownBy(
-                                        () -> adminService.updateUserAuthority(
-                                                        userId, List.of(), AuthorityAction.ADD, adminId))
-                                        .isInstanceOf(CustomException.class)
-                                        .extracting("errorCode")
-                                        .isEqualTo(ErrorCode.INVALID_ARGUMENT);
-                }
-
-                @Test
-                @DisplayName("관리자 권한이 없는 유저가 권한 수정을 시도하면 NO_AUTHORITY_FOR_ROLE_UPDATE 에러를 던진다")
-                void it_throws_when_requester_is_not_admin() {
-                        // given
-                        User normalUser = new User();
-                        normalUser.setRole(Role.USER);
-                        when(userRepository.findById(adminId)).thenReturn(Optional.of(normalUser));
-
-                        // when & then
-                        assertThatThrownBy(
-                                        () -> adminService.updateUserAuthority(
-                                                        userId,
-                                                        List.of(Authority.ACCESS_NOTICE),
-                                                        AuthorityAction.ADD,
-                                                        adminId))
-                                        .isInstanceOf(CustomException.class)
-                                        .extracting("errorCode")
-                                        .isEqualTo(ErrorCode.NO_AUTHORITY_FOR_ROLE_UPDATE);
-                }
+            // then
+            assertThat(targetUser.hasAuthority(Authority.ACCESS_NOTICE)).isEqualTo(false);
+            assertThat(targetUser.hasAuthority(Authority.ACCESS_VISIT)).isEqualTo(false);
+            verify(userRepository).save(targetUser);
         }
 
-        @Nested
-        @DisplayName("개인정보 수정 요청 승인/반려 메서드는")
-        class Describe_myInfoUpdateApproval {
+        @Test
+        @DisplayName("이미 가진 권한을 ADD 하면 AUTHORITY_ALREADY_ASSIGNED 에러를 던진다")
+        void it_throws_when_adding_already_assigned_authority() {
+            // given
+            User targetUser = User.builder().id(userId).role(Role.USER).build();
+            targetUser.addAuthority(Authority.ACCESS_NOTICE);
+            when(userRepository.findById(userId)).thenReturn(Optional.of(targetUser));
 
-                @Test
-                @DisplayName("관리자가 승인하면 요청 상태가 APPROVED로 바뀌고 사용자 정보가 반영된다")
-                void approveMyInfoUpdate_success() {
-                        // given
-                        User targetUser = User.builder().id(userId).nameEng("OLD").phoneNumber("01011112222").build();
-                        targetUser.setPhoneNumberHash(User.hashValue("01011112222"));
-                        MyInfoUpdateRequest request = MyInfoUpdateRequest.builder()
-                                        .id(10L)
-                                        .user(targetUser)
-                                        .requestedNameEng("NEW")
-                                        .requestedPhoneNumber("01099998888")
-                                        .requestedPhoneNumberHash(User.hashValue("01099998888"))
-                                        .status(MyInfoUpdateRequestStatus.PENDING)
-                                        .build();
-
-                        when(userRepository.findById(userId)).thenReturn(Optional.of(targetUser));
-                        when(myInfoUpdateRequestRepository.findFirstByUserIdAndStatusOrderByCreatedAtDesc(
-                                        userId, MyInfoUpdateRequestStatus.PENDING))
-                                        .thenReturn(Optional.of(request));
-                        when(userRepository.existsByPhoneNumberHash(User.hashValue("01099998888")))
-                                        .thenReturn(false);
-
-                        // when
-                        adminService.approveMyInfoUpdate(userId, adminId);
-
-                        // then
-                        assertThat(targetUser.getNameEng()).isEqualTo("NEW");
-                        assertThat(targetUser.getPhoneNumber()).isEqualTo("01099998888");
-                        assertThat(request.getStatus()).isEqualTo(MyInfoUpdateRequestStatus.APPROVED);
-                        verify(userRepository).save(targetUser);
-                        verify(myInfoUpdateRequestRepository).save(request);
-                        verify(notificationService).sendAlertToUser(any(), any(), any(), any());
-                }
-
-                @Test
-                @DisplayName("관리자가 반려하면 요청 상태가 REJECTED로 바뀐다")
-                void rejectMyInfoUpdate_success() {
-                        // given
-                        User targetUser = User.builder().id(userId).build();
-                        MyInfoUpdateRequest request = MyInfoUpdateRequest.builder()
-                                        .id(10L)
-                                        .user(targetUser)
-                                        .status(MyInfoUpdateRequestStatus.PENDING)
-                                        .build();
-
-                        when(userRepository.findById(userId)).thenReturn(Optional.of(targetUser));
-                        when(myInfoUpdateRequestRepository.findFirstByUserIdAndStatusOrderByCreatedAtDesc(
-                                        userId, MyInfoUpdateRequestStatus.PENDING))
-                                        .thenReturn(Optional.of(request));
-
-                        // when
-                        adminService.rejectMyInfoUpdate(userId, "증빙 불충분", adminId);
-
-                        // then
-                        assertThat(request.getStatus()).isEqualTo(MyInfoUpdateRequestStatus.REJECTED);
-                        assertThat(request.getRejectReason()).isEqualTo("증빙 불충분");
-                        verify(myInfoUpdateRequestRepository).save(request);
-                        verify(notificationService).sendAlertToUser(any(), any(), any(), any(), any());
-                }
-
-                @Test
-                @DisplayName("대기 요청 목록 조회 시 PENDING 요청 목록을 반환한다")
-                void getPendingMyInfoUpdateRequests_success() {
-                        // given
-                        User targetUser = User.builder().id(userId).nameKor("홍길동").email("hong@test.com").build();
-                        MyInfoUpdateRequest request = MyInfoUpdateRequest.builder()
-                                        .id(77L)
-                                        .user(targetUser)
-                                        .requestedNameEng("HONG")
-                                        .status(MyInfoUpdateRequestStatus.PENDING)
-                                        .build();
-                        when(myInfoUpdateRequestRepository.findAllByStatusWithUser(
-                                        MyInfoUpdateRequestStatus.PENDING))
-                                        .thenReturn(List.of(request));
-
-                        // when
-                        List<MyInfoUpdateRequestSummaryResponseDto> result = adminService
-                                        .getPendingMyInfoUpdateRequests(adminId);
-
-                        // then
-                        assertThat(result.size()).isEqualTo(1);
-                        assertThat(result.get(0).getRequestId()).isEqualTo(77L);
-                        assertThat(result.get(0).getUserId()).isEqualTo(userId);
-                        assertThat(result.get(0).getRequestedNameEng()).isEqualTo("HONG");
-                }
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    adminService.updateUserAuthority(
+                                            userId,
+                                            List.of(Authority.ACCESS_NOTICE),
+                                            AuthorityAction.ADD,
+                                            adminId))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.AUTHORITY_ALREADY_ASSIGNED);
         }
+
+        @Test
+        @DisplayName("없는 권한을 REMOVE 하면 AUTHORITY_NOT_ASSIGNED 에러를 던진다")
+        void it_throws_when_removing_not_assigned_authority() {
+            // given
+            User targetUser = User.builder().id(userId).role(Role.USER).build();
+            when(userRepository.findById(userId)).thenReturn(Optional.of(targetUser));
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    adminService.updateUserAuthority(
+                                            userId,
+                                            List.of(Authority.ACCESS_NOTICE),
+                                            AuthorityAction.REMOVE,
+                                            adminId))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.AUTHORITY_NOT_ASSIGNED);
+        }
+
+        @Test
+        @DisplayName("권한 목록이 비어 있으면 INVALID_ARGUMENT 에러를 던진다")
+        void it_throws_when_authority_list_is_empty() {
+            // given
+            User targetUser = User.builder().id(userId).role(Role.USER).build();
+            when(userRepository.findById(userId)).thenReturn(Optional.of(targetUser));
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    adminService.updateUserAuthority(
+                                            userId, List.of(), AuthorityAction.ADD, adminId))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.INVALID_ARGUMENT);
+        }
+
+        @Test
+        @DisplayName("관리자 권한이 없는 유저가 권한 수정을 시도하면 NO_AUTHORITY_FOR_ROLE_UPDATE 에러를 던진다")
+        void it_throws_when_requester_is_not_admin() {
+            // given
+            User normalUser = new User();
+            normalUser.setRole(Role.USER);
+            when(userRepository.findById(adminId)).thenReturn(Optional.of(normalUser));
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    adminService.updateUserAuthority(
+                                            userId,
+                                            List.of(Authority.ACCESS_NOTICE),
+                                            AuthorityAction.ADD,
+                                            adminId))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.NO_AUTHORITY_FOR_ROLE_UPDATE);
+        }
+    }
+
+    @Nested
+    @DisplayName("개인정보 수정 요청 승인/반려 메서드는")
+    class Describe_myInfoUpdateApproval {
+
+        @Test
+        @DisplayName("관리자가 승인하면 요청 상태가 APPROVED로 바뀌고 사용자 정보가 반영된다")
+        void approveMyInfoUpdate_success() {
+            // given
+            User targetUser =
+                    User.builder().id(userId).nameEng("OLD").phoneNumber("01011112222").build();
+            targetUser.setPhoneNumberHash(User.hashValue("01011112222"));
+            MyInfoUpdateRequest request =
+                    MyInfoUpdateRequest.builder()
+                            .id(10L)
+                            .user(targetUser)
+                            .requestedNameEng("NEW")
+                            .requestedPhoneNumber("01099998888")
+                            .requestedPhoneNumberHash(User.hashValue("01099998888"))
+                            .status(MyInfoUpdateRequestStatus.PENDING)
+                            .build();
+
+            when(userRepository.findById(userId)).thenReturn(Optional.of(targetUser));
+            when(myInfoUpdateRequestRepository.findFirstByUserIdAndStatusOrderByCreatedAtDesc(
+                            userId, MyInfoUpdateRequestStatus.PENDING))
+                    .thenReturn(Optional.of(request));
+            when(userRepository.existsByPhoneNumberHash(User.hashValue("01099998888")))
+                    .thenReturn(false);
+
+            // when
+            adminService.approveMyInfoUpdate(userId, adminId);
+
+            // then
+            assertThat(targetUser.getNameEng()).isEqualTo("NEW");
+            assertThat(targetUser.getPhoneNumber()).isEqualTo("01099998888");
+            assertThat(request.getStatus()).isEqualTo(MyInfoUpdateRequestStatus.APPROVED);
+            verify(userRepository).save(targetUser);
+            verify(myInfoUpdateRequestRepository).save(request);
+            verify(notificationService).sendAlertToUser(any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("관리자가 반려하면 요청 상태가 REJECTED로 바뀐다")
+        void rejectMyInfoUpdate_success() {
+            // given
+            User targetUser = User.builder().id(userId).build();
+            MyInfoUpdateRequest request =
+                    MyInfoUpdateRequest.builder()
+                            .id(10L)
+                            .user(targetUser)
+                            .status(MyInfoUpdateRequestStatus.PENDING)
+                            .build();
+
+            when(userRepository.findById(userId)).thenReturn(Optional.of(targetUser));
+            when(myInfoUpdateRequestRepository.findFirstByUserIdAndStatusOrderByCreatedAtDesc(
+                            userId, MyInfoUpdateRequestStatus.PENDING))
+                    .thenReturn(Optional.of(request));
+
+            // when
+            adminService.rejectMyInfoUpdate(userId, "증빙 불충분", adminId);
+
+            // then
+            assertThat(request.getStatus()).isEqualTo(MyInfoUpdateRequestStatus.REJECTED);
+            assertThat(request.getRejectReason()).isEqualTo("증빙 불충분");
+            verify(myInfoUpdateRequestRepository).save(request);
+            verify(notificationService).sendAlertToUser(any(), any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("대기 요청 목록 조회 시 PENDING 요청 목록을 반환한다")
+        void getPendingMyInfoUpdateRequests_success() {
+            // given
+            User targetUser =
+                    User.builder().id(userId).nameKor("홍길동").email("hong@test.com").build();
+            MyInfoUpdateRequest request =
+                    MyInfoUpdateRequest.builder()
+                            .id(77L)
+                            .user(targetUser)
+                            .requestedNameEng("HONG")
+                            .status(MyInfoUpdateRequestStatus.PENDING)
+                            .build();
+            when(myInfoUpdateRequestRepository.findAllByStatusWithUser(
+                            MyInfoUpdateRequestStatus.PENDING))
+                    .thenReturn(List.of(request));
+
+            // when
+            List<MyInfoUpdateRequestSummaryResponseDto> result =
+                    adminService.getPendingMyInfoUpdateRequests(adminId);
+
+            // then
+            assertThat(result.size()).isEqualTo(1);
+            assertThat(result.get(0).getRequestId()).isEqualTo(77L);
+            assertThat(result.get(0).getUserId()).isEqualTo(userId);
+            assertThat(result.get(0).getRequestedNameEng()).isEqualTo("HONG");
+        }
+    }
 }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/global/common/service/CommonCodeServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/global/common/service/CommonCodeServiceTest.java
@@ -1,56 +1,57 @@
 package kr.co.awesomelead.groupware_backend.global.common.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.JobType;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
 import kr.co.awesomelead.groupware_backend.global.common.dto.response.EnumCodeDto;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 class CommonCodeServiceTest {
 
-        private final CommonCodeService commonCodeService = new CommonCodeService();
+    private final CommonCodeService commonCodeService = new CommonCodeService();
 
-        @Test
-        @DisplayName("부서 공통 코드 목록이 정상 조회된다")
-        void getDepartments_ReturnsDepartments() {
-                // given & when
-                List<EnumCodeDto> departments = commonCodeService.getDepartments();
+    @Test
+    @DisplayName("부서 공통 코드 목록이 정상 조회된다")
+    void getDepartments_ReturnsDepartments() {
+        // given & when
+        List<EnumCodeDto> departments = commonCodeService.getDepartments();
 
-                // then
-                assertThat(departments).hasSize(DepartmentName.values().length);
-                assertThat(departments)
-                                .extracting(EnumCodeDto::getCode)
-                                .contains(DepartmentName.CHUNGNAM_HQ.name(), DepartmentName.PRODUCTION.name());
-        }
+        // then
+        assertThat(departments).hasSize(DepartmentName.values().length);
+        assertThat(departments)
+                .extracting(EnumCodeDto::getCode)
+                .contains(DepartmentName.CHUNGNAM_HQ.name(), DepartmentName.PRODUCTION.name());
+    }
 
-        @Test
-        @DisplayName("직급 공통 코드 목록이 정상 조회된다")
-        void getPositions_ReturnsPositions() {
-                // given & when
-                List<EnumCodeDto> positions = commonCodeService.getPositions();
+    @Test
+    @DisplayName("직급 공통 코드 목록이 정상 조회된다")
+    void getPositions_ReturnsPositions() {
+        // given & when
+        List<EnumCodeDto> positions = commonCodeService.getPositions();
 
-                // then
-                assertThat(positions).hasSize(Position.values().length);
-                assertThat(positions)
-                                .extracting(EnumCodeDto::getCode)
-                                .contains(Position.CEO.name(), Position.STAFF.name());
-        }
+        // then
+        assertThat(positions).hasSize(Position.values().length);
+        assertThat(positions)
+                .extracting(EnumCodeDto::getCode)
+                .contains(Position.CEO.name(), Position.STAFF.name());
+    }
 
-        @Test
-        @DisplayName("직무 공통 코드 목록이 정상 조회된다")
-        void getJobTypes_ReturnsJobTypes() {
-                // given & when
-                List<EnumCodeDto> jobTypes = commonCodeService.getJobTypes();
+    @Test
+    @DisplayName("직무 공통 코드 목록이 정상 조회된다")
+    void getJobTypes_ReturnsJobTypes() {
+        // given & when
+        List<EnumCodeDto> jobTypes = commonCodeService.getJobTypes();
 
-                // then
-                assertThat(jobTypes).hasSize(JobType.values().length);
-                assertThat(jobTypes)
-                                .extracting(EnumCodeDto::getCode)
-                                .contains(JobType.FIELD.name(), JobType.MANAGEMENT.name());
-        }
+        // then
+        assertThat(jobTypes).hasSize(JobType.values().length);
+        assertThat(jobTypes)
+                .extracting(EnumCodeDto::getCode)
+                .contains(JobType.FIELD.name(), JobType.MANAGEMENT.name());
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #148

## 📝작업 내용
- 프론트엔드 폼 구성 편의를 위한 공통 시스템 코드(부서, 직급, 직종) 통합 조회 API 구현 및 개별 엔드포인트(`/api/common/codes/{type}`) 분리
- `UserApprovalRequestDto` 내 부서 ID(`departmentId`)를 부서명 Enum(`departmentName`)으로 리팩터링
- `AdminService`: 부서 조회 시 ID 기반 조회에서 부서명 Enum 기반 조회(`departmentRepository.findByName`)로 변경
- `AdminController`: Swagger 예시값 현행화

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함 (`CommonCodeServiceTest`, `AdminServiceTest`)
- [x] 테스트를 수행함 (모두 통과)
- [x] API 응답 스펙 및 Swagger 정합성 수동 검증 완료
