### PR TITLE
feat(150): ApprovalQueryRepository N+1 최적화 및 조회 인덱스 적용

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/entity/Approval.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/entity/Approval.java
@@ -20,9 +20,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
+
 import kr.co.awesomelead.groupware_backend.domain.approval.enums.ApprovalStatus;
 import kr.co.awesomelead.groupware_backend.domain.approval.enums.DocumentType;
 import kr.co.awesomelead.groupware_backend.domain.approval.enums.RetentionPeriod;
@@ -31,11 +29,17 @@ import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.global.common.entity.BaseTimeEntity;
 import kr.co.awesomelead.groupware_backend.global.error.CustomException;
 import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
 import org.hibernate.annotations.BatchSize;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 
 @Entity
 @Getter
@@ -44,10 +48,12 @@ import org.hibernate.annotations.BatchSize;
 @DiscriminatorColumn(name = "document_type") // 문서 구분 컬럼
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "approvals", indexes = {
-    @Index(name = "idx_approval_created_at", columnList = "created_at"),
-    @Index(name = "idx_approval_drafter_status", columnList = "drafter_id, status")
-})
+@Table(
+        name = "approvals",
+        indexes = {
+            @Index(name = "idx_approval_created_at", columnList = "created_at"),
+            @Index(name = "idx_approval_drafter_status", columnList = "drafter_id, status")
+        })
 public abstract class Approval extends BaseTimeEntity {
 
     @Id
@@ -66,8 +72,8 @@ public abstract class Approval extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(
-        nullable = false,
-        columnDefinition = "ENUM('WAITING','PENDING','APPROVED','REJECTED','CANCELED')")
+            nullable = false,
+            columnDefinition = "ENUM('WAITING','PENDING','APPROVED','REJECTED','CANCELED')")
     private ApprovalStatus status; // 상태: PENDING, APPROVED, REJECTED 등
 
     @Enumerated(EnumType.STRING)
@@ -116,8 +122,8 @@ public abstract class Approval extends BaseTimeEntity {
         activateNextStep(myStep.getSequence());
 
         // 모든 step이 APPROVED이면 문서 전체 승인 처리
-        boolean allApproved = steps.stream()
-            .allMatch(s -> s.getStatus() == ApprovalStatus.APPROVED);
+        boolean allApproved =
+                steps.stream().allMatch(s -> s.getStatus() == ApprovalStatus.APPROVED);
         if (allApproved) {
             this.status = ApprovalStatus.APPROVED;
         }
@@ -134,9 +140,9 @@ public abstract class Approval extends BaseTimeEntity {
 
     private ApprovalStep findMyStep(User approver) {
         return steps.stream()
-            .filter(s -> s.getApprover().getId().equals(approver.getId()))
-            .findFirst()
-            .orElseThrow(() -> new CustomException(ErrorCode.NOT_APPROVER));
+                .filter(s -> s.getApprover().getId().equals(approver.getId()))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_APPROVER));
     }
 
     private void validateStepPending(ApprovalStep step) {
@@ -147,10 +153,10 @@ public abstract class Approval extends BaseTimeEntity {
 
     private void validateMyTurn(ApprovalStep myStep) {
         ApprovalStep currentStep =
-            steps.stream()
-                .filter(s -> s.getStatus() == ApprovalStatus.PENDING)
-                .min(Comparator.comparingInt(ApprovalStep::getSequence))
-                .orElseThrow(() -> new CustomException(ErrorCode.ALREADY_PROCESSED_STEP));
+                steps.stream()
+                        .filter(s -> s.getStatus() == ApprovalStatus.PENDING)
+                        .min(Comparator.comparingInt(ApprovalStep::getSequence))
+                        .orElseThrow(() -> new CustomException(ErrorCode.ALREADY_PROCESSED_STEP));
 
         if (!currentStep.getId().equals(myStep.getId())) {
             throw new CustomException(ErrorCode.NOT_YOUR_TURN);
@@ -159,22 +165,22 @@ public abstract class Approval extends BaseTimeEntity {
 
     private void activateNextStep(int approvedSequence) {
         steps.stream()
-            .filter(
-                s ->
-                    s.getSequence() > approvedSequence
-                        && s.getStatus() == ApprovalStatus.WAITING)
-            .min(Comparator.comparingInt(ApprovalStep::getSequence))
-            .ifPresent(next -> next.setStatus(ApprovalStatus.PENDING));
+                .filter(
+                        s ->
+                                s.getSequence() > approvedSequence
+                                        && s.getStatus() == ApprovalStatus.WAITING)
+                .min(Comparator.comparingInt(ApprovalStep::getSequence))
+                .ifPresent(next -> next.setStatus(ApprovalStatus.PENDING));
     }
 
     public ApprovalStatus getDisplayStatus(Long viewerId) {
         if (this.status == ApprovalStatus.PENDING) {
             boolean isMyTurn =
-                this.steps.stream()
-                    .anyMatch(
-                        s ->
-                            s.getApprover().getId().equals(viewerId)
-                                && s.getStatus() == ApprovalStatus.PENDING);
+                    this.steps.stream()
+                            .anyMatch(
+                                    s ->
+                                            s.getApprover().getId().equals(viewerId)
+                                                    && s.getStatus() == ApprovalStatus.PENDING);
             if (!isMyTurn) {
                 return ApprovalStatus.IN_PROGRESS;
             }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/repository/querydsl/ApprovalQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/repository/querydsl/ApprovalQueryRepository.java
@@ -5,9 +5,7 @@ import static kr.co.awesomelead.groupware_backend.domain.approval.entity.QApprov
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
+
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalListRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalSummaryResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.entity.Approval;
@@ -23,12 +21,18 @@ import kr.co.awesomelead.groupware_backend.domain.approval.enums.DocumentType;
 import kr.co.awesomelead.groupware_backend.domain.approval.enums.ParticipantType;
 import kr.co.awesomelead.groupware_backend.domain.approval.mapper.ApprovalMapper;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -38,7 +42,7 @@ public class ApprovalQueryRepository {
     private final ApprovalMapper approvalMapper;
 
     public Page<ApprovalSummaryResponseDto> findApprovalsByCondition(
-        ApprovalListRequestDto condition, Long userId, String userRole) {
+            ApprovalListRequestDto condition, Long userId, String userRole) {
         Pageable pageable = PageRequest.of(condition.getPage(), condition.getSize());
 
         // 1. 카테고리별 기본 조회 조건 (ALL, IN_PROGRESS, REFERENCE, DRAFT)
@@ -48,42 +52,43 @@ public class ApprovalQueryRepository {
         BooleanExpression docTypeExpression = eqDocumentType(condition.getDocumentType());
 
         // 3. 메인 쿼리 작성 (N+1 최적화를 위해 페이징에서는 ToOne만 fetchJoin, 컬렉션은 BatchSize)
-        JPAQuery<Approval> query = queryFactory
-            .selectFrom(approval)
-            .join(approval.drafter).fetchJoin()
-            .join(approval.draftDepartment).fetchJoin()
-            .where(categoryExpression, docTypeExpression)
-            .orderBy(approval.createdAt.desc())
-            .distinct();
+        JPAQuery<Approval> query =
+                queryFactory
+                        .selectFrom(approval)
+                        .join(approval.drafter)
+                        .fetchJoin()
+                        .join(approval.draftDepartment)
+                        .fetchJoin()
+                        .where(categoryExpression, docTypeExpression)
+                        .orderBy(approval.createdAt.desc())
+                        .distinct();
 
         // 4. 페이징 적용된 엔티티 조회
         List<Approval> approvals =
-            query.offset(pageable.getOffset()).limit(pageable.getPageSize()).fetch();
+                query.offset(pageable.getOffset()).limit(pageable.getPageSize()).fetch();
 
         // 5. 전체 카운트 조회
         long totalCount =
-            Optional.ofNullable(
-                    queryFactory
-                        .select(approval.countDistinct())
-                        .from(approval)
-                        .where(categoryExpression, docTypeExpression)
-                        .fetchOne())
-                .orElse(0L);
+                Optional.ofNullable(
+                                queryFactory
+                                        .select(approval.countDistinct())
+                                        .from(approval)
+                                        .where(categoryExpression, docTypeExpression)
+                                        .fetchOne())
+                        .orElse(0L);
 
         // 6. DTO 변환
         return new PageImpl<>(
-            approvals.stream()
-                .map(approval -> approvalMapper.toSummaryResponseDto(approval, userId))
-                .collect(Collectors.toList()),
-            pageable,
-            totalCount == 0L ? 0 : totalCount);
+                approvals.stream()
+                        .map(approval -> approvalMapper.toSummaryResponseDto(approval, userId))
+                        .collect(Collectors.toList()),
+                pageable,
+                totalCount == 0L ? 0 : totalCount);
     }
 
-    /**
-     * 카테고리(ALL, IN_PROGRESS, REFERENCE, DRAFT) 및 Status 하위 필터에 따른 동적 쿼리 조합
-     */
+    /** 카테고리(ALL, IN_PROGRESS, REFERENCE, DRAFT) 및 Status 하위 필터에 따른 동적 쿼리 조합 */
     private BooleanExpression getCategoryExpression(
-        ApprovalListRequestDto condition, Long userId, String userRole) {
+            ApprovalListRequestDto condition, Long userId, String userRole) {
         ApprovalCategory category = condition.getCategory();
         if (category == null) {
             return null;
@@ -93,29 +98,26 @@ public class ApprovalQueryRepository {
             case ALL -> getAllCategoryExpression(userId, userRole);
             case IN_PROGRESS -> getInProgressCategoryExpression(condition.getStatus(), userId);
             case REFERENCE -> getReferenceCategoryExpression(
-                condition.getStatus(), condition.getParticipantType(), userId);
+                    condition.getStatus(), condition.getParticipantType(), userId);
             case DRAFT -> getDraftCategoryExpression(condition.getStatus(), userId);
         };
     }
 
-    /**
-     * 1. ALL (전체) 카테고리 조건 - ADMIN/MASTER_ADMIN 이면 모든 문서 조회 - USER 이면 (결재진행 + 참조 + 내작성) 전체 합집합
-     */
+    /** 1. ALL (전체) 카테고리 조건 - ADMIN/MASTER_ADMIN 이면 모든 문서 조회 - USER 이면 (결재진행 + 참조 + 내작성) 전체 합집합 */
     private BooleanExpression getAllCategoryExpression(Long userId, String userRole) {
         if (Role.ADMIN.name().equals(userRole) || Role.MASTER_ADMIN.name().equals(userRole)) {
             return null; // 조건 없이 전체 풀 스캔
         }
 
         // 일반 유저인 경우 연관된 모든 문서 (기안자이거나, 결재선에 포함되거나, 참조자에 포함됨)
-        return approval.drafter.id
-            .eq(userId) // 내 작성
-            .or(approval.steps.any().approver.id.eq(userId)) // 결재 진행 연관
-            .or(approval.participants.any().user.id.eq(userId)); // 참조/열람 연관
+        return approval.drafter
+                .id
+                .eq(userId) // 내 작성
+                .or(approval.steps.any().approver.id.eq(userId)) // 결재 진행 연관
+                .or(approval.participants.any().user.id.eq(userId)); // 참조/열람 연관
     }
 
-    /**
-     * 2. IN_PROGRESS (결재 진행) 카테고리 조건
-     */
+    /** 2. IN_PROGRESS (결재 진행) 카테고리 조건 */
     private BooleanExpression getInProgressCategoryExpression(ApprovalStatus status, Long userId) {
         // 기본적으로 내가 결재선에 포함되어 있어야 함
         BooleanExpression baseCondition = approval.steps.any().approver.id.eq(userId);
@@ -126,51 +128,63 @@ public class ApprovalQueryRepository {
 
         return switch (status) {
             case WAITING -> baseCondition.and(
-                approval.steps
-                    .any().approver.id
-                    .eq(userId)
-                    .and(approval.steps.any().status.eq(ApprovalStatus.PENDING))); // 내 차례
+                    approval.steps
+                            .any()
+                            .approver
+                            .id
+                            .eq(userId)
+                            .and(approval.steps.any().status.eq(ApprovalStatus.PENDING))); // 내 차례
             case APPROVED -> baseCondition.and(
-                approval.steps
-                    .any().approver.id
-                    .eq(userId)
-                    .and(
-                        approval.steps
-                            .any().status
-                            .eq(ApprovalStatus.APPROVED))); // 내가 기결함
+                    approval.steps
+                            .any()
+                            .approver
+                            .id
+                            .eq(userId)
+                            .and(
+                                    approval.steps
+                                            .any()
+                                            .status
+                                            .eq(ApprovalStatus.APPROVED))); // 내가 기결함
             case REJECTED -> baseCondition.and(
-                // 내 단계가 반려거나, 혹은 다른 단계에서 반려/회수되어 문서가 결국 반려/취소 상태인 경우
-                approval.steps
-                    .any().approver.id
-                    .eq(userId)
-                    .and(approval.steps.any().status.eq(ApprovalStatus.REJECTED))
-                    .or(
-                        approval.status.in(
-                            ApprovalStatus.REJECTED, ApprovalStatus.CANCELED)));
+                    // 내 단계가 반려거나, 혹은 다른 단계에서 반려/회수되어 문서가 결국 반려/취소 상태인 경우
+                    approval.steps
+                            .any()
+                            .approver
+                            .id
+                            .eq(userId)
+                            .and(approval.steps.any().status.eq(ApprovalStatus.REJECTED))
+                            .or(
+                                    approval.status.in(
+                                            ApprovalStatus.REJECTED, ApprovalStatus.CANCELED)));
             default -> baseCondition;
         };
     }
 
-    /**
-     * 3. REFERENCE (참조 문서) 카테고리 조건
-     */
+    /** 3. REFERENCE (참조 문서) 카테고리 조건 */
     private BooleanExpression getReferenceCategoryExpression(
-        ApprovalStatus status, ParticipantType participantType, Long userId) {
+            ApprovalStatus status, ParticipantType participantType, Long userId) {
         // 1. 참조자(REFERRER)인 경우: 상신 직후부터 전체 노출
-        BooleanExpression isReferrer = approval.participants
-            .any().user.id
-            .eq(userId)
-            .and(
+        BooleanExpression isReferrer =
                 approval.participants
-                    .any().participantType
-                    .eq(ParticipantType.REFERRER));
+                        .any()
+                        .user
+                        .id
+                        .eq(userId)
+                        .and(
+                                approval.participants
+                                        .any()
+                                        .participantType
+                                        .eq(ParticipantType.REFERRER));
 
         // 2. 열람권자(VIEWER)인 경우: 최종 승인(APPROVED)된 문서만 노출
-        BooleanExpression isViewerAndApproved = approval.participants
-            .any().user.id
-            .eq(userId)
-            .and(approval.participants.any().participantType.eq(ParticipantType.VIEWER))
-            .and(approval.status.eq(ApprovalStatus.APPROVED));
+        BooleanExpression isViewerAndApproved =
+                approval.participants
+                        .any()
+                        .user
+                        .id
+                        .eq(userId)
+                        .and(approval.participants.any().participantType.eq(ParticipantType.VIEWER))
+                        .and(approval.status.eq(ApprovalStatus.APPROVED));
 
         // ROLE(ParticipantType) 필터가 명시된 경우 해당 역할만 필터링
         if (participantType == ParticipantType.REFERRER) {
@@ -191,9 +205,7 @@ public class ApprovalQueryRepository {
         return baseCondition;
     }
 
-    /**
-     * 4. DRAFT (내 작성) 카테고리 조건
-     */
+    /** 4. DRAFT (내 작성) 카테고리 조건 */
     private BooleanExpression getDraftCategoryExpression(ApprovalStatus status, Long userId) {
         BooleanExpression baseCondition = approval.drafter.id.eq(userId);
 
@@ -204,16 +216,14 @@ public class ApprovalQueryRepository {
         // 내 작성 문서에서의 상태 필터링
         return switch (status) {
             case WAITING, PENDING, IN_PROGRESS -> baseCondition.and(
-                approval.status.in(ApprovalStatus.WAITING, ApprovalStatus.PENDING));
+                    approval.status.in(ApprovalStatus.WAITING, ApprovalStatus.PENDING));
             case APPROVED -> baseCondition.and(approval.status.eq(ApprovalStatus.APPROVED));
             case REJECTED, CANCELED -> baseCondition.and(
-                approval.status.in(ApprovalStatus.REJECTED, ApprovalStatus.CANCELED));
+                    approval.status.in(ApprovalStatus.REJECTED, ApprovalStatus.CANCELED));
         };
     }
 
-    /**
-     * 서식(문서 종류) 서브 필터
-     */
+    /** 서식(문서 종류) 서브 필터 */
     private BooleanExpression eqDocumentType(DocumentType documentType) {
         if (documentType == null) {
             return null;


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #150

## 📝작업 내용
- `ApprovalQueryRepository`에서 결재 목록 조회 시 발생하는 N+1 쿼리 이슈 탐지 및 개선 (ToOne 관계 `Fetch Join`, 컬렉션 `@BatchSize` 기반)
- `Approval` 엔티티 `steps`, `participants`, `attachments` 요소에 `@BatchSize(size = 100)` 추가 적용
- `ApprovalQueryRepository.findApprovalsByCondition` 메인 쿼리에 `.join(approval.drafter).fetchJoin()` 및 `.join(approval.draftDepartment).fetchJoin()` 추가
- `Approval` 엔티티 및 MySQL `approvals` 테이블에 조회 병목 방지를 위한 `idx_approval_created_at`, `idx_approval_drafter_status` DB 인덱스 설계 및 추가

## 📸 스크린샷 (선택)
- X

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항
- X