### PR TITLE
fix: 한비로 SSO create_token 호출을 실제 동작(session_id=gw_id) 기준으로 수정

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/integration/hanbiro/service/HanbiroSsoService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/integration/hanbiro/service/HanbiroSsoService.java
@@ -101,9 +101,7 @@ public class HanbiroSsoService {
         if (!Boolean.TRUE.equals(createTokenResponse.getSuccess())
                 || createTokenResponse.getRedirectUri() == null
                 || createTokenResponse.getRedirectUri().isBlank()) {
-            log.warn(
-                    "Hanbiro create_token 1차 실패(gw_id), msg={}",
-                    createTokenResponse.getMsg());
+            log.warn("Hanbiro create_token 1차 실패(gw_id), msg={}", createTokenResponse.getMsg());
 
             createTokenResponse = callCreateToken(authResponse.getSession());
             if (!Boolean.TRUE.equals(createTokenResponse.getSuccess())


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #166 

## 📝작업 내용
- 한비로 SSO create_token 호출을 실제 동작(session_id=gw_id) 기준으로 수정햤습니다.

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [ ] 테스트를 수행함

## 💬리뷰 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?