### PR TITLE
fix(197): /api/users/list 인증 없이 접근 가능하도록 permitAll 추가

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/config/SecurityConfig.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/config/SecurityConfig.java
@@ -101,7 +101,8 @@ public class SecurityConfig {
                                         "/api/test/**",
                                         "/api/departments/hierarchy",
                                         "/api/departments/{departmentId}/users",
-                                        "/api/visits/**") // 내방객이 본인 방문기록 조회
+                                        "/api/visits/**", // 내방객이 본인 방문기록 조회
+                                        "/api/users/list") // 유저 목록 공개 조회
                                 .permitAll()
                                 .requestMatchers(
                                         "/api/auth/logout",


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #197

## 📝작업 내용

- `SecurityConfig.java`의 `permitAll()` 목록에 `/api/users/list` 추가
    - 기존에는 `anyRequest().authenticated()`에 걸려 JWT 토큰 없이 401 반환
    - 내방객 및 관리직 전용 직원 목록 조회 API를 인증 없이 접근 가능하도록 변경

## 📸 스크린샷 (선택)

## 🧪 테스트 여부

- [ ] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)

- `/api/users/list`를 공개 엔드포인트로 전환하는 것이 보안상 의도된 변경임을 확인 부탁드립니다.