### PR TITLE
fix(204): DEPARTMENT 교육 목록 조회 시 빈 목록 반환 버그 수정

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
@@ -2,6 +2,7 @@ package kr.co.awesomelead.groupware_backend.domain.education.repository;
 
 import static kr.co.awesomelead.groupware_backend.domain.education.entity.QEduAttendance.eduAttendance;
 import static kr.co.awesomelead.groupware_backend.domain.education.entity.QEduReport.eduReport;
+import static kr.co.awesomelead.groupware_backend.domain.education.entity.QEducationCategory.educationCategory;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -52,9 +53,10 @@ public class EduReportQueryRepository {
                                         .exists(),
                                 eduReport.pinned,
                                 eduReport.signatureRequired,
-                                eduReport.category.id,
-                                eduReport.category.name))
+                                educationCategory.id,
+                                educationCategory.name))
                 .from(eduReport)
+                .leftJoin(eduReport.category, educationCategory)
                 .where(eqEduType(type), eqCategoryId(categoryId), deptFilter(type, hasAccess, dept))
                 .orderBy(eduReport.pinned.desc(), eduReport.eduDate.desc())
                 .fetch();
@@ -68,7 +70,7 @@ public class EduReportQueryRepository {
     }
 
     private BooleanExpression eqCategoryId(Long categoryId) {
-        return categoryId != null ? eduReport.category.id.eq(categoryId) : null;
+        return categoryId != null ? educationCategory.id.eq(categoryId) : null;
     }
 
     /**


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #204

## 📝작업 내용

- `GET /api/edu-reports?type=DEPARTMENT` 요청 시 DB에 데이터가 존재함에도 빈 목록이 반환되는 버그 수정
    - `EduReportQueryRepository.findEduReports()`의 SELECT 절에서 `eduReport.category.id`, `eduReport.category.name`를 명시적 JOIN 없이 참조하여 QueryDSL이 묵시적 INNER JOIN을 생성
    - `DEPARTMENT` 교육은 `category_id = NULL`이므로 INNER JOIN 결과에서 전부 제외됨
    - `.leftJoin(eduReport.category, educationCategory)` 명시적 추가로 수정
- SELECT 절 및 `eqCategoryId()` 내 경로를 `eduReport.category.*` → `educationCategory.*` (조인 별칭)로 변경
- `QEducationCategory`, `QEduReport` QClass를 `src/main/generated/`에 추가/갱신

## 📸 스크린샷 (선택)

## 🧪 테스트 여부

- [ ] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)

- X