### PR TITLE
fix(251): 알림 시스템 고도화 및 내 정보 수정 API 개편

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
@@ -801,7 +801,7 @@ public class AdminController {
 
     @Operation(
             summary = "내 정보 수정 요청 승인",
-            description = "해당 사용자(userId)의 최신 PENDING 개인정보 수정 요청 1건을 승인하고 실제 사용자 정보에 반영합니다.")
+            description = "requestId(MyInfoUpdateRequest PK)로 해당 PENDING 개인정보 수정 요청을 승인하고 실제 사용자 정보에 반영합니다.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -818,7 +818,7 @@ public class AdminController {
                                           "isSuccess": true,
                                           "code": "COMMON200",
                                           "message": "요청에 성공했습니다.",
-                                          "result": "22번 사용자의 개인정보 수정 요청이 승인되었습니다."
+                                          "result": "개인정보 수정 요청이 승인되었습니다."
                                         }
                                         """))),
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -840,47 +840,35 @@ public class AdminController {
                                         """))),
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
                         responseCode = "404",
-                        description = "요청 또는 사용자 없음",
+                        description = "요청 없음",
                         content =
                                 @Content(
                                         mediaType = "application/json",
-                                        examples = {
-                                            @ExampleObject(
-                                                    name = "사용자 없음",
-                                                    value =
-                                                            """
-                                                        {
-                                                          "isSuccess": false,
-                                                          "code": "USER_NOT_FOUND",
-                                                          "message": "해당 사용자를 찾을 수 없습니다.",
-                                                          "result": null
-                                                        }
-                                                        """),
-                                            @ExampleObject(
-                                                    name = "요청 없음",
-                                                    value =
-                                                            """
-                                                        {
-                                                          "isSuccess": false,
-                                                          "code": "MY_INFO_UPDATE_REQUEST_NOT_FOUND",
-                                                          "message": "해당 개인정보 수정 요청을 찾을 수 없습니다.",
-                                                          "result": null
-                                                        }
-                                                        """)
-                                        }))
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
+                                        {
+                                          "isSuccess": false,
+                                          "code": "MY_INFO_UPDATE_REQUEST_NOT_FOUND",
+                                          "message": "해당 개인정보 수정 요청을 찾을 수 없습니다.",
+                                          "result": null
+                                        }
+                                        """)))
             })
-    @PatchMapping("/users/{userId}/my-info/approve")
+    @PatchMapping("/my-info/requests/{requestId}/approve")
     public ResponseEntity<ApiResponse<String>> approveMyInfoUpdate(
-            @Parameter(description = "승인 대상 사용자 ID", required = true, example = "22") @PathVariable
-                    Long userId,
+            @Parameter(description = "승인할 내 정보 수정 요청 ID", required = true, example = "10")
+                    @PathVariable
+                    Long requestId,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-        adminService.approveMyInfoUpdate(userId, userDetails.getId());
-        return ResponseEntity.ok(ApiResponse.onSuccess(userId + "번 사용자의 개인정보 수정 요청이 승인되었습니다."));
+        adminService.approveMyInfoUpdate(requestId, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess("개인정보 수정 요청이 승인되었습니다."));
     }
 
     @Operation(
             summary = "내 정보 수정 요청 반려",
-            description = "해당 사용자(userId)의 최신 PENDING 개인정보 수정 요청 1건을 반려합니다.")
+            description = "requestId(MyInfoUpdateRequest PK)로 해당 PENDING 개인정보 수정 요청을 반려합니다.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -897,7 +885,7 @@ public class AdminController {
                                           "isSuccess": true,
                                           "code": "COMMON200",
                                           "message": "요청에 성공했습니다.",
-                                          "result": "22번 사용자의 개인정보 수정 요청이 반려되었습니다."
+                                          "result": "개인정보 수정 요청이 반려되었습니다."
                                         }
                                         """))),
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -936,43 +924,31 @@ public class AdminController {
                                         """))),
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
                         responseCode = "404",
-                        description = "요청 또는 사용자 없음",
+                        description = "요청 없음",
                         content =
                                 @Content(
                                         mediaType = "application/json",
-                                        examples = {
-                                            @ExampleObject(
-                                                    name = "사용자 없음",
-                                                    value =
-                                                            """
-                                                        {
-                                                          "isSuccess": false,
-                                                          "code": "USER_NOT_FOUND",
-                                                          "message": "해당 사용자를 찾을 수 없습니다.",
-                                                          "result": null
-                                                        }
-                                                        """),
-                                            @ExampleObject(
-                                                    name = "요청 없음",
-                                                    value =
-                                                            """
-                                                        {
-                                                          "isSuccess": false,
-                                                          "code": "MY_INFO_UPDATE_REQUEST_NOT_FOUND",
-                                                          "message": "해당 개인정보 수정 요청을 찾을 수 없습니다.",
-                                                          "result": null
-                                                        }
-                                                        """)
-                                        }))
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
+                                        {
+                                          "isSuccess": false,
+                                          "code": "MY_INFO_UPDATE_REQUEST_NOT_FOUND",
+                                          "message": "해당 개인정보 수정 요청을 찾을 수 없습니다.",
+                                          "result": null
+                                        }
+                                        """)))
             })
-    @PatchMapping("/users/{userId}/my-info/reject")
+    @PatchMapping("/my-info/requests/{requestId}/reject")
     public ResponseEntity<ApiResponse<String>> rejectMyInfoUpdate(
-            @Parameter(description = "반려 대상 사용자 ID", required = true, example = "22") @PathVariable
-                    Long userId,
+            @Parameter(description = "반려할 내 정보 수정 요청 ID", required = true, example = "10")
+                    @PathVariable
+                    Long requestId,
             @Valid @RequestBody MyInfoUpdateRejectRequestDto requestDto,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-        adminService.rejectMyInfoUpdate(userId, requestDto.getReason(), userDetails.getId());
-        return ResponseEntity.ok(ApiResponse.onSuccess(userId + "번 사용자의 개인정보 수정 요청이 반려되었습니다."));
+        adminService.rejectMyInfoUpdate(requestId, requestDto.getReason(), userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess("개인정보 수정 요청이 반려되었습니다."));
     }
 
     @Operation(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
@@ -801,7 +801,9 @@ public class AdminController {
 
     @Operation(
             summary = "내 정보 수정 요청 승인",
-            description = "requestId(MyInfoUpdateRequest PK)로 해당 PENDING 개인정보 수정 요청을 승인하고 실제 사용자 정보에 반영합니다.")
+            description =
+                    "requestId(MyInfoUpdateRequest PK)로 해당 PENDING 개인정보 수정 요청을 승인하고 실제 사용자 정보에"
+                        + " 반영합니다.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
@@ -451,6 +451,10 @@ public class AdminService {
         userRepository.save(targetUser);
         myInfoUpdateRequestRepository.save(request);
 
+        // 관리자들의 승인 대기 알림 해제
+        notificationService.resolveRequiresApproval(
+                NotificationDomainType.MY_INFO_UPDATE, request.getId());
+
         // 요청 승인 알림 전송 (FCM + Notification DB)
         notificationService.sendAlertToUser(
                 targetUser.getId(),
@@ -486,6 +490,10 @@ public class AdminService {
 
         request.reject(admin, reason.trim());
         myInfoUpdateRequestRepository.save(request);
+
+        // 관리자들의 승인 대기 알림 해제
+        notificationService.resolveRequiresApproval(
+                NotificationDomainType.MY_INFO_UPDATE, request.getId());
 
         // 요청 반려 알림 전송 (FCM + Notification DB)
         notificationService.sendAlertToUser(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
@@ -405,26 +405,26 @@ public class AdminService {
     }
 
     @Transactional
-    public void approveMyInfoUpdate(Long userId, Long adminId) {
+    public void approveMyInfoUpdate(Long requestId, Long adminId) {
         User admin =
                 userRepository
                         .findById(adminId)
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         validateMyInfoApprovalAuthority(admin);
 
-        User targetUser =
-                userRepository
-                        .findById(userId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
         MyInfoUpdateRequest request =
                 myInfoUpdateRequestRepository
-                        .findFirstByUserIdAndStatusOrderByCreatedAtDesc(
-                                userId, MyInfoUpdateRequestStatus.PENDING)
+                        .findById(requestId)
                         .orElseThrow(
                                 () ->
                                         new CustomException(
                                                 ErrorCode.MY_INFO_UPDATE_REQUEST_NOT_FOUND));
+
+        if (request.getStatus() != MyInfoUpdateRequestStatus.PENDING) {
+            throw new CustomException(ErrorCode.MY_INFO_UPDATE_REQUEST_NOT_FOUND);
+        }
+
+        User targetUser = request.getUser();
 
         if (request.getRequestedNameEng() != null) {
             targetUser.setNameEng(request.getRequestedNameEng());
@@ -453,7 +453,7 @@ public class AdminService {
 
         // 요청 승인 알림 전송 (FCM + Notification DB)
         notificationService.sendAlertToUser(
-                userId,
+                targetUser.getId(),
                 NotificationMessage.MY_INFO_UPDATE_APPROVED,
                 NotificationDomainType.MY_INFO_UPDATE,
                 request.getId(),
@@ -461,7 +461,7 @@ public class AdminService {
     }
 
     @Transactional
-    public void rejectMyInfoUpdate(Long userId, String reason, Long adminId) {
+    public void rejectMyInfoUpdate(Long requestId, String reason, Long adminId) {
         User admin =
                 userRepository
                         .findById(adminId)
@@ -472,25 +472,24 @@ public class AdminService {
             throw new CustomException(ErrorCode.MY_INFO_UPDATE_REJECT_REASON_REQUIRED);
         }
 
-        userRepository
-                .findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
         MyInfoUpdateRequest request =
                 myInfoUpdateRequestRepository
-                        .findFirstByUserIdAndStatusOrderByCreatedAtDesc(
-                                userId, MyInfoUpdateRequestStatus.PENDING)
+                        .findById(requestId)
                         .orElseThrow(
                                 () ->
                                         new CustomException(
                                                 ErrorCode.MY_INFO_UPDATE_REQUEST_NOT_FOUND));
+
+        if (request.getStatus() != MyInfoUpdateRequestStatus.PENDING) {
+            throw new CustomException(ErrorCode.MY_INFO_UPDATE_REQUEST_NOT_FOUND);
+        }
 
         request.reject(admin, reason.trim());
         myInfoUpdateRequestRepository.save(request);
 
         // 요청 반려 알림 전송 (FCM + Notification DB)
         notificationService.sendAlertToUser(
-                userId,
+                request.getUser().getId(),
                 NotificationMessage.MY_INFO_UPDATE_REJECTED,
                 NotificationDomainType.MY_INFO_UPDATE,
                 request.getId(),

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
@@ -36,6 +36,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -455,7 +456,8 @@ public class AdminService {
                 userId,
                 NotificationMessage.MY_INFO_UPDATE_APPROVED,
                 NotificationDomainType.MY_INFO_UPDATE,
-                request.getId());
+                request.getId(),
+                Map.of("requestId", request.getId()));
     }
 
     @Transactional
@@ -492,6 +494,7 @@ public class AdminService {
                 NotificationMessage.MY_INFO_UPDATE_REJECTED,
                 NotificationDomainType.MY_INFO_UPDATE,
                 request.getId(),
+                Map.of("requestId", request.getId()),
                 reason.trim());
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalService.java
@@ -19,6 +19,7 @@ import kr.co.awesomelead.groupware_backend.domain.approval.enums.ParticipantType
 import kr.co.awesomelead.groupware_backend.domain.approval.mapper.ApprovalMapper;
 import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalAttachmentRepository;
 import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalRepository;
+import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationDomainType;
 import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
@@ -227,6 +228,9 @@ public class ApprovalService {
 
         approval.approve(approver, comment);
 
+        // 현재 결재자의 승인 대기 알림 해제
+        notificationService.resolveRequiresApproval(NotificationDomainType.APPROVAL, approvalId);
+
         // 승인 후 상태에 따라 알림 분기
         boolean allApproved =
                 approval.getSteps().stream()
@@ -280,6 +284,9 @@ public class ApprovalService {
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         approval.reject(approver, comment);
+
+        // 현재 결재자의 승인 대기 알림 해제
+        notificationService.resolveRequiresApproval(NotificationDomainType.APPROVAL, approvalId);
 
         // 기안자에게 반려 알림
         try {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
@@ -51,6 +51,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -119,6 +120,7 @@ public class AuthService {
                 NotificationMessage.SIGNUP_ADMIN_ALERT,
                 NotificationDomainType.AUTH,
                 null,
+                Map.of("targetId", savedUser.getId()),
                 savedUser.getDisplayName());
 
         return new SignupResponseDto(savedUser.getId(), savedUser.getEmail());

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -132,8 +132,10 @@ public class EduReportService {
         Map<String, Object> metadata =
                 requestDto.getEduType() == EduType.SAFETY
                         ? Map.of(
-                                "educationType", requestDto.getEduType().name(),
-                                "detailType", "GENERAL")
+                                "educationType",
+                                requestDto.getEduType().name(),
+                                "detailType",
+                                "GENERAL")
                         : Map.of("educationType", requestDto.getEduType().name());
         notificationService.sendEduReportAlertToTargets(
                 requestDto.getEduType().getDescription(),

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -39,6 +39,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -128,11 +129,18 @@ public class EduReportService {
         } else {
             targetUserIds = userRepository.findAllIdsByDepartmentId(requestDto.getDepartmentId());
         }
+        Map<String, Object> metadata =
+                requestDto.getEduType() == EduType.SAFETY
+                        ? Map.of(
+                                "educationType", requestDto.getEduType().name(),
+                                "detailType", "GENERAL")
+                        : Map.of("educationType", requestDto.getEduType().name());
         notificationService.sendEduReportAlertToTargets(
                 requestDto.getEduType().getDescription(),
                 requestDto.getTitle(),
                 savedReport.getId(),
-                targetUserIds);
+                targetUserIds,
+                metadata);
 
         return savedReport.getId();
     }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/controller/NotificationController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/controller/NotificationController.java
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
@@ -63,11 +64,13 @@ public class NotificationController {
     @GetMapping
     public ResponseEntity<ApiResponse<Page<NotificationResponseDto>>> getNotifications(
             @RequestHeader("Authorization") String authorizationHeader,
+            @RequestParam(required = false, defaultValue = "false") boolean pendingApproval,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
                     Pageable pageable) {
         Long userId = extractUserId(authorizationHeader);
         return ResponseEntity.ok(
-                ApiResponse.onSuccess(notificationService.getNotifications(userId, pageable)));
+                ApiResponse.onSuccess(
+                        notificationService.getNotifications(userId, pendingApproval, pageable)));
     }
 
     @Operation(summary = "미읽음 알림 수 조회", description = "읽지 않은 알림 건수를 반환합니다.")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/dto/response/NotificationResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/dto/response/NotificationResponseDto.java
@@ -38,6 +38,9 @@ public class NotificationResponseDto {
     @Schema(description = "도메인별 메타데이터 (requestId, approvalTargetId 등)", example = "{\"requestId\": 10}")
     private final Map<String, Object> metadata;
 
+    @Schema(description = "승인 대기 여부 (true인 알림만 필터링 가능)", example = "false")
+    private final boolean requiresApproval;
+
     private NotificationResponseDto(Notification notification) {
         this.id = notification.getId();
         this.title = notification.getTitle();
@@ -47,6 +50,7 @@ public class NotificationResponseDto {
         this.isRead = notification.getIsRead();
         this.createdAt = notification.getCreatedAt();
         this.metadata = notification.getMetadata();
+        this.requiresApproval = notification.isRequiresApproval();
     }
 
     public static NotificationResponseDto from(Notification notification) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/dto/response/NotificationResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/dto/response/NotificationResponseDto.java
@@ -35,7 +35,9 @@ public class NotificationResponseDto {
     @Schema(description = "생성일시", example = "2026-02-25T01:00:00")
     private final LocalDateTime createdAt;
 
-    @Schema(description = "도메인별 메타데이터 (requestId, approvalTargetId 등)", example = "{\"requestId\": 10}")
+    @Schema(
+            description = "도메인별 메타데이터 (requestId, approvalTargetId 등)",
+            example = "{\"requestId\": 10}")
     private final Map<String, Object> metadata;
 
     @Schema(description = "승인 대기 여부 (true인 알림만 필터링 가능)", example = "false")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/dto/response/NotificationResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/dto/response/NotificationResponseDto.java
@@ -8,6 +8,7 @@ import kr.co.awesomelead.groupware_backend.domain.notification.enums.Notificatio
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 @Getter
 @Schema(description = "알림 응답")
@@ -34,15 +35,18 @@ public class NotificationResponseDto {
     @Schema(description = "생성일시", example = "2026-02-25T01:00:00")
     private final LocalDateTime createdAt;
 
+    @Schema(description = "도메인별 메타데이터 (requestId, approvalTargetId 등)", example = "{\"requestId\": 10}")
+    private final Map<String, Object> metadata;
+
     private NotificationResponseDto(Notification notification) {
         this.id = notification.getId();
         this.title = notification.getTitle();
         this.content = notification.getContent();
         this.domainType = notification.getDomainType();
         this.domainId = notification.getDomainId();
-
         this.isRead = notification.getIsRead();
         this.createdAt = notification.getCreatedAt();
+        this.metadata = notification.getMetadata();
     }
 
     public static NotificationResponseDto from(Notification notification) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/entity/Notification.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/entity/Notification.java
@@ -111,7 +111,8 @@ public class Notification {
             Map<String, Object> metadata,
             boolean requiresApproval) {
         validate(userId, title, content, domainType);
-        return new Notification(userId, title, content, domainType, domainId, metadata, requiresApproval);
+        return new Notification(
+                userId, title, content, domainType, domainId, metadata, requiresApproval);
     }
 
     private static void validate(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/entity/Notification.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/entity/Notification.java
@@ -1,6 +1,7 @@
 package kr.co.awesomelead.groupware_backend.domain.notification.entity;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -11,11 +12,13 @@ import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 
 import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationDomainType;
+import kr.co.awesomelead.groupware_backend.global.util.NotificationMetadataConverter;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 @Entity
 @Getter
@@ -45,6 +48,10 @@ public class Notification {
     @Column(nullable = false)
     private Boolean isRead;
 
+    @Convert(converter = NotificationMetadataConverter.class)
+    @Column(columnDefinition = "TEXT")
+    private Map<String, Object> metadata;
+
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
@@ -58,12 +65,14 @@ public class Notification {
             String title,
             String content,
             NotificationDomainType domainType,
-            Long domainId) {
+            Long domainId,
+            Map<String, Object> metadata) {
         this.userId = userId;
         this.title = title;
         this.content = content;
         this.domainType = domainType;
         this.domainId = domainId;
+        this.metadata = metadata;
         this.isRead = false;
     }
 
@@ -74,7 +83,18 @@ public class Notification {
             NotificationDomainType domainType,
             Long domainId) {
         validate(userId, title, content, domainType);
-        return new Notification(userId, title, content, domainType, domainId);
+        return new Notification(userId, title, content, domainType, domainId, null);
+    }
+
+    public static Notification of(
+            Long userId,
+            String title,
+            String content,
+            NotificationDomainType domainType,
+            Long domainId,
+            Map<String, Object> metadata) {
+        validate(userId, title, content, domainType);
+        return new Notification(userId, title, content, domainType, domainId, metadata);
     }
 
     private static void validate(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/entity/Notification.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/entity/Notification.java
@@ -52,6 +52,9 @@ public class Notification {
     @Column(columnDefinition = "TEXT")
     private Map<String, Object> metadata;
 
+    @Column(nullable = false)
+    private boolean requiresApproval;
+
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
@@ -66,7 +69,8 @@ public class Notification {
             String content,
             NotificationDomainType domainType,
             Long domainId,
-            Map<String, Object> metadata) {
+            Map<String, Object> metadata,
+            boolean requiresApproval) {
         this.userId = userId;
         this.title = title;
         this.content = content;
@@ -74,6 +78,7 @@ public class Notification {
         this.domainId = domainId;
         this.metadata = metadata;
         this.isRead = false;
+        this.requiresApproval = requiresApproval;
     }
 
     public static Notification of(
@@ -83,7 +88,7 @@ public class Notification {
             NotificationDomainType domainType,
             Long domainId) {
         validate(userId, title, content, domainType);
-        return new Notification(userId, title, content, domainType, domainId, null);
+        return new Notification(userId, title, content, domainType, domainId, null, false);
     }
 
     public static Notification of(
@@ -94,7 +99,19 @@ public class Notification {
             Long domainId,
             Map<String, Object> metadata) {
         validate(userId, title, content, domainType);
-        return new Notification(userId, title, content, domainType, domainId, metadata);
+        return new Notification(userId, title, content, domainType, domainId, metadata, false);
+    }
+
+    public static Notification of(
+            Long userId,
+            String title,
+            String content,
+            NotificationDomainType domainType,
+            Long domainId,
+            Map<String, Object> metadata,
+            boolean requiresApproval) {
+        validate(userId, title, content, domainType);
+        return new Notification(userId, title, content, domainType, domainId, metadata, requiresApproval);
     }
 
     private static void validate(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/enums/NotificationDomainType.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/enums/NotificationDomainType.java
@@ -13,7 +13,8 @@ public enum NotificationDomainType {
     PAYSLIP,
     REQUEST_HISTORY,
     MY_INFO_UPDATE,
-    CHECK_SHEET;
+    CHECK_SHEET,
+    SAFETY_TRAINING;
 
     @JsonValue
     public String getValue() {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/enums/NotificationMessage.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/enums/NotificationMessage.java
@@ -36,7 +36,10 @@ public enum NotificationMessage {
     APPROVAL_CREATED_APPROVER("결재 요청", "[%s] 결재 요청이 도착했습니다."),
     APPROVAL_CREATED_REFERRER("결재 참조", "[%s] 문서가 참조되었습니다."),
     APPROVAL_REJECTED("결재 반려", "[%s] 문서가 반려되었습니다. 사유: %s"),
-    APPROVAL_FINALLY_APPROVED("결재 최종 승인", "[%s] 문서가 최종 승인되었습니다.");
+    APPROVAL_FINALLY_APPROVED("결재 최종 승인", "[%s] 문서가 최종 승인되었습니다."),
+
+    // 안전보건교육 세션
+    SAFETY_TRAINING_SESSION_CREATED("새 안전보건교육 등록", "[안전보건교육] %s 교육이 등록되었습니다.");
 
     private final String title;
     private final String contentPattern;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/repository/NotificationRepository.java
@@ -14,14 +14,17 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     Page<Notification> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 
-    Page<Notification> findByUserIdAndRequiresApprovalTrueOrderByCreatedAtDesc(Long userId, Pageable pageable);
+    Page<Notification> findByUserIdAndRequiresApprovalTrueOrderByCreatedAtDesc(
+            Long userId, Pageable pageable);
 
     long countByUserIdAndIsReadFalse(Long userId);
 
     void deleteByDomainTypeAndDomainId(NotificationDomainType domainType, Long domainId);
 
     @Modifying
-    @Query("UPDATE Notification n SET n.requiresApproval = false WHERE n.domainType = :domainType AND n.domainId = :domainId AND n.requiresApproval = true")
+    @Query(
+            "UPDATE Notification n SET n.requiresApproval = false WHERE n.domainType = :domainType"
+                + " AND n.domainId = :domainId AND n.requiresApproval = true")
     void resolveRequiresApprovalByDomainTypeAndDomainId(
             @Param("domainType") NotificationDomainType domainType,
             @Param("domainId") Long domainId);

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/repository/NotificationRepository.java
@@ -6,12 +6,23 @@ import kr.co.awesomelead.groupware_backend.domain.notification.enums.Notificatio
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     Page<Notification> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 
+    Page<Notification> findByUserIdAndRequiresApprovalTrueOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
     long countByUserIdAndIsReadFalse(Long userId);
 
     void deleteByDomainTypeAndDomainId(NotificationDomainType domainType, Long domainId);
+
+    @Modifying
+    @Query("UPDATE Notification n SET n.requiresApproval = false WHERE n.domainType = :domainType AND n.domainId = :domainId AND n.requiresApproval = true")
+    void resolveRequiresApprovalByDomainTypeAndDomainId(
+            @Param("domainType") NotificationDomainType domainType,
+            @Param("domainId") Long domainId);
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/service/NotificationService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/service/NotificationService.java
@@ -21,6 +21,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +37,7 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final UserRepository userRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Transactional
     public void createNotification(
@@ -42,7 +46,19 @@ public class NotificationService {
             String content,
             NotificationDomainType domainType,
             Long domainId) {
-        Notification notification = Notification.of(userId, title, content, domainType, domainId);
+        createNotification(userId, title, content, domainType, domainId, null);
+    }
+
+    @Transactional
+    public void createNotification(
+            Long userId,
+            String title,
+            String content,
+            NotificationDomainType domainType,
+            Long domainId,
+            Map<String, Object> metadata) {
+        Notification notification =
+                Notification.of(userId, title, content, domainType, domainId, metadata);
         notificationRepository.save(notification);
         log.info("알림 생성 - userId: {}, domainType: {}", userId, domainType);
     }
@@ -87,6 +103,16 @@ public class NotificationService {
             NotificationDomainType domainType,
             Long domainId,
             Object... args) {
+        sendAlertToAdmins(template, domainType, domainId, null, args);
+    }
+
+    @Transactional
+    public void sendAlertToAdmins(
+            NotificationMessage template,
+            NotificationDomainType domainType,
+            Long domainId,
+            Map<String, Object> metadata,
+            Object... args) {
         String title = template.getTitle();
         String content = template.formatContent(args);
 
@@ -95,12 +121,15 @@ public class NotificationService {
 
         for (User admin : admins) {
             // 1. 알림함 저장
-            createNotification(admin.getId(), title, content, domainType, domainId);
+            createNotification(admin.getId(), title, content, domainType, domainId, metadata);
 
             // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
             eventPublisher.publishEvent(
                     new FcmSendEvent(
-                            admin.getId(), title, content, buildFcmData(domainType, domainId)));
+                            admin.getId(),
+                            title,
+                            content,
+                            buildFcmData(domainType, domainId, metadata)));
         }
 
         log.info("관리자 그룹 알림 전송 완료 - 대상 Admin 수: {}, 템플릿: {}", admins.size(), template.name());
@@ -122,15 +151,27 @@ public class NotificationService {
             NotificationDomainType domainType,
             Long domainId,
             Object... args) {
+        sendAlertToUser(userId, template, domainType, domainId, null, args);
+    }
+
+    @Transactional
+    public void sendAlertToUser(
+            Long userId,
+            NotificationMessage template,
+            NotificationDomainType domainType,
+            Long domainId,
+            Map<String, Object> metadata,
+            Object... args) {
         String title = template.getTitle();
         String content = template.formatContent(args);
 
         // 1. 알림함 저장
-        createNotification(userId, title, content, domainType, domainId);
+        createNotification(userId, title, content, domainType, domainId, metadata);
 
         // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
         eventPublisher.publishEvent(
-                new FcmSendEvent(userId, title, content, buildFcmData(domainType, domainId)));
+                new FcmSendEvent(
+                        userId, title, content, buildFcmData(domainType, domainId, metadata)));
 
         log.info("단일 유저 알림 전송 완료 - userId: {}, 템플릿: {}", userId, template.name());
     }
@@ -448,9 +489,21 @@ public class NotificationService {
     }
 
     private Map<String, String> buildFcmData(NotificationDomainType domainType, Long domainId) {
+        return buildFcmData(domainType, domainId, null);
+    }
+
+    private Map<String, String> buildFcmData(
+            NotificationDomainType domainType, Long domainId, Map<String, Object> metadata) {
         Map<String, String> data = new HashMap<>();
         data.put("domainType", domainType.name());
         data.put("domainId", domainId != null ? domainId.toString() : "");
+        if (metadata != null && !metadata.isEmpty()) {
+            try {
+                data.put("metadata", objectMapper.writeValueAsString(metadata));
+            } catch (JsonProcessingException e) {
+                log.error("FCM metadata 직렬화 실패", e);
+            }
+        }
         return data;
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/service/NotificationService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/service/NotificationService.java
@@ -221,6 +221,16 @@ public class NotificationService {
     @Transactional
     public void sendEduReportAlertToTargets(
             String eduTypeLabel, String eduTitle, Long reportId, List<Long> targetUserIds) {
+        sendEduReportAlertToTargets(eduTypeLabel, eduTitle, reportId, targetUserIds, null);
+    }
+
+    @Transactional
+    public void sendEduReportAlertToTargets(
+            String eduTypeLabel,
+            String eduTitle,
+            Long reportId,
+            List<Long> targetUserIds,
+            Map<String, Object> metadata) {
         if (targetUserIds == null || targetUserIds.isEmpty()) {
             log.info("교육 알림 전송 건너뜀 - 대상 없음, reportId: {}", reportId);
             return;
@@ -232,7 +242,8 @@ public class NotificationService {
 
         for (Long userId : targetUserIds) {
             // 1. 알림함 저장
-            createNotification(userId, title, content, NotificationDomainType.EDUCATION, reportId);
+            createNotification(
+                    userId, title, content, NotificationDomainType.EDUCATION, reportId, metadata);
 
             // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
             eventPublisher.publishEvent(
@@ -240,7 +251,7 @@ public class NotificationService {
                             userId,
                             title,
                             content,
-                            buildFcmData(NotificationDomainType.EDUCATION, reportId)));
+                            buildFcmData(NotificationDomainType.EDUCATION, reportId, metadata)));
         }
 
         log.info("교육 알림 전송 완료 - reportId: {}, 대상 수: {}", reportId, targetUserIds.size());
@@ -260,6 +271,16 @@ public class NotificationService {
             Long visitId,
             Long hostDepartmentId,
             Object... contentArgs) {
+        sendVisitAlertToDepartment(template, visitId, hostDepartmentId, null, contentArgs);
+    }
+
+    @Transactional
+    public void sendVisitAlertToDepartment(
+            NotificationMessage template,
+            Long visitId,
+            Long hostDepartmentId,
+            Map<String, Object> metadata,
+            Object... contentArgs) {
         List<Long> targetUserIds = userRepository.findAllIdsByDepartmentId(hostDepartmentId);
 
         if (targetUserIds.isEmpty()) {
@@ -272,7 +293,7 @@ public class NotificationService {
 
         for (Long userId : targetUserIds) {
             // 1. 알림함 저장
-            createNotification(userId, title, content, NotificationDomainType.VISIT, visitId);
+            createNotification(userId, title, content, NotificationDomainType.VISIT, visitId, metadata);
 
             // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
             eventPublisher.publishEvent(
@@ -280,7 +301,7 @@ public class NotificationService {
                             userId,
                             title,
                             content,
-                            buildFcmData(NotificationDomainType.VISIT, visitId)));
+                            buildFcmData(NotificationDomainType.VISIT, visitId, metadata)));
         }
 
         log.info(
@@ -486,6 +507,50 @@ public class NotificationService {
                 approvalId,
                 drafterId,
                 viewerIds.size());
+    }
+
+    /**
+     * 안전보건교육 세션 생성 시 대상 유저 전체에게 FCM 알림 전송 + Notification 저장
+     *
+     * @param sessionId 생성된 세션 ID (domainId로 저장)
+     * @param sessionTitle 세션 제목
+     * @param targetUserIds 알림을 받을 유저 ID 목록
+     */
+    @Transactional
+    public void sendSafetyTrainingSessionAlertToAttendees(
+            Long sessionId, String sessionTitle, List<Long> targetUserIds) {
+        if (targetUserIds == null || targetUserIds.isEmpty()) {
+            log.info("안전보건교육 알림 전송 건너뜀 - 대상 없음, sessionId: {}", sessionId);
+            return;
+        }
+
+        String title = NotificationMessage.SAFETY_TRAINING_SESSION_CREATED.getTitle();
+        String content =
+                NotificationMessage.SAFETY_TRAINING_SESSION_CREATED.formatContent(sessionTitle);
+        Map<String, Object> metadata =
+                Map.of("educationType", "SAFETY", "detailType", "SESSION");
+
+        for (Long userId : targetUserIds) {
+            createNotification(
+                    userId,
+                    title,
+                    content,
+                    NotificationDomainType.SAFETY_TRAINING,
+                    sessionId,
+                    metadata);
+            eventPublisher.publishEvent(
+                    new FcmSendEvent(
+                            userId,
+                            title,
+                            content,
+                            buildFcmData(
+                                    NotificationDomainType.SAFETY_TRAINING, sessionId, metadata)));
+        }
+
+        log.info(
+                "안전보건교육 세션 알림 전송 완료 - sessionId: {}, 대상 수: {}",
+                sessionId,
+                targetUserIds.size());
     }
 
     private Map<String, String> buildFcmData(NotificationDomainType domainType, Long domainId) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/service/NotificationService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/service/NotificationService.java
@@ -57,17 +57,40 @@ public class NotificationService {
             NotificationDomainType domainType,
             Long domainId,
             Map<String, Object> metadata) {
+        createNotification(userId, title, content, domainType, domainId, metadata, false);
+    }
+
+    @Transactional
+    public void createNotification(
+            Long userId,
+            String title,
+            String content,
+            NotificationDomainType domainType,
+            Long domainId,
+            Map<String, Object> metadata,
+            boolean requiresApproval) {
         Notification notification =
-                Notification.of(userId, title, content, domainType, domainId, metadata);
+                Notification.of(userId, title, content, domainType, domainId, metadata, requiresApproval);
         notificationRepository.save(notification);
         log.info("알림 생성 - userId: {}, domainType: {}", userId, domainType);
     }
 
     @Transactional(readOnly = true)
-    public Page<NotificationResponseDto> getNotifications(Long userId, Pageable pageable) {
-        return notificationRepository
-                .findByUserIdOrderByCreatedAtDesc(userId, pageable)
-                .map(NotificationResponseDto::from);
+    public Page<NotificationResponseDto> getNotifications(
+            Long userId, boolean pendingApproval, Pageable pageable) {
+        Page<Notification> page =
+                pendingApproval
+                        ? notificationRepository
+                                .findByUserIdAndRequiresApprovalTrueOrderByCreatedAtDesc(
+                                        userId, pageable)
+                        : notificationRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable);
+        return page.map(NotificationResponseDto::from);
+    }
+
+    @Transactional
+    public void resolveRequiresApproval(NotificationDomainType domainType, Long domainId) {
+        notificationRepository.resolveRequiresApprovalByDomainTypeAndDomainId(domainType, domainId);
+        log.info("requiresApproval 해제 - domainType: {}, domainId: {}", domainType, domainId);
     }
 
     @Transactional
@@ -113,6 +136,26 @@ public class NotificationService {
             Long domainId,
             Map<String, Object> metadata,
             Object... args) {
+        sendAlertToAdminsInternal(template, domainType, domainId, metadata, false, args);
+    }
+
+    @Transactional
+    public void sendAlertToAdminsRequiringApproval(
+            NotificationMessage template,
+            NotificationDomainType domainType,
+            Long domainId,
+            Map<String, Object> metadata,
+            Object... args) {
+        sendAlertToAdminsInternal(template, domainType, domainId, metadata, true, args);
+    }
+
+    private void sendAlertToAdminsInternal(
+            NotificationMessage template,
+            NotificationDomainType domainType,
+            Long domainId,
+            Map<String, Object> metadata,
+            boolean requiresApproval,
+            Object... args) {
         String title = template.getTitle();
         String content = template.formatContent(args);
 
@@ -121,7 +164,8 @@ public class NotificationService {
 
         for (User admin : admins) {
             // 1. 알림함 저장
-            createNotification(admin.getId(), title, content, domainType, domainId, metadata);
+            createNotification(
+                    admin.getId(), title, content, domainType, domainId, metadata, requiresApproval);
 
             // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
             eventPublisher.publishEvent(
@@ -290,10 +334,12 @@ public class NotificationService {
 
         String title = template.getTitle();
         String content = template.formatContent(contentArgs);
+        boolean requiresApproval = metadata != null && Boolean.TRUE.equals(metadata.get("isApprovalTarget"));
 
         for (Long userId : targetUserIds) {
             // 1. 알림함 저장
-            createNotification(userId, title, content, NotificationDomainType.VISIT, visitId, metadata);
+            createNotification(
+                    userId, title, content, NotificationDomainType.VISIT, visitId, metadata, requiresApproval);
 
             // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
             eventPublisher.publishEvent(
@@ -384,7 +430,9 @@ public class NotificationService {
                 approverTitle,
                 approverContent,
                 NotificationDomainType.APPROVAL,
-                approvalId);
+                approvalId,
+                null,
+                true);
         eventPublisher.publishEvent(
                 new FcmSendEvent(
                         firstApproverId,
@@ -428,7 +476,7 @@ public class NotificationService {
         String content = NotificationMessage.APPROVAL_CREATED_APPROVER.formatContent(docTitle);
 
         createNotification(
-                nextApproverId, title, content, NotificationDomainType.APPROVAL, approvalId);
+                nextApproverId, title, content, NotificationDomainType.APPROVAL, approvalId, null, true);
         eventPublisher.publishEvent(
                 new FcmSendEvent(
                         nextApproverId,

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/service/NotificationService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/service/NotificationService.java
@@ -1,5 +1,8 @@
 package kr.co.awesomelead.groupware_backend.domain.notification.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import kr.co.awesomelead.groupware_backend.domain.fcm.event.FcmSendEvent;
 import kr.co.awesomelead.groupware_backend.domain.notification.dto.response.NotificationResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.notification.entity.Notification;
@@ -20,9 +23,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.HashMap;
 import java.util.List;
@@ -70,7 +70,8 @@ public class NotificationService {
             Map<String, Object> metadata,
             boolean requiresApproval) {
         Notification notification =
-                Notification.of(userId, title, content, domainType, domainId, metadata, requiresApproval);
+                Notification.of(
+                        userId, title, content, domainType, domainId, metadata, requiresApproval);
         notificationRepository.save(notification);
         log.info("알림 생성 - userId: {}, domainType: {}", userId, domainType);
     }
@@ -165,7 +166,13 @@ public class NotificationService {
         for (User admin : admins) {
             // 1. 알림함 저장
             createNotification(
-                    admin.getId(), title, content, domainType, domainId, metadata, requiresApproval);
+                    admin.getId(),
+                    title,
+                    content,
+                    domainType,
+                    domainId,
+                    metadata,
+                    requiresApproval);
 
             // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
             eventPublisher.publishEvent(
@@ -334,12 +341,19 @@ public class NotificationService {
 
         String title = template.getTitle();
         String content = template.formatContent(contentArgs);
-        boolean requiresApproval = metadata != null && Boolean.TRUE.equals(metadata.get("isApprovalTarget"));
+        boolean requiresApproval =
+                metadata != null && Boolean.TRUE.equals(metadata.get("isApprovalTarget"));
 
         for (Long userId : targetUserIds) {
             // 1. 알림함 저장
             createNotification(
-                    userId, title, content, NotificationDomainType.VISIT, visitId, metadata, requiresApproval);
+                    userId,
+                    title,
+                    content,
+                    NotificationDomainType.VISIT,
+                    visitId,
+                    metadata,
+                    requiresApproval);
 
             // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
             eventPublisher.publishEvent(
@@ -476,7 +490,13 @@ public class NotificationService {
         String content = NotificationMessage.APPROVAL_CREATED_APPROVER.formatContent(docTitle);
 
         createNotification(
-                nextApproverId, title, content, NotificationDomainType.APPROVAL, approvalId, null, true);
+                nextApproverId,
+                title,
+                content,
+                NotificationDomainType.APPROVAL,
+                approvalId,
+                null,
+                true);
         eventPublisher.publishEvent(
                 new FcmSendEvent(
                         nextApproverId,
@@ -575,8 +595,7 @@ public class NotificationService {
         String title = NotificationMessage.SAFETY_TRAINING_SESSION_CREATED.getTitle();
         String content =
                 NotificationMessage.SAFETY_TRAINING_SESSION_CREATED.formatContent(sessionTitle);
-        Map<String, Object> metadata =
-                Map.of("educationType", "SAFETY", "detailType", "SESSION");
+        Map<String, Object> metadata = Map.of("educationType", "SAFETY", "detailType", "SESSION");
 
         for (Long userId : targetUserIds) {
             createNotification(
@@ -595,10 +614,7 @@ public class NotificationService {
                                     NotificationDomainType.SAFETY_TRAINING, sessionId, metadata)));
         }
 
-        log.info(
-                "안전보건교육 세션 알림 전송 완료 - sessionId: {}, 대상 수: {}",
-                sessionId,
-                targetUserIds.size());
+        log.info("안전보건교육 세션 알림 전송 완료 - sessionId: {}, 대상 수: {}", sessionId, targetUserIds.size());
     }
 
     private Map<String, String> buildFcmData(NotificationDomainType domainType, Long domainId) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
@@ -3,6 +3,7 @@ package kr.co.awesomelead.groupware_backend.domain.safetytraining.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
+import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.request.SafetyTrainingSessionCreateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.request.SafetyTrainingSessionSearchConditionDto;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.request.SafetyTrainingSessionStatusUpdateRequestDto;
@@ -64,6 +65,7 @@ public class SafetyTrainingSessionService {
     private final ObjectMapper objectMapper;
     private final SafetyTrainingExcelService safetyTrainingExcelService;
     private final S3Service s3Service;
+    private final NotificationService notificationService;
 
     @Transactional(readOnly = true)
     public SafetyTrainingPreviewResponseDto preview(
@@ -153,6 +155,11 @@ public class SafetyTrainingSessionService {
         saved.setTargetCount(rows.size());
         saved.setAttendedCount(0);
         saved.setAbsentCount(0);
+
+        // 안전보건교육 세션 생성 알림 전송
+        List<Long> attendeeIds = attendees.stream().map(User::getId).toList();
+        notificationService.sendSafetyTrainingSessionAlertToAttendees(
+                saved.getId(), saved.getTitle(), attendeeIds);
 
         return saved.getId();
     }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserService.java
@@ -21,6 +21,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.data.domain.Page;
+
+import java.util.Map;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -129,7 +131,7 @@ public class UserService {
                         .requestedAddress2(requestedAddress2)
                         .status(MyInfoUpdateRequestStatus.PENDING)
                         .build();
-        myInfoUpdateRequestRepository.save(request);
+        MyInfoUpdateRequest saved = myInfoUpdateRequestRepository.save(request);
 
         if (requestedPhoneNumber != null) {
             phoneAuthService.clearVerification(requestedPhoneNumber);
@@ -139,10 +141,11 @@ public class UserService {
         notificationService.sendAlertToAdmins(
                 NotificationMessage.MY_INFO_UPDATE_REQUEST_ADMIN,
                 NotificationDomainType.MY_INFO_UPDATE,
-                request.getId(),
+                saved.getId(),
+                Map.of("requestId", saved.getId()),
                 user.getDisplayName());
 
-        log.info("내 정보 수정 요청 생성 - 사용자 ID: {}, 요청 ID: {}", user.getId(), request.getId());
+        log.info("내 정보 수정 요청 생성 - 사용자 ID: {}, 요청 ID: {}", user.getId(), saved.getId());
 
         return MyInfoResponseDto.from(user);
     }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserService.java
@@ -21,13 +21,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.data.domain.Page;
-
-import java.util.Map;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
 
 @Slf4j
 @Service

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserService.java
@@ -138,7 +138,7 @@ public class UserService {
         }
 
         // Admin 권한 유저들에게 정보수정 승인 요청 알림 전송 (FCM + Notification DB)
-        notificationService.sendAlertToAdmins(
+        notificationService.sendAlertToAdminsRequiringApproval(
                 NotificationMessage.MY_INFO_UPDATE_REQUEST_ADMIN,
                 NotificationDomainType.MY_INFO_UPDATE,
                 saved.getId(),

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
@@ -38,6 +38,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.Map;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
@@ -82,6 +84,7 @@ public class VisitService {
                     NotificationMessage.VISIT_ONE_DAY_PRE,
                     visitId,
                     hostDeptId,
+                    Map.of("isApprovalTarget", false, "status", VisitStatus.PENDING.name()),
                     visit.getVisitorName(),
                     visit.getStartDate(),
                     dto.getPlannedEntryTime(),
@@ -115,6 +118,7 @@ public class VisitService {
                     NotificationMessage.VISIT_LONG_TERM_PRE,
                     visitId,
                     hostDeptId,
+                    Map.of("status", VisitStatus.PENDING.name(), "isApprovalTarget", true),
                     visit.getVisitorName(),
                     dto.getStartDate(),
                     dto.getEndDate());
@@ -158,6 +162,7 @@ public class VisitService {
                     NotificationMessage.VISIT_CHECK_IN,
                     visitId,
                     hostDeptId,
+                    Map.of("isApprovalTarget", false, "status", VisitStatus.IN_PROGRESS.name()),
                     visit.getVisitorName(),
                     record.getEntryTime().toLocalTime());
         }
@@ -254,6 +259,7 @@ public class VisitService {
                     NotificationMessage.VISIT_CHECK_IN,
                     visit.getId(),
                     host.getDepartment().getId(),
+                    Map.of("isApprovalTarget", false, "status", VisitStatus.IN_PROGRESS.name()),
                     visit.getVisitorName(),
                     entryTime.toLocalTime());
         }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
@@ -39,8 +39,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-
-import java.util.Map;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
@@ -48,6 +46,7 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
@@ -3,6 +3,7 @@ package kr.co.awesomelead.groupware_backend.domain.visit.service;
 import static kr.co.awesomelead.groupware_backend.domain.visit.entity.Visit.hashValue;
 
 import kr.co.awesomelead.groupware_backend.domain.department.repository.DepartmentRepository;
+import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationDomainType;
 import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationMessage;
 import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
@@ -500,5 +501,8 @@ public class VisitService {
 
         // 5. 상태 변경 처리
         visit.process(dto.getStatus(), dto.getRejectionReason());
+
+        // 6. 승인 대기 알림 해제 (승인/반려 모두)
+        notificationService.resolveRequiresApproval(NotificationDomainType.VISIT, visitId);
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/util/NotificationMetadataConverter.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/util/NotificationMetadataConverter.java
@@ -1,0 +1,46 @@
+package kr.co.awesomelead.groupware_backend.global.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+
+@Slf4j
+@Converter
+public class NotificationMetadataConverter
+        implements AttributeConverter<Map<String, Object>, String> {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(Map<String, Object> attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            log.error("NotificationMetadata 직렬화 실패", e);
+            return null;
+        }
+    }
+
+    @Override
+    public Map<String, Object> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return null;
+        }
+        try {
+            return objectMapper.readValue(dbData, new TypeReference<>() {});
+        } catch (JsonProcessingException e) {
+            log.error("NotificationMetadata 역직렬화 실패: {}", dbData, e);
+            return null;
+        }
+    }
+}

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
@@ -666,15 +666,12 @@ class AdminServiceTest {
                             .status(MyInfoUpdateRequestStatus.PENDING)
                             .build();
 
-            when(userRepository.findById(userId)).thenReturn(Optional.of(targetUser));
-            when(myInfoUpdateRequestRepository.findFirstByUserIdAndStatusOrderByCreatedAtDesc(
-                            userId, MyInfoUpdateRequestStatus.PENDING))
-                    .thenReturn(Optional.of(request));
+            when(myInfoUpdateRequestRepository.findById(10L)).thenReturn(Optional.of(request));
             when(userRepository.existsByPhoneNumberHash(User.hashValue("01099998888")))
                     .thenReturn(false);
 
             // when
-            adminService.approveMyInfoUpdate(userId, adminId);
+            adminService.approveMyInfoUpdate(10L, adminId);
 
             // then
             assertThat(targetUser.getNameEng()).isEqualTo("NEW");
@@ -697,13 +694,10 @@ class AdminServiceTest {
                             .status(MyInfoUpdateRequestStatus.PENDING)
                             .build();
 
-            when(userRepository.findById(userId)).thenReturn(Optional.of(targetUser));
-            when(myInfoUpdateRequestRepository.findFirstByUserIdAndStatusOrderByCreatedAtDesc(
-                            userId, MyInfoUpdateRequestStatus.PENDING))
-                    .thenReturn(Optional.of(request));
+            when(myInfoUpdateRequestRepository.findById(10L)).thenReturn(Optional.of(request));
 
             // when
-            adminService.rejectMyInfoUpdate(userId, "증빙 불충분", adminId);
+            adminService.rejectMyInfoUpdate(10L, "증빙 불충분", adminId);
 
             // then
             assertThat(request.getStatus()).isEqualTo(MyInfoUpdateRequestStatus.REJECTED);

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
@@ -51,6 +51,7 @@ import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
@@ -681,7 +682,7 @@ class AdminServiceTest {
             assertThat(request.getStatus()).isEqualTo(MyInfoUpdateRequestStatus.APPROVED);
             verify(userRepository).save(targetUser);
             verify(myInfoUpdateRequestRepository).save(request);
-            verify(notificationService).sendAlertToUser(any(), any(), any(), any());
+            verify(notificationService).sendAlertToUser(any(), any(), any(), any(), any(Map.class));
         }
 
         @Test
@@ -708,7 +709,7 @@ class AdminServiceTest {
             assertThat(request.getStatus()).isEqualTo(MyInfoUpdateRequestStatus.REJECTED);
             assertThat(request.getRejectReason()).isEqualTo("증빙 불충분");
             verify(myInfoUpdateRequestRepository).save(request);
-            verify(notificationService).sendAlertToUser(any(), any(), any(), any(), any());
+            verify(notificationService).sendAlertToUser(any(), any(), any(), any(), any(Map.class), any());
         }
 
         @Test

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
@@ -703,7 +703,8 @@ class AdminServiceTest {
             assertThat(request.getStatus()).isEqualTo(MyInfoUpdateRequestStatus.REJECTED);
             assertThat(request.getRejectReason()).isEqualTo("증빙 불충분");
             verify(myInfoUpdateRequestRepository).save(request);
-            verify(notificationService).sendAlertToUser(any(), any(), any(), any(), any(Map.class), any());
+            verify(notificationService)
+                    .sendAlertToUser(any(), any(), any(), any(), any(Map.class), any());
         }
 
         @Test

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/approval/ApprovalTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/approval/ApprovalTest.java
@@ -38,6 +38,7 @@ import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalRe
 import kr.co.awesomelead.groupware_backend.domain.approval.repository.querydsl.ApprovalQueryRepository;
 import kr.co.awesomelead.groupware_backend.domain.approval.service.ApprovalService;
 import kr.co.awesomelead.groupware_backend.domain.department.entity.Department;
+import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
@@ -85,6 +86,8 @@ public class ApprovalTest {
     @Mock private ApprovalMapper approvalMapper;
 
     @Mock private S3Service s3Service;
+
+    @Mock private NotificationService notificationService;
 
     private User drafter;
     private Department department;

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/approval/ApprovalTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/approval/ApprovalTest.java
@@ -38,9 +38,9 @@ import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalRe
 import kr.co.awesomelead.groupware_backend.domain.approval.repository.querydsl.ApprovalQueryRepository;
 import kr.co.awesomelead.groupware_backend.domain.approval.service.ApprovalService;
 import kr.co.awesomelead.groupware_backend.domain.department.entity.Department;
-import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
+import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
@@ -210,7 +210,8 @@ class AuthServiceTest {
         verify(userRepository, times(1)).save(any(User.class));
         verify(emailAuthService, times(1)).clearVerification(signupDto.getEmail());
         verify(phoneAuthService, times(1)).clearVerification(signupDto.getPhoneNumber());
-        verify(notificationService, times(1)).sendAlertToAdmins(any(), any(), any(), any(Map.class), any());
+        verify(notificationService, times(1))
+                .sendAlertToAdmins(any(), any(), any(), any(Map.class), any());
     }
 
     @Test

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
@@ -51,6 +51,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDate;
+import java.util.Map;
 import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
@@ -209,7 +210,7 @@ class AuthServiceTest {
         verify(userRepository, times(1)).save(any(User.class));
         verify(emailAuthService, times(1)).clearVerification(signupDto.getEmail());
         verify(phoneAuthService, times(1)).clearVerification(signupDto.getPhoneNumber());
-        verify(notificationService, times(1)).sendAlertToAdmins(any(), any(), any(), any());
+        verify(notificationService, times(1)).sendAlertToAdmins(any(), any(), any(), any(Map.class), any());
     }
 
     @Test

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
@@ -181,7 +181,8 @@ public class EduReportServiceTest {
         assertThat(savedReport.getContent()).isEqualTo("교육 보고서 내용");
 
         verify(notificationService, times(1))
-                .sendEduReportAlertToTargets(anyString(), anyString(), anyLong(), any(), any(Map.class));
+                .sendEduReportAlertToTargets(
+                        anyString(), anyString(), anyLong(), any(), any(Map.class));
     }
 
     @Test

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
@@ -55,6 +55,7 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
@@ -180,7 +181,7 @@ public class EduReportServiceTest {
         assertThat(savedReport.getContent()).isEqualTo("교육 보고서 내용");
 
         verify(notificationService, times(1))
-                .sendEduReportAlertToTargets(anyString(), anyString(), anyLong(), any());
+                .sendEduReportAlertToTargets(anyString(), anyString(), anyLong(), any(), any(Map.class));
     }
 
     @Test

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/notification/NotificationMetadataConverterTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/notification/NotificationMetadataConverterTest.java
@@ -1,0 +1,67 @@
+package kr.co.awesomelead.groupware_backend.domain.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import kr.co.awesomelead.groupware_backend.global.util.NotificationMetadataConverter;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+class NotificationMetadataConverterTest {
+
+    private final NotificationMetadataConverter converter = new NotificationMetadataConverter();
+
+    @Test
+    @DisplayName("Map을 JSON 문자열로 직렬화한다")
+    void convertToDatabaseColumn_returnsJsonString() {
+        Map<String, Object> metadata = Map.of("requestId", 10, "status", "PENDING");
+
+        String result = converter.convertToDatabaseColumn(metadata);
+
+        assertThat(result).isNotNull();
+        assertThat(result).contains("requestId");
+        assertThat(result).contains("PENDING");
+    }
+
+    @Test
+    @DisplayName("null 또는 빈 Map은 null을 반환한다")
+    void convertToDatabaseColumn_returnsNull_whenNullOrEmpty() {
+        assertThat(converter.convertToDatabaseColumn(null)).isNull();
+        assertThat(converter.convertToDatabaseColumn(Map.of())).isNull();
+    }
+
+    @Test
+    @DisplayName("JSON 문자열을 Map으로 역직렬화한다")
+    void convertToEntityAttribute_returnsMap() {
+        String json = "{\"requestId\":10,\"status\":\"PENDING\"}";
+
+        Map<String, Object> result = converter.convertToEntityAttribute(json);
+
+        assertThat(result).isNotNull();
+        assertThat(result.get("status")).isEqualTo("PENDING");
+        assertThat(((Number) result.get("requestId")).intValue()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("null 또는 빈 문자열은 null을 반환한다")
+    void convertToEntityAttribute_returnsNull_whenNullOrBlank() {
+        assertThat(converter.convertToEntityAttribute(null)).isNull();
+        assertThat(converter.convertToEntityAttribute("")).isNull();
+        assertThat(converter.convertToEntityAttribute("   ")).isNull();
+    }
+
+    @Test
+    @DisplayName("직렬화 후 역직렬화하면 원래 값과 동일하다")
+    void roundTrip_preservesValues() {
+        Map<String, Object> original = Map.of("approvalTargetId", 42L, "isApprovalTarget", true);
+
+        String json = converter.convertToDatabaseColumn(original);
+        Map<String, Object> restored = converter.convertToEntityAttribute(json);
+
+        assertThat(restored).isNotNull();
+        assertThat(((Number) restored.get("approvalTargetId")).longValue()).isEqualTo(42L);
+        assertThat(restored.get("isApprovalTarget")).isEqualTo(true);
+    }
+}

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/notification/NotificationServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/notification/NotificationServiceTest.java
@@ -48,8 +48,7 @@ class NotificationServiceTest {
     @Test
     @DisplayName("createNotification - metadata 없이 호출 시 metadata가 null로 저장된다")
     void createNotification_withoutMetadata_savesNotification() {
-        notificationService.createNotification(
-                1L, "제목", "내용", NotificationDomainType.VISIT, 10L);
+        notificationService.createNotification(1L, "제목", "내용", NotificationDomainType.VISIT, 10L);
 
         ArgumentCaptor<Notification> captor = forClass(Notification.class);
         verify(notificationRepository).save(captor.capture());
@@ -99,8 +98,10 @@ class NotificationServiceTest {
         User masterAdmin = mock(User.class);
         when(masterAdmin.getId()).thenReturn(20L);
 
-        when(userRepository.findAllByRole(Role.ADMIN)).thenReturn(new java.util.ArrayList<>(List.of(admin1)));
-        when(userRepository.findAllByRole(Role.MASTER_ADMIN)).thenReturn(new java.util.ArrayList<>(List.of(masterAdmin)));
+        when(userRepository.findAllByRole(Role.ADMIN))
+                .thenReturn(new java.util.ArrayList<>(List.of(admin1)));
+        when(userRepository.findAllByRole(Role.MASTER_ADMIN))
+                .thenReturn(new java.util.ArrayList<>(List.of(masterAdmin)));
 
         Map<String, Object> metadata = Map.of("visitId", 77);
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/notification/NotificationServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/notification/NotificationServiceTest.java
@@ -1,0 +1,120 @@
+package kr.co.awesomelead.groupware_backend.domain.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import kr.co.awesomelead.groupware_backend.domain.fcm.event.FcmSendEvent;
+import kr.co.awesomelead.groupware_backend.domain.notification.entity.Notification;
+import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationDomainType;
+import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationMessage;
+import kr.co.awesomelead.groupware_backend.domain.notification.repository.NotificationRepository;
+import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
+import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
+import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.List;
+import java.util.Map;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock private NotificationRepository notificationRepository;
+    @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private UserRepository userRepository;
+
+    @InjectMocks private NotificationService notificationService;
+
+    @BeforeEach
+    void setUp() {
+        when(notificationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    @Test
+    @DisplayName("createNotification - metadata 없이 호출 시 metadata가 null로 저장된다")
+    void createNotification_withoutMetadata_savesNotification() {
+        notificationService.createNotification(
+                1L, "제목", "내용", NotificationDomainType.VISIT, 10L);
+
+        ArgumentCaptor<Notification> captor = forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+        assertThat(captor.getValue().getMetadata()).isNull();
+    }
+
+    @Test
+    @DisplayName("createNotification - metadata 포함하여 호출 시 엔티티에 metadata가 저장된다")
+    void createNotification_withMetadata_savesMetadata() {
+        Map<String, Object> metadata = Map.of("requestId", 99, "status", "PENDING");
+
+        notificationService.createNotification(
+                1L, "제목", "내용", NotificationDomainType.VISIT, 10L, metadata);
+
+        ArgumentCaptor<Notification> captor = forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+        assertThat(captor.getValue().getMetadata()).isNotNull();
+        assertThat(captor.getValue().getMetadata().get("status")).isEqualTo("PENDING");
+    }
+
+    @Test
+    @DisplayName("sendAlertToUser - metadata 포함 시 FCM 이벤트 data에 metadata JSON이 포함된다")
+    void sendAlertToUser_withMetadata_fcmEventContainsMetadata() {
+        Map<String, Object> metadata = Map.of("approvalTargetId", 55);
+
+        notificationService.sendAlertToUser(
+                2L,
+                NotificationMessage.APPROVAL_CREATED_APPROVER,
+                NotificationDomainType.APPROVAL,
+                20L,
+                metadata,
+                "결재문서");
+
+        ArgumentCaptor<FcmSendEvent> fcmCaptor = forClass(FcmSendEvent.class);
+        verify(eventPublisher).publishEvent(fcmCaptor.capture());
+
+        Map<String, String> fcmData = fcmCaptor.getValue().data();
+        assertThat(fcmData).containsKey("metadata");
+        assertThat(fcmData.get("metadata")).contains("approvalTargetId");
+    }
+
+    @Test
+    @DisplayName("sendAlertToAdmins - metadata 포함 시 모든 관리자에게 metadata가 저장된다")
+    void sendAlertToAdmins_withMetadata_savesMetadataForEachAdmin() {
+        User admin1 = mock(User.class);
+        when(admin1.getId()).thenReturn(10L);
+        User masterAdmin = mock(User.class);
+        when(masterAdmin.getId()).thenReturn(20L);
+
+        when(userRepository.findAllByRole(Role.ADMIN)).thenReturn(new java.util.ArrayList<>(List.of(admin1)));
+        when(userRepository.findAllByRole(Role.MASTER_ADMIN)).thenReturn(new java.util.ArrayList<>(List.of(masterAdmin)));
+
+        Map<String, Object> metadata = Map.of("visitId", 77);
+
+        notificationService.sendAlertToAdmins(
+                NotificationMessage.VISIT_CHECK_IN,
+                NotificationDomainType.VISIT,
+                77L,
+                metadata,
+                "홍길동",
+                "2026-04-09 09:00");
+
+        ArgumentCaptor<Notification> captor = forClass(Notification.class);
+        verify(notificationRepository, times(2)).save(captor.capture());
+
+        captor.getAllValues().forEach(n -> assertThat(n.getMetadata()).containsKey("visitId"));
+    }
+}

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserServiceTest.java
@@ -45,6 +45,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
@@ -175,6 +176,8 @@ class UserServiceTest {
                             myInfoUpdateRequestRepository.existsByUserIdAndStatus(
                                     testUser.getId(), MyInfoUpdateRequestStatus.PENDING))
                     .willReturn(false);
+            given(myInfoUpdateRequestRepository.save(any(MyInfoUpdateRequest.class)))
+                    .willReturn(MyInfoUpdateRequest.builder().id(99L).build());
 
             // when
             MyInfoResponseDto response = userService.updateMyInfo(userDetails, requestDto);
@@ -185,7 +188,7 @@ class UserServiceTest {
 
             verify(userRepository).findByEmail(TEST_EMAIL);
             verify(myInfoUpdateRequestRepository).save(any(MyInfoUpdateRequest.class));
-            verify(notificationService).sendAlertToAdmins(any(), any(), any(), any());
+            verify(notificationService).sendAlertToAdmins(any(), any(), any(), any(Map.class), any());
         }
 
         @Test
@@ -203,6 +206,8 @@ class UserServiceTest {
                     .willReturn(false);
             given(phoneAuthService.isPhoneVerified(NEW_PHONE)).willReturn(true);
             given(userRepository.existsByPhoneNumberHash(newPhoneHash)).willReturn(false);
+            given(myInfoUpdateRequestRepository.save(any(MyInfoUpdateRequest.class)))
+                    .willReturn(MyInfoUpdateRequest.builder().id(99L).build());
 
             // when
             MyInfoResponseDto response = userService.updateMyInfo(userDetails, requestDto);
@@ -216,7 +221,7 @@ class UserServiceTest {
             verify(userRepository).existsByPhoneNumberHash(newPhoneHash);
             verify(myInfoUpdateRequestRepository).save(any(MyInfoUpdateRequest.class));
             verify(phoneAuthService).clearVerification(NEW_PHONE);
-            verify(notificationService).sendAlertToAdmins(any(), any(), any(), any());
+            verify(notificationService).sendAlertToAdmins(any(), any(), any(), any(Map.class), any());
         }
 
         @Test
@@ -235,6 +240,8 @@ class UserServiceTest {
                     .willReturn(false);
             given(phoneAuthService.isPhoneVerified(NEW_PHONE)).willReturn(true);
             given(userRepository.existsByPhoneNumberHash(newPhoneHash)).willReturn(false);
+            given(myInfoUpdateRequestRepository.save(any(MyInfoUpdateRequest.class)))
+                    .willReturn(MyInfoUpdateRequest.builder().id(99L).build());
 
             // when
             MyInfoResponseDto response = userService.updateMyInfo(userDetails, requestDto);
@@ -247,7 +254,7 @@ class UserServiceTest {
             verify(userRepository).findByEmail(TEST_EMAIL);
             verify(phoneAuthService).isPhoneVerified(NEW_PHONE);
             verify(myInfoUpdateRequestRepository).save(any(MyInfoUpdateRequest.class));
-            verify(notificationService).sendAlertToAdmins(any(), any(), any(), any());
+            verify(notificationService).sendAlertToAdmins(any(), any(), any(), any(Map.class), any());
         }
 
         @Test

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserServiceTest.java
@@ -188,7 +188,8 @@ class UserServiceTest {
 
             verify(userRepository).findByEmail(TEST_EMAIL);
             verify(myInfoUpdateRequestRepository).save(any(MyInfoUpdateRequest.class));
-            verify(notificationService).sendAlertToAdminsRequiringApproval(any(), any(), any(), any(Map.class), any());
+            verify(notificationService)
+                    .sendAlertToAdminsRequiringApproval(any(), any(), any(), any(Map.class), any());
         }
 
         @Test
@@ -221,7 +222,8 @@ class UserServiceTest {
             verify(userRepository).existsByPhoneNumberHash(newPhoneHash);
             verify(myInfoUpdateRequestRepository).save(any(MyInfoUpdateRequest.class));
             verify(phoneAuthService).clearVerification(NEW_PHONE);
-            verify(notificationService).sendAlertToAdminsRequiringApproval(any(), any(), any(), any(Map.class), any());
+            verify(notificationService)
+                    .sendAlertToAdminsRequiringApproval(any(), any(), any(), any(Map.class), any());
         }
 
         @Test
@@ -254,7 +256,8 @@ class UserServiceTest {
             verify(userRepository).findByEmail(TEST_EMAIL);
             verify(phoneAuthService).isPhoneVerified(NEW_PHONE);
             verify(myInfoUpdateRequestRepository).save(any(MyInfoUpdateRequest.class));
-            verify(notificationService).sendAlertToAdminsRequiringApproval(any(), any(), any(), any(Map.class), any());
+            verify(notificationService)
+                    .sendAlertToAdminsRequiringApproval(any(), any(), any(), any(Map.class), any());
         }
 
         @Test

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserServiceTest.java
@@ -188,7 +188,7 @@ class UserServiceTest {
 
             verify(userRepository).findByEmail(TEST_EMAIL);
             verify(myInfoUpdateRequestRepository).save(any(MyInfoUpdateRequest.class));
-            verify(notificationService).sendAlertToAdmins(any(), any(), any(), any(Map.class), any());
+            verify(notificationService).sendAlertToAdminsRequiringApproval(any(), any(), any(), any(Map.class), any());
         }
 
         @Test
@@ -221,7 +221,7 @@ class UserServiceTest {
             verify(userRepository).existsByPhoneNumberHash(newPhoneHash);
             verify(myInfoUpdateRequestRepository).save(any(MyInfoUpdateRequest.class));
             verify(phoneAuthService).clearVerification(NEW_PHONE);
-            verify(notificationService).sendAlertToAdmins(any(), any(), any(), any(Map.class), any());
+            verify(notificationService).sendAlertToAdminsRequiringApproval(any(), any(), any(), any(Map.class), any());
         }
 
         @Test
@@ -254,7 +254,7 @@ class UserServiceTest {
             verify(userRepository).findByEmail(TEST_EMAIL);
             verify(phoneAuthService).isPhoneVerified(NEW_PHONE);
             verify(myInfoUpdateRequestRepository).save(any(MyInfoUpdateRequest.class));
-            verify(notificationService).sendAlertToAdmins(any(), any(), any(), any(Map.class), any());
+            verify(notificationService).sendAlertToAdminsRequiringApproval(any(), any(), any(), any(Map.class), any());
         }
 
         @Test

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
@@ -28,6 +28,7 @@ import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitCategory;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitPurpose;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitStatus;
 import kr.co.awesomelead.groupware_backend.domain.visit.mapper.VisitMapper;
+import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
 import kr.co.awesomelead.groupware_backend.domain.visit.repository.VisitRepository;
 import kr.co.awesomelead.groupware_backend.domain.visit.service.VisitService;
 import kr.co.awesomelead.groupware_backend.global.error.CustomException;
@@ -66,6 +67,7 @@ public class VisitServiceTest {
     @Mock private UserRepository userRepository;
     @Mock private S3Service s3Service;
     @Mock private PasswordEncoder passwordEncoder;
+    @Mock private NotificationService notificationService;
 
     private static final Long HOST_ID = 1L;
     private static final Long VISIT_ID = 100L;

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
+import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Authority;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.JobType;
@@ -28,7 +29,6 @@ import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitCategory;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitPurpose;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitStatus;
 import kr.co.awesomelead.groupware_backend.domain.visit.mapper.VisitMapper;
-import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
 import kr.co.awesomelead.groupware_backend.domain.visit.repository.VisitRepository;
 import kr.co.awesomelead.groupware_backend.domain.visit.service.VisitService;
 import kr.co.awesomelead.groupware_backend.global.error.CustomException;


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #251

## 📝작업 내용

- 알림 엔티티에 `metadata` 필드(TEXT, JSON) 추가 및 JPA 변환기 구현
    - `NotificationMetadataConverter` — `Map<String, Object>` ↔ JSON 직렬화
    - FCM 페이로드에 metadata 포함하여 클라이언트 상세 처리 지원
- 도메인별 metadata 연동 (AUTH, MY_INFO_UPDATE, VISIT, EDUCATION, SAFETY_TRAINING)
- 승인 대기 알림 필터링 기능 추가
    - `requiresApproval TINYINT(1)` 컬럼 추가
    - `GET /api/notifications?pendingApproval=true` 파라미터 추가
    - 해당 알림: VISIT 장기방문, APPROVAL 결재자, MY_INFO_UPDATE 관리자
- 승인/반려 처리 시 `requiresApproval` 자동 해제 (VISIT, APPROVAL, MY_INFO_UPDATE)
- 내 정보 수정 승인/반려 API 식별자 변경
    - `PATCH /users/{userId}/my-info/approve` → `PATCH /my-info/requests/{requestId}/approve`
    - `PATCH /users/{userId}/my-info/reject` → `PATCH /my-info/requests/{requestId}/reject`

## 📸 스크린샷 (선택)

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)

- X