### PR TITLE
fix(254): 권한명/안전교육 응답 조건/비밀번호 찾기 계정검증 플로우 정렬

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/config/SecurityConfig.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/config/SecurityConfig.java
@@ -90,6 +90,7 @@ public class SecurityConfig {
                                         "/api/auth/bootstrap-promote-admin",
                                         "/api/auth/reissue",
                                         "/api/auth/verify-phone-code",
+                                        "/api/auth/verify-account/phone",
                                         "/api/auth/verify-identity",
                                         "/api/auth/verify-email-code",
                                         "/api/auth/send-phone-code",

--- a/src/main/java/kr/co/awesomelead/groupware_backend/config/SecurityConfig.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/config/SecurityConfig.java
@@ -90,6 +90,7 @@ public class SecurityConfig {
                                         "/api/auth/bootstrap-promote-admin",
                                         "/api/auth/reissue",
                                         "/api/auth/verify-phone-code",
+                                        "/api/auth/verify-account/email",
                                         "/api/auth/verify-account/phone",
                                         "/api/auth/verify-identity",
                                         "/api/auth/verify-email-code",

--- a/src/main/java/kr/co/awesomelead/groupware_backend/config/SwaggerConfig.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/config/SwaggerConfig.java
@@ -62,6 +62,7 @@ public class SwaggerConfig {
                     "/api/auth/bootstrap-promote-admin",
                     "/api/auth/reissue",
                     "/api/auth/verify-phone-code",
+                    "/api/auth/verify-account/email",
                     "/api/auth/verify-account/phone",
                     "/api/auth/verify-identity",
                     "/api/auth/verify-email-code",

--- a/src/main/java/kr/co/awesomelead/groupware_backend/config/SwaggerConfig.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/config/SwaggerConfig.java
@@ -62,6 +62,7 @@ public class SwaggerConfig {
                     "/api/auth/bootstrap-promote-admin",
                     "/api/auth/reissue",
                     "/api/auth/verify-phone-code",
+                    "/api/auth/verify-account/phone",
                     "/api/auth/verify-identity",
                     "/api/auth/verify-email-code",
                     "/api/auth/send-phone-code",

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
@@ -803,7 +803,7 @@ public class AdminController {
             summary = "내 정보 수정 요청 승인",
             description =
                     "requestId(MyInfoUpdateRequest PK)로 해당 PENDING 개인정보 수정 요청을 승인하고 실제 사용자 정보에"
-                        + " 반영합니다.")
+                            + " 반영합니다.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
@@ -183,8 +183,8 @@ public class AdminController {
                                             "position": "사원",
                                             "jobType": "관리직",
                                             "authorities": [
-                                              { "code": "ACCESS_MESSAGE", "label": "메세지 작성", "enabled": true },
-                                              { "code": "ACCESS_EDUCATION", "label": "교육 작성", "enabled": false }
+                                              { "code": "SEND_NOTIFICATION", "label": "알림 전송", "enabled": true },
+                                              { "code": "WRITE_DEPARTMENT_EDUCATION", "label": "부서 교육 작성", "enabled": false }
                                             ],
                                             "hireDate": "2025-09-22",
                                             "resignationDate": null,
@@ -380,7 +380,7 @@ public class AdminController {
                                               "departmentName": "경영지원부",
                                               "position": "사원",
                                               "jobType": "관리직",
-                                              "authorities": ["메세지 작성"],
+                                              "authorities": ["알림 전송"],
                                               "hireDate": "2025-09-22",
                                               "resignationDate": null,
                                               "role": "일반 사용자",
@@ -553,7 +553,7 @@ public class AdminController {
                                                           "departmentName": "경영지원부",
                                                           "position": "사원",
                                                           "jobType": "관리직",
-                                                          "authorities": ["메세지 작성"],
+                                                          "authorities": ["알림 전송"],
                                                           "hireDate": "2025-09-22",
                                                           "resignationDate": null,
                                                           "role": "일반 사용자"
@@ -578,11 +578,11 @@ public class AdminController {
                                                           "position": "사원",
                                                           "jobType": "관리직",
                                                           "authorities": [
-                                                            "메세지 작성",
-                                                            "교육 작성",
+                                                            "알림 전송",
+                                                            "부서 교육 작성",
                                                             "공지 작성",
-                                                            "방문자 관리 접근",
-                                                            "사원 데이터 관리"
+                                                            "내방객 관리",
+                                                            "직원 정보 수정"
                                                           ],
                                                           "hireDate": "2025-09-22",
                                                           "resignationDate": null,
@@ -1054,8 +1054,8 @@ public class AdminController {
                                             "position": "사원",
                                             "jobType": "사무직",
                                             "authorities": [
-                                              { "code": "ACCESS_MESSAGE", "label": "메세지 이용", "enabled": false },
-                                              { "code": "ACCESS_EDUCATION", "label": "교육 이용", "enabled": true }
+                                              { "code": "SEND_NOTIFICATION", "label": "알림 전송", "enabled": false },
+                                              { "code": "WRITE_DEPARTMENT_EDUCATION", "label": "부서 교육 작성", "enabled": true }
                                             ],
                                             "hireDate": "2025-09-22",
                                             "resignationDate": null,

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
@@ -148,8 +148,8 @@ public class AdminService {
         } else {
             // 관리직의 경우 기본 권한 부여
             if (requestDto.getJobType() == JobType.MANAGEMENT) {
-                user.addAuthority(Authority.ACCESS_MESSAGE);
-                user.addAuthority(Authority.ACCESS_EDUCATION);
+                user.addAuthority(Authority.SEND_NOTIFICATION);
+                user.addAuthority(Authority.WRITE_DEPARTMENT_EDUCATION);
             }
             // ADMIN 역할인 경우 모든 권한 부여
             if (requestDto.getRole() == Role.ADMIN) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
@@ -52,7 +52,7 @@ public class AnnualLeaveService {
                 userRepository
                         .findById(userId)
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        if (!currentUser.hasAuthority(Authority.MANAGE_EMPLOYEE_DATA)) {
+        if (!currentUser.hasAuthority(Authority.EDIT_EMPLOYEE_INFO)) {
             throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_ANNUAL_LEAVE);
         }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/controller/ApprovalConfigController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/controller/ApprovalConfigController.java
@@ -39,14 +39,14 @@ public class ApprovalConfigController {
             summary = "결재선 설정 저장",
             description =
                     "문서 양식(DocumentType)별 기본 결재자/참조자 ID 목록을 저장합니다. 기존 설정이 있으면 덮어씁니다."
-                            + " `MANAGE_APPROVAL_CONFIG` 권한이 필요합니다.")
+                            + " `MANAGE_APPROVAL_LINE` 권한이 필요합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",
                 description = "저장 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "403",
-                description = "결재 설정 관리 권한 없음")
+                description = "결재선 설정 관리 권한 없음")
     })
     @PostMapping
     public ResponseEntity<ApiResponse<ApprovalConfigResponseDto>> saveConfig(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalConfigService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalConfigService.java
@@ -38,7 +38,7 @@ public class ApprovalConfigService {
                         .findById(userId)
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        if (!user.hasAuthority(Authority.MANAGE_APPROVAL_CONFIG)) {
+        if (!user.hasAuthority(Authority.MANAGE_APPROVAL_LINE)) {
             throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_APPROVAL_CONFIG);
         }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/controller/AuthController.java
@@ -21,9 +21,9 @@ import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.ResetPassword
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.SendAuthCodeRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.SendEmailAuthCodeRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.SignupRequestDto;
-import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.VerifyAuthCodeRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.VerifyAccountByEmailRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.VerifyAccountByPhoneRequestDto;
+import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.VerifyAuthCodeRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.VerifyEmailAuthCodeRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.VerifyIdentityRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.response.AuthTokensDto;
@@ -791,8 +791,7 @@ public class AuthController {
 
     @Operation(
             summary = "이메일 비밀번호 찾기용 계정 검증",
-            description =
-                    "이메일 인증번호 검증 완료 후, 비밀번호 찾기 버튼에서 입력한 이메일 계정 존재 여부를 최종 검증합니다.")
+            description = "이메일 인증번호 검증 완료 후, 비밀번호 찾기 버튼에서 입력한 이메일 계정 존재 여부를 최종 검증합니다.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -872,7 +871,8 @@ public class AuthController {
     @Operation(
             summary = "이메일로 비밀번호 재설정",
             description =
-                    "이메일 계정 검증(`POST /api/auth/verify-account/email`)과 이메일 인증을 완료한 후, 비밀번호를 재설정합니다.")
+                    "이메일 계정 검증(`POST /api/auth/verify-account/email`)과 이메일 인증을 완료한 후, 비밀번호를"
+                        + " 재설정합니다.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -949,8 +949,7 @@ public class AuthController {
 
     @Operation(
             summary = "휴대폰 비밀번호 찾기용 계정 검증",
-            description =
-                    "휴대폰 인증번호 검증 완료 후, 비밀번호 찾기 버튼에서 입력한 이메일/전화번호가 동일 계정인지 최종 검증합니다.")
+            description = "휴대폰 인증번호 검증 완료 후, 비밀번호 찾기 버튼에서 입력한 이메일/전화번호가 동일 계정인지 최종 검증합니다.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -1041,7 +1040,8 @@ public class AuthController {
     @Operation(
             summary = "휴대폰으로 비밀번호 재설정",
             description =
-                    "이메일/전화번호 계정 검증(`POST /api/auth/verify-account/phone`)과 휴대폰 인증을 완료한 후, 비밀번호를 재설정합니다.")
+                    "이메일/전화번호 계정 검증(`POST /api/auth/verify-account/phone`)과 휴대폰 인증을 완료한 후, 비밀번호를"
+                        + " 재설정합니다.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/controller/AuthController.java
@@ -22,6 +22,7 @@ import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.SendAuthCodeR
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.SendEmailAuthCodeRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.SignupRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.VerifyAuthCodeRequestDto;
+import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.VerifyAccountByEmailRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.VerifyAccountByPhoneRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.VerifyEmailAuthCodeRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.VerifyIdentityRequestDto;
@@ -788,7 +789,90 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
-    @Operation(summary = "이메일로 비밀번호 재설정", description = "이메일 인증을 완료한 후, 비밀번호 재설정합니다.")
+    @Operation(
+            summary = "이메일 비밀번호 찾기용 계정 검증",
+            description =
+                    "이메일 인증번호 검증 완료 후, 비밀번호 찾기 버튼에서 입력한 이메일 계정 존재 여부를 최종 검증합니다.")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "계정 검증 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
+                                        {
+                                          "isSuccess": true,
+                                          "code": "COMMON204",
+                                          "message": "계정 검증이 완료되었습니다.",
+                                          "result": null
+                                        }
+                                        """))),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "400",
+                        description = "입력값 검증 실패 또는 이메일 인증 미완료",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples = {
+                                            @ExampleObject(
+                                                    name = "입력값 검증 실패",
+                                                    value =
+                                                            """
+                                                        {
+                                                          "isSuccess": false,
+                                                          "code": "COMMON400",
+                                                          "message": "입력값이 유효하지 않습니다.",
+                                                          "result": {
+                                                            "email": "유효한 이메일 형식이 아닙니다."
+                                                          }
+                                                        }
+                                                        """),
+                                            @ExampleObject(
+                                                    name = "이메일 인증 미완료",
+                                                    value =
+                                                            """
+                                                        {
+                                                          "isSuccess": false,
+                                                          "code": "EMAIL_NOT_VERIFIED",
+                                                          "message": "이메일 인증이 필요합니다.",
+                                                          "result": null
+                                                        }
+                                                        """)
+                                        })),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "404",
+                        description = "사용자를 찾을 수 없음",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
+                                        {
+                                          "isSuccess": false,
+                                          "code": "USER_NOT_FOUND",
+                                          "message": "해당 사용자를 찾을 수 없습니다.",
+                                          "result": null
+                                        }
+                                        """)))
+            })
+    @PostMapping("/verify-account/email")
+    public ResponseEntity<ApiResponse<Void>> verifyAccountByEmail(
+            @Valid @RequestBody VerifyAccountByEmailRequestDto requestDto) {
+        authService.verifyAccountByEmail(requestDto.getEmail());
+        return ResponseEntity.ok(ApiResponse.onNoContent("계정 검증이 완료되었습니다."));
+    }
+
+    @Operation(
+            summary = "이메일로 비밀번호 재설정",
+            description =
+                    "이메일 계정 검증(`POST /api/auth/verify-account/email`)과 이메일 인증을 완료한 후, 비밀번호를 재설정합니다.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/controller/AuthController.java
@@ -22,6 +22,7 @@ import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.SendAuthCodeR
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.SendEmailAuthCodeRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.SignupRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.VerifyAuthCodeRequestDto;
+import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.VerifyAccountByPhoneRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.VerifyEmailAuthCodeRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.VerifyIdentityRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.response.AuthTokensDto;
@@ -862,7 +863,101 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.onNoContent("비밀번호가 성공적으로 재설정되었습니다."));
     }
 
-    @Operation(summary = "휴대폰으로 비밀번호 재설정", description = "이메일과 휴대폰 인증을 완료한 후, 비밀번호를 재설정합니다.")
+    @Operation(
+            summary = "휴대폰 비밀번호 찾기용 계정 검증",
+            description =
+                    "휴대폰 인증번호 검증 완료 후, 비밀번호 찾기 버튼에서 입력한 이메일/전화번호가 동일 계정인지 최종 검증합니다.")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "계정 검증 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
+                                        {
+                                          "isSuccess": true,
+                                          "code": "COMMON204",
+                                          "message": "계정 검증이 완료되었습니다.",
+                                          "result": null
+                                        }
+                                        """))),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "400",
+                        description = "입력값 검증 실패, 전화번호 인증 미완료 또는 전화번호 불일치",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples = {
+                                            @ExampleObject(
+                                                    name = "입력값 검증 실패",
+                                                    value =
+                                                            """
+                                                        {
+                                                          "isSuccess": false,
+                                                          "code": "COMMON400",
+                                                          "message": "입력값이 유효하지 않습니다.",
+                                                          "result": {
+                                                            "email": "유효한 이메일 형식이 아닙니다."
+                                                          }
+                                                        }
+                                                        """),
+                                            @ExampleObject(
+                                                    name = "전화번호 인증 미완료",
+                                                    value =
+                                                            """
+                                                        {
+                                                          "isSuccess": false,
+                                                          "code": "PHONE_NOT_VERIFIED",
+                                                          "message": "전화번호 인증이 필요합니다.",
+                                                          "result": null
+                                                        }
+                                                        """),
+                                            @ExampleObject(
+                                                    name = "전화번호 불일치",
+                                                    value =
+                                                            """
+                                                        {
+                                                          "isSuccess": false,
+                                                          "code": "PHONE_NUMBER_MISMATCH",
+                                                          "message": "입력한 전화번호가 계정의 전화번호와 일치하지 않습니다.",
+                                                          "result": null
+                                                        }
+                                                        """)
+                                        })),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "404",
+                        description = "사용자를 찾을 수 없음",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
+                                        {
+                                          "isSuccess": false,
+                                          "code": "USER_NOT_FOUND",
+                                          "message": "해당 사용자를 찾을 수 없습니다.",
+                                          "result": null
+                                        }
+                                        """)))
+            })
+    @PostMapping("/verify-account/phone")
+    public ResponseEntity<ApiResponse<Void>> verifyAccountByPhone(
+            @Valid @RequestBody VerifyAccountByPhoneRequestDto requestDto) {
+        authService.verifyAccountByPhone(requestDto.getEmail(), requestDto.getPhoneNumber());
+        return ResponseEntity.ok(ApiResponse.onNoContent("계정 검증이 완료되었습니다."));
+    }
+
+    @Operation(
+            summary = "휴대폰으로 비밀번호 재설정",
+            description =
+                    "이메일/전화번호 계정 검증(`POST /api/auth/verify-account/phone`)과 휴대폰 인증을 완료한 후, 비밀번호를 재설정합니다.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -910,17 +1005,6 @@ public class AuthController {
                                                           "isSuccess": false,
                                                           "code": "PHONE_NOT_VERIFIED",
                                                           "message": "전화번호 인증이 필요합니다.",
-                                                          "result": null
-                                                        }
-                                                        """),
-                                            @ExampleObject(
-                                                    name = "전화번호 불일치",
-                                                    value =
-                                                            """
-                                                        {
-                                                          "isSuccess": false,
-                                                          "code": "PHONE_NUMBER_MISMATCH",
-                                                          "message": "입력한 전화번호가 계정의 전화번호와 일치하지 않습니다.",
                                                           "result": null
                                                         }
                                                         """),

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/dto/request/ResetPasswordByPhoneRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/dto/request/ResetPasswordByPhoneRequestDto.java
@@ -20,11 +20,6 @@ public class ResetPasswordByPhoneRequestDto {
     @Email(message = "유효한 이메일 형식이 아닙니다.")
     private String email;
 
-    @Schema(description = "전화번호 ('-' 없이 10~11자리)", example = "01012345678", required = true)
-    @NotBlank(message = "전화번호는 필수입니다.")
-    @Pattern(regexp = "^\\d{10,11}$", message = "전화번호는 '-' 없이 10~11자리 숫자로 입력해주세요.")
-    private String phoneNumber;
-
     @Schema(
             description = "새 비밀번호 (영문, 숫자, 특수문자 포함 8자 이상)",
             example = "newPassword123!",

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/dto/request/VerifyAccountByEmailRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/dto/request/VerifyAccountByEmailRequestDto.java
@@ -1,0 +1,20 @@
+package kr.co.awesomelead.groupware_backend.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Schema(description = "이메일 비밀번호 찾기용 계정 검증 요청")
+public class VerifyAccountByEmailRequestDto {
+
+    @Schema(description = "이메일", example = "test@example.com", required = true)
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "유효한 이메일 형식이 아닙니다.")
+    private String email;
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/dto/request/VerifyAccountByPhoneRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/dto/request/VerifyAccountByPhoneRequestDto.java
@@ -1,0 +1,26 @@
+package kr.co.awesomelead.groupware_backend.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Schema(description = "휴대폰 비밀번호 찾기용 계정 검증 요청")
+public class VerifyAccountByPhoneRequestDto {
+
+    @Schema(description = "이메일", example = "test@example.com", required = true)
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "유효한 이메일 형식이 아닙니다.")
+    private String email;
+
+    @Schema(description = "전화번호 ('-' 없이 10~11자리)", example = "01012345678", required = true)
+    @NotBlank(message = "전화번호는 필수입니다.")
+    @Pattern(regexp = "^\\d{10,11}$", message = "전화번호는 '-' 없이 10~11자리 숫자로 입력해주세요.")
+    private String phoneNumber;
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
@@ -306,6 +306,22 @@ public class AuthService {
         log.info("비밀번호 재설정 완료 (이메일 인증) - 사용자 ID: {}", user.getId());
     }
 
+    public void verifyAccountByPhone(String email, String phoneNumber) {
+        User user =
+                userRepository
+                        .findByEmail(email)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        String phoneNumberHash = User.hashValue(phoneNumber);
+        if (!phoneNumberHash.equals(user.getPhoneNumberHash())) {
+            throw new CustomException(ErrorCode.PHONE_NUMBER_MISMATCH);
+        }
+
+        if (!phoneAuthService.isPhoneVerified(phoneNumber)) {
+            throw new CustomException(ErrorCode.PHONE_NOT_VERIFIED);
+        }
+    }
+
     public void resetPasswordByPhone(ResetPasswordByPhoneRequestDto requestDto) {
 
         // 1. 이메일로 사용자 조회
@@ -314,28 +330,24 @@ public class AuthService {
                         .findByEmail(requestDto.getEmail())
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        // 2. 휴대폰 인증 여부 확인
-        if (!phoneAuthService.isPhoneVerified(requestDto.getPhoneNumber())) {
+        String registeredPhoneNumber = user.getPhoneNumber();
+
+        // 2. 등록된 휴대폰 번호 인증 여부 확인
+        if (!phoneAuthService.isPhoneVerified(registeredPhoneNumber)) {
             throw new CustomException(ErrorCode.PHONE_NOT_VERIFIED);
         }
 
-        // 3. 해시로 전화번호 일치 여부 확인
-        String phoneNumberHash = User.hashValue(requestDto.getPhoneNumber());
-        if (!user.getPhoneNumberHash().equals(phoneNumberHash)) {
-            throw new CustomException(ErrorCode.PHONE_NUMBER_MISMATCH);
-        }
-
-        // 4. 새 비밀번호 일치 확인
+        // 3. 새 비밀번호 일치 확인
         if (!requestDto.getNewPassword().equals(requestDto.getNewPasswordConfirm())) {
             throw new CustomException(ErrorCode.PASSWORD_MISMATCH);
         }
 
-        // 5. 비밀번호 변경
+        // 4. 비밀번호 변경
         user.setPassword(bCryptPasswordEncoder.encode(requestDto.getNewPassword()));
         userRepository.save(user);
 
-        // 6. 인증 플래그 삭제
-        phoneAuthService.clearVerification(requestDto.getPhoneNumber());
+        // 5. 인증 플래그 삭제
+        phoneAuthService.clearVerification(registeredPhoneNumber);
 
         log.info("비밀번호 재설정 완료 (휴대폰 인증) - 사용자 ID: {}, 이메일: {}", user.getId(), user.getEmail());
     }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
@@ -306,6 +306,16 @@ public class AuthService {
         log.info("비밀번호 재설정 완료 (이메일 인증) - 사용자 ID: {}", user.getId());
     }
 
+    public void verifyAccountByEmail(String email) {
+        if (!emailAuthService.isEmailVerified(email)) {
+            throw new CustomException(ErrorCode.EMAIL_NOT_VERIFIED);
+        }
+
+        userRepository
+                .findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
     public void verifyAccountByPhone(String email, String phoneNumber) {
         User user =
                 userRepository

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
@@ -63,9 +63,9 @@ import java.util.List;
     ### API별 권한
     - 생성
       - PSM/안전보건: `WRITE_SAFETY`
-      - 부서교육: `ACCESS_EDUCATION`
+      - 부서교육: `WRITE_DEPARTMENT_EDUCATION`
     - 목록 조회/상세 조회/출석(서명): 로그인 사용자
-    - 부서교육 수정/상태변경/삭제: `ACCESS_EDUCATION`
+    - 부서교육 수정/상태변경/삭제: `WRITE_DEPARTMENT_EDUCATION`
     - 첨부파일 다운로드: 인증 불필요(공개)
 
     ### 교육 유형(EduType)
@@ -279,8 +279,8 @@ public class EduReportController {
 
             - `type` 미지정 시 전체 유형 조회
             - `categoryId`는 PSM/안전보건 카테고리 필터 용도
-            - `departmentName`은 `type=DEPARTMENT` + `ACCESS_EDUCATION` 권한 사용자일 때만 유효
-            - `ACCESS_EDUCATION` 권한이 없는 사용자는 부서교육의 경우 본인 부서 데이터만 조회
+            - `departmentName`은 `type=DEPARTMENT` + `WRITE_DEPARTMENT_EDUCATION` 권한 사용자일 때만 유효
+            - `WRITE_DEPARTMENT_EDUCATION` 권한이 없는 사용자는 부서교육의 경우 본인 부서 데이터만 조회
             """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -371,7 +371,7 @@ public class EduReportController {
                     """
             교육 보고서 상세 정보를 조회합니다.
 
-            - `ACCESS_EDUCATION` 권한 사용자는 `attendees`, `numberOfPeople`, `numberOfAttendees`를 조회할 수 있습니다.
+            - `WRITE_DEPARTMENT_EDUCATION` 권한 사용자는 `attendees`, `numberOfPeople`, `numberOfAttendees`를 조회할 수 있습니다.
             - 일반 사용자는 위 필드가 `null`로 반환됩니다.
             """)
     @ApiResponses({
@@ -423,7 +423,7 @@ public class EduReportController {
                     """
             부서교육(`eduType=부서 교육`)을 수정합니다.
 
-            - `ACCESS_EDUCATION` 권한 필요
+            - `WRITE_DEPARTMENT_EDUCATION` 권한 필요
             - `OPEN` 상태에서만 수정 가능
             - 서명(출석) 완료자가 1명이라도 있으면 수정 불가
             """)
@@ -538,7 +538,7 @@ public class EduReportController {
                     """
             부서교육(`eduType=부서 교육`) 상태를 `OPEN`/`CLOSED`로 변경합니다.
 
-            - `ACCESS_EDUCATION` 권한 필요
+            - `WRITE_DEPARTMENT_EDUCATION` 권한 필요
             - 상태 변경 후 `CLOSED`인 부서교육은 출석(서명)할 수 없습니다.
             """)
     @ApiResponses({
@@ -596,7 +596,7 @@ public class EduReportController {
         return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
     }
 
-    @Operation(summary = "교육 보고서 삭제", description = "교육 보고서를 삭제합니다. `ACCESS_EDUCATION` 권한이 필요합니다.")
+    @Operation(summary = "교육 보고서 삭제", description = "교육 보고서를 삭제합니다. `WRITE_DEPARTMENT_EDUCATION` 권한이 필요합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
@@ -596,7 +596,9 @@ public class EduReportController {
         return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
     }
 
-    @Operation(summary = "교육 보고서 삭제", description = "교육 보고서를 삭제합니다. `WRITE_DEPARTMENT_EDUCATION` 권한이 필요합니다.")
+    @Operation(
+            summary = "교육 보고서 삭제",
+            description = "교육 보고서를 삭제합니다. `WRITE_DEPARTMENT_EDUCATION` 권한이 필요합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportDetailDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportDetailDto.java
@@ -57,13 +57,13 @@ public class EduReportDetailDto {
     @Schema(description = "첨부 파일 목록")
     private List<AttachmentResponse> attachments;
 
-    @Schema(description = "교육 대상 인원 수 (ACCESS_EDUCATION 권한 없으면 null)", example = "50")
+    @Schema(description = "교육 대상 인원 수 (WRITE_DEPARTMENT_EDUCATION 권한 없으면 null)", example = "50")
     private Integer numberOfPeople;
 
-    @Schema(description = "출석 인원 수 (ACCESS_EDUCATION 권한 없으면 null)", example = "45")
+    @Schema(description = "출석 인원 수 (WRITE_DEPARTMENT_EDUCATION 권한 없으면 null)", example = "45")
     private Integer numberOfAttendees;
 
-    @Schema(description = "출석자 목록 (ACCESS_EDUCATION 권한 없으면 null)")
+    @Schema(description = "출석자 목록 (WRITE_DEPARTMENT_EDUCATION 권한 없으면 null)")
     private List<AttendeeInfo> attendees;
 
     @Getter

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/mapper/EduMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/mapper/EduMapper.java
@@ -31,7 +31,7 @@ public interface EduMapper {
     /**
      * EduReport → EduReportDetailDto 변환
      *
-     * @param attendances 출석자 목록 (ACCESS_EDUCATION 권한 없으면 null)
+     * @param attendances 출석자 목록 (WRITE_DEPARTMENT_EDUCATION 권한 없으면 null)
      * @param numberOfPeople 교육 대상 인원 수 (-1L이면 null로 처리)
      */
     @Mapping(target = "attendance", ignore = true)

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
@@ -31,7 +31,7 @@ public class EduReportQueryRepository {
      * @param type 교육 유형 필터 (null 이면 전체)
      * @param dept 부서 필터 엔티티
      * @param userId 출석 여부 서브쿼리에 사용할 현재 사용자 ID
-     * @param hasAccess ACCESS_EDUCATION 권한 보유 여부
+     * @param hasAccess WRITE_DEPARTMENT_EDUCATION 권한 보유 여부
      */
     public List<EduReportSummaryDto> findEduReports(
             EduType type, Department dept, Long categoryId, Long userId, boolean hasAccess) {
@@ -86,7 +86,7 @@ public class EduReportQueryRepository {
      */
     private BooleanExpression deptFilter(EduType type, boolean hasAccess, Department dept) {
         if (hasAccess) {
-            // ACCESS_EDUCATION 권한 있음:
+            // WRITE_DEPARTMENT_EDUCATION 권한 있음:
             // - DEPARTMENT 조회일 때만 departmentName 필터 적용
             // - PSM/SAFETY 조회는 departmentName 무시
             if (type == EduType.DEPARTMENT && dept != null) {
@@ -94,7 +94,7 @@ public class EduReportQueryRepository {
             }
             return null;
         }
-        // ACCESS_EDUCATION 권한 없음: 기존 로직 유지
+        // WRITE_DEPARTMENT_EDUCATION 권한 없음: 기존 로직 유지
         // - DEPARTMENT 타입이 아닌 교육(PSM, SAFETY)은 모두 보임
         // - DEPARTMENT 타입이면 자신의 부서 교육만 보임
         return eduReport.eduType.ne(EduType.DEPARTMENT).or(eduReport.department.eq(dept));

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -155,7 +155,7 @@ public class EduReportService {
             return;
         }
 
-        if (!user.hasAuthority(Authority.ACCESS_EDUCATION)) {
+        if (!user.hasAuthority(Authority.WRITE_DEPARTMENT_EDUCATION)) {
             throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_EDU_REPORT);
         }
     }
@@ -169,7 +169,7 @@ public class EduReportService {
                         .findById(id)
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        boolean hasAccess = user.hasAuthority(Authority.ACCESS_EDUCATION);
+        boolean hasAccess = user.hasAuthority(Authority.WRITE_DEPARTMENT_EDUCATION);
 
         Department dept;
         if (hasAccess) {
@@ -204,13 +204,13 @@ public class EduReportService {
                         .findById(eduReportId)
                         .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
 
-        boolean hasAccess = user.hasAuthority(Authority.ACCESS_EDUCATION);
+        boolean hasAccess = user.hasAuthority(Authority.WRITE_DEPARTMENT_EDUCATION);
 
         List<EduAttendance> attendances = null;
         long numberOfPeople = -1L;
 
         if (hasAccess) {
-            // ACCESS_EDUCATION 권한 있음: 출석자 목록과 통계 포함
+            // WRITE_DEPARTMENT_EDUCATION 권한 있음: 출석자 목록과 통계 포함
             attendances = eduAttendanceRepository.findAllByEduReportIdWithUser(eduReportId);
             numberOfPeople = calculateTargetPeopleCount(report);
         }
@@ -232,7 +232,7 @@ public class EduReportService {
                         .findById(id)
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        if (!user.hasAuthority(Authority.ACCESS_EDUCATION)) {
+        if (!user.hasAuthority(Authority.WRITE_DEPARTMENT_EDUCATION)) {
             throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_EDU_REPORT);
         }
 
@@ -396,7 +396,7 @@ public class EduReportService {
     }
 
     private void validateDepartmentManageAuthority(User user) {
-        if (!user.hasAuthority(Authority.ACCESS_EDUCATION)) {
+        if (!user.hasAuthority(Authority.WRITE_DEPARTMENT_EDUCATION)) {
             throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_EDU_REPORT);
         }
     }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/repository/NotificationRepository.java
@@ -24,7 +24,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Modifying
     @Query(
             "UPDATE Notification n SET n.requiresApproval = false WHERE n.domainType = :domainType"
-                + " AND n.domainId = :domainId AND n.requiresApproval = true")
+                    + " AND n.domainId = :domainId AND n.requiresApproval = true")
     void resolveRequiresApprovalByDomainTypeAndDomainId(
             @Param("domainType") NotificationDomainType domainType,
             @Param("domainId") Long domainId);

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/service/PayslipService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/service/PayslipService.java
@@ -48,7 +48,7 @@ public class PayslipService {
                 userRepository
                         .findById(userId)
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        if (!user.hasAuthority(Authority.MANAGE_EMPLOYEE_DATA)) {
+        if (!user.hasAuthority(Authority.EDIT_EMPLOYEE_INFO)) {
             throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_PAYSLIP);
         }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/controller/SafetyTrainingSessionController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/controller/SafetyTrainingSessionController.java
@@ -127,7 +127,8 @@ public class SafetyTrainingSessionController {
 
     @Operation(
             summary = "안전보건 교육 세션 상세 조회",
-            description = "제목, 교육 정보, 보고서 파일 URL, 내 수료/미수료 및 서명 가능 여부를 조회합니다.")
+            description =
+                    "제목, 교육 정보(실시자 이름/직급/부서 포함), 보고서 파일 URL, 내 수료/미수료 및 서명 가능 여부를 조회합니다.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/controller/SafetyTrainingSessionController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/controller/SafetyTrainingSessionController.java
@@ -127,8 +127,7 @@ public class SafetyTrainingSessionController {
 
     @Operation(
             summary = "안전보건 교육 세션 상세 조회",
-            description =
-                    "제목, 교육 정보(실시자 이름/직급/부서 포함), 보고서 파일 URL, 내 수료/미수료 및 서명 가능 여부를 조회합니다.")
+            description = "제목, 교육 정보(실시자 이름/직급/부서 포함), 보고서 파일 URL, 내 수료/미수료 및 서명 가능 여부를 조회합니다.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingSessionDetailResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingSessionDetailResponseDto.java
@@ -57,6 +57,9 @@ public class SafetyTrainingSessionDetailResponseDto {
     @Schema(description = "교육 실시자 직급", example = "대리")
     private Position instructorPosition;
 
+    @Schema(description = "교육 실시자 부서명", example = "경영지원부")
+    private String instructorDepartmentName;
+
     @Schema(description = "교육 내용", example = "개인정보 보호 및 사내 보안 규정 안내")
     private String educationContent;
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingSessionSummaryResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingSessionSummaryResponseDto.java
@@ -55,10 +55,7 @@ public class SafetyTrainingSessionSummaryResponseDto {
     @Schema(description = "미참석 인원 수", example = "9")
     private int absentCount;
 
-    @Schema(
-            description =
-                    "현재 로그인 사용자의 서명 완료 여부 (대표이사/마스터 관리자/타회사 세션은 null)",
-            example = "true")
+    @Schema(description = "현재 로그인 사용자의 서명 완료 여부 (대표이사/마스터 관리자/타회사 세션은 null)", example = "true")
     private Boolean mySigned;
 
     @Schema(description = "생성 시각", example = "2026-03-24T11:00:00")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingSessionSummaryResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingSessionSummaryResponseDto.java
@@ -55,8 +55,11 @@ public class SafetyTrainingSessionSummaryResponseDto {
     @Schema(description = "미참석 인원 수", example = "9")
     private int absentCount;
 
-    @Schema(description = "현재 로그인 사용자의 서명 완료 여부", example = "true")
-    private boolean mySigned;
+    @Schema(
+            description =
+                    "현재 로그인 사용자의 서명 완료 여부 (대표이사/마스터 관리자/타회사 세션은 null)",
+            example = "true")
+    private Boolean mySigned;
 
     @Schema(description = "생성 시각", example = "2026-03-24T11:00:00")
     private LocalDateTime createdAt;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
@@ -196,7 +196,7 @@ public class SafetyTrainingSessionService {
         List<Long> sessionIds =
                 sessionsPage.getContent().stream().map(SafetyTrainingSession::getId).toList();
         Set<Long> signedSessionIds = Collections.emptySet();
-        if (!sessionIds.isEmpty()) {
+        if (!sessionIds.isEmpty() && canExposeMySigned(actor)) {
             signedSessionIds =
                     new HashSet<>(
                             attendeeRepository.findSignedSessionIdsByUserIdAndSessionIds(
@@ -205,7 +205,13 @@ public class SafetyTrainingSessionService {
 
         Set<Long> finalSignedSessionIds = signedSessionIds;
         return sessionsPage.map(
-                session -> toSummaryDto(session, finalSignedSessionIds.contains(session.getId())));
+                session ->
+                        toSummaryDto(
+                                session,
+                                resolveMySigned(
+                                        actor,
+                                        session,
+                                        finalSignedSessionIds.contains(session.getId()))));
     }
 
     @Transactional(readOnly = true)
@@ -818,6 +824,21 @@ public class SafetyTrainingSessionService {
                 && myStatus != SafetyTrainingAttendeeStatus.SIGNED;
     }
 
+    private boolean canExposeMySigned(User actor) {
+        return actor.getPosition() != Position.CEO && actor.getRole() != Role.MASTER_ADMIN;
+    }
+
+    private Boolean resolveMySigned(User actor, SafetyTrainingSession session, boolean signed) {
+        if (!canExposeMySigned(actor)) {
+            return null;
+        }
+        if (actor.getWorkLocation() == null
+                || actor.getWorkLocation() != session.getCompanyScope()) {
+            return null;
+        }
+        return signed;
+    }
+
     private List<SafetyEducationMethod> toMethods(String educationMethodsJson) {
         if (educationMethodsJson == null || educationMethodsJson.isBlank()) {
             return Collections.emptyList();
@@ -862,7 +883,7 @@ public class SafetyTrainingSessionService {
     }
 
     private SafetyTrainingSessionSummaryResponseDto toSummaryDto(
-            SafetyTrainingSession session, boolean mySigned) {
+            SafetyTrainingSession session, Boolean mySigned) {
         return SafetyTrainingSessionSummaryResponseDto.builder()
                 .sessionId(session.getId())
                 .title(session.getTitle())

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
@@ -24,6 +24,7 @@ import kr.co.awesomelead.groupware_backend.domain.safetytraining.repository.Safe
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Authority;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
 import kr.co.awesomelead.groupware_backend.global.error.CustomException;
@@ -287,9 +288,7 @@ public class SafetyTrainingSessionService {
                         attendee.getSignatureKey() == null
                                 ? null
                                 : s3Service.getPresignedViewUrl(attendee.getSignatureKey()))
-                .canSign(
-                        session.getStatus() == SafetyTrainingSessionStatus.OPEN
-                                && myStatus != SafetyTrainingAttendeeStatus.SIGNED)
+                .canSign(canSignSession(actor, session, myStatus))
                 .build();
     }
 
@@ -802,6 +801,21 @@ public class SafetyTrainingSessionService {
                 || actor.getWorkLocation() != session.getCompanyScope()) {
             throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_SAFETY_READ);
         }
+    }
+
+    private boolean canSignSession(
+            User actor, SafetyTrainingSession session, SafetyTrainingAttendeeStatus myStatus) {
+        if (actor.getPosition() == Position.CEO || actor.getRole() == Role.MASTER_ADMIN) {
+            return false;
+        }
+
+        if (actor.getWorkLocation() == null
+                || actor.getWorkLocation() != session.getCompanyScope()) {
+            return false;
+        }
+
+        return session.getStatus() == SafetyTrainingSessionStatus.OPEN
+                && myStatus != SafetyTrainingAttendeeStatus.SIGNED;
     }
 
     private List<SafetyEducationMethod> toMethods(String educationMethodsJson) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
@@ -264,6 +264,16 @@ public class SafetyTrainingSessionService {
                         session.getInstructorUser() == null
                                 ? null
                                 : session.getInstructorUser().getPosition())
+                .instructorDepartmentName(
+                        session.getInstructorUser() == null
+                                        || session.getInstructorUser().getDepartment() == null
+                                        || session.getInstructorUser().getDepartment().getName()
+                                                == null
+                                ? null
+                                : session.getInstructorUser()
+                                        .getDepartment()
+                                        .getName()
+                                        .getDescription())
                 .educationContent(session.getEducationContent())
                 .targetCount(session.getTargetCount())
                 .attendedCount(session.getAttendedCount())

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/controller/UserController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/controller/UserController.java
@@ -78,10 +78,12 @@ import org.springframework.web.bind.annotation.RestController;
               - SUSPENDED: 비활성
 
             - **Authority**: 권한
-              - WRITE_MESSAGE: 메세지 작성 권한 -> jobType이 관리직일 경우 부여하고 시작
-              - WRITE_EDUCATION: 교육 작성 권한 -> jobType이 관리직일 경우 부여하고 시작
-              - WRITE_NOTICE: 공지 작성 권한
-              - UPLOAD_ANNUAL_LEAVE: 연차 업로드 권한
+              - SEND_NOTIFICATION: 알림 전송 권한 -> jobType이 관리직일 경우 부여하고 시작
+              - WRITE_DEPARTMENT_EDUCATION: 부서 교육 작성 -> jobType이 관리직일 경우 부여하고 시작
+              - ACCESS_NOTICE: 공지 작성 권한
+              - MANAGE_VISITOR: 내방객 관리 권한
+              - EDIT_EMPLOYEE_INFO: 직원 정보 수정 권한
+              - MANAGE_APPROVAL_LINE: 결재선 설정 관리 권한
             """)
 @RestController
 @RequestMapping("/api/users")
@@ -193,11 +195,11 @@ public class UserController {
                                                                              "jobType": "관리직",
                                                                              "role": "일반 사용자",
                                                                              "authorities": [
-                                                                               { "code": "ACCESS_MESSAGE", "label": "메세지 작성", "enabled": true },
-                                                                               { "code": "ACCESS_EDUCATION", "label": "교육 작성", "enabled": false },
+                                                                               { "code": "SEND_NOTIFICATION", "label": "알림 전송", "enabled": true },
+                                                                               { "code": "WRITE_DEPARTMENT_EDUCATION", "label": "부서 교육 작성", "enabled": false },
                                                                                { "code": "ACCESS_NOTICE", "label": "공지 작성", "enabled": false },
-                                                                               { "code": "ACCESS_VISIT", "label": "방문자 관리 접근", "enabled": false },
-                                                                               { "code": "MANAGE_EMPLOYEE_DATA", "label": "사원 데이터 관리", "enabled": false }
+                                                                               { "code": "MANAGE_VISITOR", "label": "내방객 관리", "enabled": false },
+                                                                               { "code": "EDIT_EMPLOYEE_INFO", "label": "직원 정보 수정", "enabled": false }
                                                                              ],
                                                                              "hireDate": "2024-03-01",
                                                                              "resignationDate": null

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/dto/response/MyInfoAuthorityItemDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/dto/response/MyInfoAuthorityItemDto.java
@@ -13,10 +13,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class MyInfoAuthorityItemDto {
 
-    @Schema(description = "권한 코드", example = "ACCESS_MESSAGE")
+    @Schema(description = "권한 코드", example = "SEND_NOTIFICATION")
     private String code;
 
-    @Schema(description = "권한 라벨", example = "메세지 작성")
+    @Schema(description = "권한 라벨", example = "알림 전송")
     private String label;
 
     @Schema(description = "보유 여부", example = "true")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/enums/Authority.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/enums/Authority.java
@@ -9,16 +9,16 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum Authority {
     // 전체 권한은 ADMIN으로 변경할 때, 자동 부여
-    ACCESS_MESSAGE("메세지 작성"), // jobType이 관리직일 경우 부여하고 시작
-    ACCESS_EDUCATION("교육 작성"), // jobType이 관리직일 경우 부여하고 시작
+    SEND_NOTIFICATION("알림 전송"), // jobType이 관리직일 경우 부여하고 시작
+    WRITE_DEPARTMENT_EDUCATION("부서 교육 작성"), // jobType이 관리직일 경우 부여하고 시작
     WRITE_SAFETY("PSM/안전보건 작성"),
     ACCESS_NOTICE("공지 작성"),
 
-    ACCESS_VISIT("방문자 관리 접근"),
+    MANAGE_VISITOR("내방객 관리"),
 
-    MANAGE_EMPLOYEE_DATA("사원 데이터 관리"), // 연차, 급여명세서, 근태확인표 발송 권한
+    EDIT_EMPLOYEE_INFO("직원 정보 수정"), // 연차, 급여명세서, 근태확인표 발송 권한
     MANAGE_CERTIFICATE_REQUEST("제증명 신청 승인/반려"),
-    MANAGE_APPROVAL_CONFIG("결재 설정 관리");
+    MANAGE_APPROVAL_LINE("결재선 설정 관리");
 
     private final String description;
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
@@ -464,7 +464,8 @@ public class VisitService {
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // MANAGEMENT 직군이고 방문 관리 권한이 있는지 확인
-        if (user.getJobType() != JobType.MANAGEMENT || !user.hasAuthority(Authority.MANAGE_VISITOR)) {
+        if (user.getJobType() != JobType.MANAGEMENT
+                || !user.hasAuthority(Authority.MANAGE_VISITOR)) {
             throw new CustomException(ErrorCode.VISIT_ACCESS_DENIED);
         }
     }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
@@ -464,7 +464,7 @@ public class VisitService {
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // MANAGEMENT 직군이고 방문 관리 권한이 있는지 확인
-        if (user.getJobType() != JobType.MANAGEMENT || !user.hasAuthority(Authority.ACCESS_VISIT)) {
+        if (user.getJobType() != JobType.MANAGEMENT || !user.hasAuthority(Authority.MANAGE_VISITOR)) {
             throw new CustomException(ErrorCode.VISIT_ACCESS_DENIED);
         }
     }
@@ -472,7 +472,7 @@ public class VisitService {
     // 직원용 사전 장기방문 승인 및 반려
     @Transactional
     public void processVisit(Long userId, Long visitId, VisitProcessRequestDto dto) {
-        // 1. 관리 권한 확인 (MANAGEMENT 직군 & ACCESS_VISIT 권한)
+        // 1. 관리 권한 확인 (MANAGEMENT 직군 & MANAGE_VISITOR 권한)
         validateAdminAuthority(userId);
 
         // 2. 방문 신청 건 조회

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
@@ -99,7 +99,7 @@ public enum ErrorCode {
     NO_AUTHORITY_FOR_NOTIFICATION(HttpStatus.FORBIDDEN, "해당 알림에 대한 접근 권한이 없습니다."),
     NO_AUTHORITY_FOR_CERTIFICATE_REQUEST_REVIEW(HttpStatus.FORBIDDEN, "제증명 신청 승인/반려 권한이 없습니다."),
     NO_AUTHORITY_FOR_EDUCATION_CATEGORY_MANAGE(HttpStatus.FORBIDDEN, "교육 카테고리 관리 권한이 없습니다."),
-    NO_AUTHORITY_FOR_APPROVAL_CONFIG(HttpStatus.FORBIDDEN, "결재 설정 관리 권한이 없습니다."),
+    NO_AUTHORITY_FOR_APPROVAL_CONFIG(HttpStatus.FORBIDDEN, "결재선 설정 관리 권한이 없습니다."),
 
     // 404 Not Found
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
@@ -534,7 +534,8 @@ class AdminServiceTest {
             User targetUser = User.builder().id(userId).role(Role.USER).build();
             when(userRepository.findById(userId)).thenReturn(Optional.of(targetUser));
 
-            List<Authority> authorities = List.of(Authority.ACCESS_NOTICE, Authority.MANAGE_VISITOR);
+            List<Authority> authorities =
+                    List.of(Authority.ACCESS_NOTICE, Authority.MANAGE_VISITOR);
 
             // when
             adminService.updateUserAuthority(userId, authorities, AuthorityAction.ADD, adminId);
@@ -554,7 +555,8 @@ class AdminServiceTest {
             targetUser.addAuthority(Authority.MANAGE_VISITOR);
             when(userRepository.findById(userId)).thenReturn(Optional.of(targetUser));
 
-            List<Authority> authorities = List.of(Authority.ACCESS_NOTICE, Authority.MANAGE_VISITOR);
+            List<Authority> authorities =
+                    List.of(Authority.ACCESS_NOTICE, Authority.MANAGE_VISITOR);
 
             // when
             adminService.updateUserAuthority(userId, authorities, AuthorityAction.REMOVE, adminId);

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
@@ -414,7 +414,7 @@ class AdminServiceTest {
             dto.setPosition(Position.STAFF);
             dto.setJobType(JobType.MANAGEMENT);
             dto.setRole(Role.USER);
-            dto.setAuthorities(List.of(Authority.ACCESS_MESSAGE));
+            dto.setAuthorities(List.of(Authority.SEND_NOTIFICATION));
 
             // when
             adminService.updateUserInfo(17L, dto, adminId);
@@ -424,7 +424,7 @@ class AdminServiceTest {
             assertThat(targetUser.getPhoneNumber()).isEqualTo("01099998888");
             assertThat(targetUser.getDepartment().getId()).isEqualTo(11L);
             assertThat(targetUser.getWorkLocation()).isEqualTo(Company.AWESOME);
-            assertThat(targetUser.hasAuthority(Authority.ACCESS_MESSAGE)).isEqualTo(true);
+            assertThat(targetUser.hasAuthority(Authority.SEND_NOTIFICATION)).isEqualTo(true);
             verify(phoneAuthService).clearVerification("01099998888");
             verify(userRepository).save(targetUser);
         }
@@ -480,7 +480,7 @@ class AdminServiceTest {
                 // then
                 assertThat(user.getRole()).isEqualTo(Role.ADMIN);
                 assertThat(user.hasAuthority(Authority.ACCESS_NOTICE)).isEqualTo(true);
-                assertThat(user.hasAuthority(Authority.MANAGE_EMPLOYEE_DATA)).isEqualTo(true);
+                assertThat(user.hasAuthority(Authority.EDIT_EMPLOYEE_INFO)).isEqualTo(true);
             }
         }
 
@@ -534,14 +534,14 @@ class AdminServiceTest {
             User targetUser = User.builder().id(userId).role(Role.USER).build();
             when(userRepository.findById(userId)).thenReturn(Optional.of(targetUser));
 
-            List<Authority> authorities = List.of(Authority.ACCESS_NOTICE, Authority.ACCESS_VISIT);
+            List<Authority> authorities = List.of(Authority.ACCESS_NOTICE, Authority.MANAGE_VISITOR);
 
             // when
             adminService.updateUserAuthority(userId, authorities, AuthorityAction.ADD, adminId);
 
             // then
             assertThat(targetUser.hasAuthority(Authority.ACCESS_NOTICE)).isEqualTo(true);
-            assertThat(targetUser.hasAuthority(Authority.ACCESS_VISIT)).isEqualTo(true);
+            assertThat(targetUser.hasAuthority(Authority.MANAGE_VISITOR)).isEqualTo(true);
             verify(userRepository).save(targetUser);
         }
 
@@ -551,17 +551,17 @@ class AdminServiceTest {
             // given
             User targetUser = User.builder().id(userId).role(Role.USER).build();
             targetUser.addAuthority(Authority.ACCESS_NOTICE);
-            targetUser.addAuthority(Authority.ACCESS_VISIT);
+            targetUser.addAuthority(Authority.MANAGE_VISITOR);
             when(userRepository.findById(userId)).thenReturn(Optional.of(targetUser));
 
-            List<Authority> authorities = List.of(Authority.ACCESS_NOTICE, Authority.ACCESS_VISIT);
+            List<Authority> authorities = List.of(Authority.ACCESS_NOTICE, Authority.MANAGE_VISITOR);
 
             // when
             adminService.updateUserAuthority(userId, authorities, AuthorityAction.REMOVE, adminId);
 
             // then
             assertThat(targetUser.hasAuthority(Authority.ACCESS_NOTICE)).isEqualTo(false);
-            assertThat(targetUser.hasAuthority(Authority.ACCESS_VISIT)).isEqualTo(false);
+            assertThat(targetUser.hasAuthority(Authority.MANAGE_VISITOR)).isEqualTo(false);
             verify(userRepository).save(targetUser);
         }
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
@@ -85,7 +85,7 @@ public class AnnualLeaveServiceTest {
             @DisplayName("데이터를 파싱하여 저장하고 성공 결과를 반환한다")
             void it_returns_success_response() throws IOException {
                 // given
-                User admin = createMockUser(Authority.MANAGE_EMPLOYEE_DATA); // 연차 발송 권한 추가
+                User admin = createMockUser(Authority.EDIT_EMPLOYEE_INFO); // 연차 발송 권한 추가
                 given(userRepository.findById(loginUserId)).willReturn(Optional.of(admin));
 
                 MultipartFile mockFile = createMockExcelFile();
@@ -121,7 +121,7 @@ public class AnnualLeaveServiceTest {
             void it_throws_exception_and_stops_everything() throws IOException {
                 // given: 날짜 칸에 "날짜없음" 이라고 적힌 잘못된 엑셀 파일 준비
                 MultipartFile invalidFile = createMockExcelFileWithWrongDateFormat();
-                User admin = createMockUser(Authority.MANAGE_EMPLOYEE_DATA);
+                User admin = createMockUser(Authority.EDIT_EMPLOYEE_INFO);
                 given(userRepository.findById(loginUserId)).willReturn(Optional.of(admin));
 
                 // when & then
@@ -144,7 +144,7 @@ public class AnnualLeaveServiceTest {
             void it_adds_to_failures() throws IOException {
                 // given
                 given(userRepository.findById(loginUserId))
-                        .willReturn(Optional.of(createMockUser(Authority.MANAGE_EMPLOYEE_DATA)));
+                        .willReturn(Optional.of(createMockUser(Authority.EDIT_EMPLOYEE_INFO)));
                 given(userRepository.findByNameAndJoinDate(anyString(), any()))
                         .willReturn(Optional.empty()); // 유저 못 찾음
 
@@ -171,7 +171,7 @@ public class AnnualLeaveServiceTest {
                 // given
                 MultipartFile mockFile = org.mockito.Mockito.mock(MultipartFile.class);
 
-                User admin = createMockUser(Authority.MANAGE_EMPLOYEE_DATA);
+                User admin = createMockUser(Authority.EDIT_EMPLOYEE_INFO);
                 given(userRepository.findById(loginUserId)).willReturn(Optional.of(admin));
 
                 given(mockFile.getInputStream()).willThrow(new IOException("강제 발생 에러"));

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/approval/ApprovalConfigServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/approval/ApprovalConfigServiceTest.java
@@ -49,7 +49,7 @@ class ApprovalConfigServiceTest {
     @BeforeEach
     void setUp() {
         adminUser = User.builder().id(ADMIN_ID).build();
-        adminUser.addAuthority(Authority.MANAGE_APPROVAL_CONFIG);
+        adminUser.addAuthority(Authority.MANAGE_APPROVAL_LINE);
 
         normalUser = User.builder().id(2L).build();
     }
@@ -130,7 +130,7 @@ class ApprovalConfigServiceTest {
         class FailureCases {
 
             @Test
-            @DisplayName("MANAGE_APPROVAL_CONFIG 권한이 없으면 403 예외가 발생한다")
+            @DisplayName("MANAGE_APPROVAL_LINE 권한이 없으면 403 예외가 발생한다")
             void saveConfig_withoutAuthority_throwsForbidden() {
                 ApprovalConfigSaveRequestDto request = new ApprovalConfigSaveRequestDto();
                 request.setDocumentType(DocumentType.BASIC);

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
@@ -102,7 +102,7 @@ class AuthServiceTest {
         loginRequestDto.setEmail(TEST_EMAIL);
         loginRequestDto.setPassword(OLD_PASSWORD);
 
-        testUser.addAuthority(Authority.ACCESS_EDUCATION);
+        testUser.addAuthority(Authority.WRITE_DEPARTMENT_EDUCATION);
 
         Authentication authentication = org.mockito.Mockito.mock(Authentication.class);
         org.springframework.security.core.GrantedAuthority grantedAuthority = () -> "ROLE_USER";
@@ -127,8 +127,8 @@ class AuthServiceTest {
         assertThat(response.getAuthorities().size()).isEqualTo(1);
 
         MyInfoAuthorityItemDto authorityDto = response.getAuthorities().get(0);
-        assertThat(authorityDto.getCode()).isEqualTo(Authority.ACCESS_EDUCATION.name());
-        assertThat(authorityDto.getLabel()).isEqualTo(Authority.ACCESS_EDUCATION.getDescription());
+        assertThat(authorityDto.getCode()).isEqualTo(Authority.WRITE_DEPARTMENT_EDUCATION.name());
+        assertThat(authorityDto.getLabel()).isEqualTo(Authority.WRITE_DEPARTMENT_EDUCATION.getDescription());
         assertThat(authorityDto.isEnabled()).isTrue();
     }
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
@@ -426,7 +426,6 @@ class AuthServiceTest {
         void setUp() {
             requestDto = new ResetPasswordByPhoneRequestDto();
             requestDto.setEmail(TEST_EMAIL);
-            requestDto.setPhoneNumber(TEST_PHONE);
             requestDto.setNewPassword(NEW_PASSWORD);
             requestDto.setNewPasswordConfirm(NEW_PASSWORD);
         }
@@ -435,9 +434,6 @@ class AuthServiceTest {
         @DisplayName("성공: 휴대폰 인증 후 비밀번호가 정상적으로 재설정된다")
         void resetPasswordByPhone_Success() {
             // given
-            String phoneHash = User.hashValue(TEST_PHONE);
-            testUser.setPhoneNumberHash(phoneHash); // 테스트 유저의 전화번호 해시 설정
-
             given(userRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.of(testUser));
             given(phoneAuthService.isPhoneVerified(TEST_PHONE)).willReturn(true);
             given(bCryptPasswordEncoder.encode(NEW_PASSWORD)).willReturn(ENCODED_NEW_PASSWORD);
@@ -488,32 +484,9 @@ class AuthServiceTest {
         }
 
         @Test
-        @DisplayName("실패: 전화번호가 계정과 일치하지 않는 경우")
-        void resetPasswordByPhone_PhoneNumberMismatch() {
-            // given
-            String differentPhoneHash = User.hashValue("01099999999"); // 다른 전화번호
-            testUser.setPhoneNumberHash(differentPhoneHash);
-
-            given(userRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.of(testUser));
-            given(phoneAuthService.isPhoneVerified(TEST_PHONE)).willReturn(true);
-
-            // when & then
-            assertThatThrownBy(() -> authService.resetPasswordByPhone(requestDto))
-                    .isInstanceOf(CustomException.class)
-                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PHONE_NUMBER_MISMATCH);
-
-            verify(userRepository).findByEmail(TEST_EMAIL);
-            verify(phoneAuthService).isPhoneVerified(TEST_PHONE);
-            verify(userRepository, never()).save(any());
-            verify(phoneAuthService, never()).clearVerification(anyString());
-        }
-
-        @Test
         @DisplayName("실패: 비밀번호 확인이 일치하지 않는 경우")
         void resetPasswordByPhone_PasswordMismatch() {
             // given
-            String phoneHash = User.hashValue(TEST_PHONE);
-            testUser.setPhoneNumberHash(phoneHash);
             requestDto.setNewPasswordConfirm("differentPassword!@#");
 
             given(userRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.of(testUser));
@@ -528,6 +501,74 @@ class AuthServiceTest {
             verify(phoneAuthService).isPhoneVerified(TEST_PHONE);
             verify(userRepository, never()).save(any());
             verify(phoneAuthService, never()).clearVerification(anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("휴대폰 비밀번호 찾기 계정 검증")
+    class VerifyAccountByPhoneTest {
+
+        @Test
+        @DisplayName("성공: 이메일과 전화번호가 동일 계정과 일치하면 통과한다")
+        void verifyAccountByPhone_Success() {
+            // given
+            testUser.setPhoneNumberHash(User.hashValue(TEST_PHONE));
+            given(userRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.of(testUser));
+            given(phoneAuthService.isPhoneVerified(TEST_PHONE)).willReturn(true);
+
+            // when
+            authService.verifyAccountByPhone(TEST_EMAIL, TEST_PHONE);
+
+            // then
+            verify(userRepository).findByEmail(TEST_EMAIL);
+            verify(phoneAuthService).isPhoneVerified(TEST_PHONE);
+        }
+
+        @Test
+        @DisplayName("실패: 이메일이 존재하지 않으면 USER_NOT_FOUND")
+        void verifyAccountByPhone_UserNotFound() {
+            // given
+            given(userRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> authService.verifyAccountByPhone(TEST_EMAIL, TEST_PHONE))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+
+            verify(userRepository).findByEmail(TEST_EMAIL);
+        }
+
+        @Test
+        @DisplayName("실패: 전화번호가 계정과 다르면 PHONE_NUMBER_MISMATCH")
+        void verifyAccountByPhone_PhoneNumberMismatch() {
+            // given
+            testUser.setPhoneNumberHash(User.hashValue("01099999999"));
+            given(userRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.of(testUser));
+
+            // when & then
+            assertThatThrownBy(() -> authService.verifyAccountByPhone(TEST_EMAIL, TEST_PHONE))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PHONE_NUMBER_MISMATCH);
+
+            verify(userRepository).findByEmail(TEST_EMAIL);
+            verify(phoneAuthService, never()).isPhoneVerified(anyString());
+        }
+
+        @Test
+        @DisplayName("실패: 전화번호 인증이 완료되지 않으면 PHONE_NOT_VERIFIED")
+        void verifyAccountByPhone_NotVerified() {
+            // given
+            testUser.setPhoneNumberHash(User.hashValue(TEST_PHONE));
+            given(userRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.of(testUser));
+            given(phoneAuthService.isPhoneVerified(TEST_PHONE)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> authService.verifyAccountByPhone(TEST_EMAIL, TEST_PHONE))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PHONE_NOT_VERIFIED);
+
+            verify(userRepository).findByEmail(TEST_EMAIL);
+            verify(phoneAuthService).isPhoneVerified(TEST_PHONE);
         }
     }
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
@@ -128,7 +128,8 @@ class AuthServiceTest {
 
         MyInfoAuthorityItemDto authorityDto = response.getAuthorities().get(0);
         assertThat(authorityDto.getCode()).isEqualTo(Authority.WRITE_DEPARTMENT_EDUCATION.name());
-        assertThat(authorityDto.getLabel()).isEqualTo(Authority.WRITE_DEPARTMENT_EDUCATION.getDescription());
+        assertThat(authorityDto.getLabel())
+                .isEqualTo(Authority.WRITE_DEPARTMENT_EDUCATION.getDescription());
         assertThat(authorityDto.isEnabled()).isTrue();
     }
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
@@ -417,6 +417,57 @@ class AuthServiceTest {
     }
 
     @Nested
+    @DisplayName("이메일 비밀번호 찾기 계정 검증")
+    class VerifyAccountByEmailTest {
+
+        @Test
+        @DisplayName("성공: 이메일 인증 완료 및 계정 존재 시 통과한다")
+        void verifyAccountByEmail_Success() {
+            // given
+            given(emailAuthService.isEmailVerified(TEST_EMAIL)).willReturn(true);
+            given(userRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.verifyAccountByEmail(TEST_EMAIL);
+
+            // then
+            verify(emailAuthService).isEmailVerified(TEST_EMAIL);
+            verify(userRepository).findByEmail(TEST_EMAIL);
+        }
+
+        @Test
+        @DisplayName("실패: 이메일 인증이 완료되지 않으면 EMAIL_NOT_VERIFIED")
+        void verifyAccountByEmail_NotVerified() {
+            // given
+            given(emailAuthService.isEmailVerified(TEST_EMAIL)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> authService.verifyAccountByEmail(TEST_EMAIL))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.EMAIL_NOT_VERIFIED);
+
+            verify(emailAuthService).isEmailVerified(TEST_EMAIL);
+            verify(userRepository, never()).findByEmail(anyString());
+        }
+
+        @Test
+        @DisplayName("실패: 이메일 계정이 존재하지 않으면 USER_NOT_FOUND")
+        void verifyAccountByEmail_UserNotFound() {
+            // given
+            given(emailAuthService.isEmailVerified(TEST_EMAIL)).willReturn(true);
+            given(userRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> authService.verifyAccountByEmail(TEST_EMAIL))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+
+            verify(emailAuthService).isEmailVerified(TEST_EMAIL);
+            verify(userRepository).findByEmail(TEST_EMAIL);
+        }
+    }
+
+    @Nested
     @DisplayName("휴대폰 인증 후 비밀번호 재설정")
     class ResetPasswordByPhoneTest {
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
@@ -248,7 +248,7 @@ public class EduReportServiceTest {
                         .build();
 
         User user = createNormalUser();
-        user.addAuthority(Authority.ACCESS_EDUCATION);
+        user.addAuthority(Authority.WRITE_DEPARTMENT_EDUCATION);
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
         when(departmentRepository.findById(999L)).thenReturn(Optional.empty());
@@ -266,7 +266,7 @@ public class EduReportServiceTest {
     @DisplayName("교육 보고서 목록 조회 성공 - 권한 없는 유저 (자신의 부서만 조회)")
     void getEduReports_Success() {
         // given
-        User user = createNormalUser(); // ACCESS_EDUCATION 권한 없음
+        User user = createNormalUser(); // WRITE_DEPARTMENT_EDUCATION 권한 없음
         Department department = defaultDept;
 
         EduReportSummaryDto report1 =
@@ -300,11 +300,11 @@ public class EduReportServiceTest {
     }
 
     @Test
-    @DisplayName("교육 보고서 목록 조회 성공 - ACCESS_EDUCATION 권한 있음, 부서 미지정 → 전체 조회")
+    @DisplayName("교육 보고서 목록 조회 성공 - WRITE_DEPARTMENT_EDUCATION 권한 있음, 부서 미지정 → 전체 조회")
     void getEduReports_WithAccess_ReturnsAll() {
         // given
         User user = createNormalUser();
-        user.addAuthority(Authority.ACCESS_EDUCATION);
+        user.addAuthority(Authority.WRITE_DEPARTMENT_EDUCATION);
 
         EduReportSummaryDto report1 =
                 EduReportSummaryDto.builder()
@@ -336,11 +336,11 @@ public class EduReportServiceTest {
     }
 
     @Test
-    @DisplayName("교육 보고서 목록 조회 성공 - ACCESS_EDUCATION 권한 있음, 특정 부서 필터")
+    @DisplayName("교육 보고서 목록 조회 성공 - WRITE_DEPARTMENT_EDUCATION 권한 있음, 특정 부서 필터")
     void getEduReports_WithAccess_FilterByDept() {
         // given
         User user = createNormalUser();
-        user.addAuthority(Authority.ACCESS_EDUCATION);
+        user.addAuthority(Authority.WRITE_DEPARTMENT_EDUCATION);
 
         Department salesDept = Department.builder().id(2L).name(DepartmentName.SALES_DEPT).build();
 
@@ -398,7 +398,7 @@ public class EduReportServiceTest {
         // given
         Long reportId = 1L;
         Long userId = 99L;
-        User user = createNormalUser(); // ACCESS_EDUCATION 권한 없음
+        User user = createNormalUser(); // WRITE_DEPARTMENT_EDUCATION 권한 없음
 
         EduReport report = EduReport.builder().id(reportId).title("단일 조회 테스트 제목").build();
 
@@ -469,7 +469,7 @@ public class EduReportServiceTest {
         Long reportId = 1L;
         Long userId = 99L; // 관리자 유저 아이디
         User adminUser = createAdminUser();
-        adminUser.addAuthority(Authority.ACCESS_EDUCATION);
+        adminUser.addAuthority(Authority.WRITE_DEPARTMENT_EDUCATION);
 
         EduAttachment attachment1 =
                 EduAttachment.builder()
@@ -544,7 +544,7 @@ public class EduReportServiceTest {
         // given
         Long userId = 99L; // 관리자 유저 아이디
         User adminUser = createAdminUser();
-        adminUser.addAuthority(Authority.ACCESS_EDUCATION);
+        adminUser.addAuthority(Authority.WRITE_DEPARTMENT_EDUCATION);
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(adminUser));
         when(eduReportRepository.findById(10L)).thenReturn(Optional.empty());
@@ -694,13 +694,13 @@ public class EduReportServiceTest {
     }
 
     @Test
-    @DisplayName("교육 보고서 조회 - ACCESS_EDUCATION 권한 있음 → attendees 포함")
+    @DisplayName("교육 보고서 조회 - WRITE_DEPARTMENT_EDUCATION 권한 있음 → attendees 포함")
     void getEduReport_WithAccess_IncludesAttendees() {
         // given
         Long reportId = 1L;
         Long userId = 99L;
         User user = createNormalUser();
-        user.addAuthority(Authority.ACCESS_EDUCATION);
+        user.addAuthority(Authority.WRITE_DEPARTMENT_EDUCATION);
 
         EduReport report =
                 EduReport.builder().id(reportId).title("권한 보고서").eduType(EduType.SAFETY).build();
@@ -737,7 +737,7 @@ public class EduReportServiceTest {
     }
 
     @Test
-    @DisplayName("교육 보고서 조회 - ACCESS_EDUCATION 권한 없음 → attendees=null")
+    @DisplayName("교육 보고서 조회 - WRITE_DEPARTMENT_EDUCATION 권한 없음 → attendees=null")
     void getEduReport_WithoutAccess_AttendeesIsNull() {
         // given
         Long reportId = 1L;

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipServiceTest.java
@@ -72,7 +72,7 @@ public class PayslipServiceTest {
             void it_throws_no_authority_exception() {
                 // given
                 given(userRepository.findById(1L)).willReturn(Optional.of(admin));
-                // admin.hasAuthority(MANAGE_EMPLOYEE_DATA) 가 false인 상황 (기본값)
+                // admin.hasAuthority(EDIT_EMPLOYEE_INFO) 가 false인 상황 (기본값)
 
                 // when & then
                 assertThatThrownBy(() -> payslipService.sendPayslip(List.of(), 1L))
@@ -90,7 +90,7 @@ public class PayslipServiceTest {
             @DisplayName("ONLY_PDF_ALLOWED 예외를 던진다.")
             void it_throws_only_pdf_exception() {
                 // given
-                admin.getAuthorities().add(Authority.MANAGE_EMPLOYEE_DATA); // 권한 부여
+                admin.getAuthorities().add(Authority.EDIT_EMPLOYEE_INFO); // 권한 부여
                 given(userRepository.findById(1L)).willReturn(Optional.of(admin));
 
                 MockMultipartFile txtFile =
@@ -112,7 +112,7 @@ public class PayslipServiceTest {
             @DisplayName("S3에 업로드하고 정보를 저장한다.")
             void it_uploads_to_s3_and_saves_info() throws IOException, IOException {
                 // given
-                admin.getAuthorities().add(Authority.MANAGE_EMPLOYEE_DATA);
+                admin.getAuthorities().add(Authority.EDIT_EMPLOYEE_INFO);
                 given(userRepository.findById(1L)).willReturn(Optional.of(admin));
 
                 MockMultipartFile pdfFile =

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
@@ -82,7 +82,7 @@ public class VisitServiceTest {
                         .workLocation(Company.AWESOME)
                         .jobType(JobType.MANAGEMENT)
                         .build();
-        host.addAuthority(Authority.ACCESS_VISIT);
+        host.addAuthority(Authority.MANAGE_VISITOR);
         return host;
     }
 
@@ -557,7 +557,7 @@ public class VisitServiceTest {
         @BeforeEach
         void setUpAdmin() {
             User admin = User.builder().id(ADMIN_ID).jobType(JobType.MANAGEMENT).build();
-            admin.addAuthority(Authority.ACCESS_VISIT);
+            admin.addAuthority(Authority.MANAGE_VISITOR);
             given(userRepository.findById(ADMIN_ID)).willReturn(Optional.of(admin));
         }
 
@@ -808,7 +808,7 @@ public class VisitServiceTest {
         @BeforeEach
         void setUpAdmin() {
             User admin = User.builder().id(ADMIN_ID).jobType(JobType.MANAGEMENT).build();
-            admin.addAuthority(Authority.ACCESS_VISIT);
+            admin.addAuthority(Authority.MANAGE_VISITOR);
             given(userRepository.findById(ADMIN_ID)).willReturn(Optional.of(admin));
         }
 
@@ -852,7 +852,7 @@ public class VisitServiceTest {
         @BeforeEach
         void setUpAdmin() {
             User admin = User.builder().id(ADMIN_ID).jobType(JobType.MANAGEMENT).build();
-            admin.addAuthority(Authority.ACCESS_VISIT);
+            admin.addAuthority(Authority.MANAGE_VISITOR);
             given(userRepository.findById(ADMIN_ID)).willReturn(Optional.of(admin));
         }
 


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #254 

## 📝작업 내용
- 권한명/권한 코드 기능 의미에 맞게 정리
  - 교육 작성 -> 부서 교육 작성
  - 메시지 작성 -> 알림 전송
  - 방문자 관리 접근 -> 내방객 관리
  - 사원 데이터 관리 -> 직원 정보 수정
  - 결재 설정 관리 -> 결재선 설정 관리
- `GET /api/safety-trainings/{sessionId}` 응답에 `instructorDepartmentName` 추가
- 세션 상세 `canSign` 조건 보정
  - 대표이사 또는 `MASTER_ADMIN` 또는 타회사 보고서인 경우 `false`
- 세션 목록 `mySigned`를 조건부 nullable로 변경
  - 대표이사 또는 `MASTER_ADMIN` 또는 타회사 보고서인 경우 `null`
- 비밀번호 찾기 플로우를 화면 설계와 정렬
  - 휴대폰: `POST /api/auth/verify-account/phone` 검증 단계 추가/강화 후 `PATCH /api/auth/reset-password/phone` 수행
  - 이메일: `POST /api/auth/verify-account/email` 검증 단계 추가 후 `PATCH /api/auth/reset-password/email` 수행
- Swagger/보안 공개 경로/문서 예시 동기화
- `AuthServiceTest` 검증 케이스 보강

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
- FE 연동 시 요청 순서 확인 부탁드립니다.
  - 휴대폰: `send-phone-code -> verify-phone-code -> verify-account/phone -> reset-password/phone`
  - 이메일: `send-email-code -> verify-email-code -> verify-account/email -> reset-password/email`
- `PATCH /api/auth/reset-password/phone` 요청 바디에서 `phoneNumber` 제거된 점 확인 부탁드립니다.
- `mySigned` nullable 스펙 변경 영향 확인 부탁드립니다.