### PR TITLE
refactor(264): 공지사항 목록/상세에 authorName·createdDate 변경 및 이전/다음 글 조회 구현

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/controller/NoticeController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/controller/NoticeController.java
@@ -263,14 +263,16 @@ public class NoticeController {
                                         "type": "REGULAR",
                                         "title": "2026년 신년 휴무 안내",
                                         "isPinned": true,
-                                        "updatedDate": "2026-01-01T09:00:00"
+                                        "authorName": "홍길동",
+                                        "createdDate": "2026-01-01T09:00:00"
                                       },
                                       {
                                         "id": 5,
                                         "type": "MENU",
                                         "title": "1월 식단표 안내",
                                         "isPinned": false,
-                                        "updatedDate": "2026-01-10T14:30:00"
+                                        "authorName": "이순신",
+                                        "createdDate": "2026-01-10T14:30:00"
                                       }
                                     ],
                                     "pageable": {
@@ -344,7 +346,7 @@ public class NoticeController {
                                 "title": "2025년 1월 전체 회의 안내",
                                 "content": "오는 1월 15일 오후 2시에 전체 회의가 있습니다.",
                                 "authorName": "홍길동",
-                                "updatedDate": "2025-01-10T14:30:00",
+                                "createdDate": "2025-01-10T14:30:00",
                                 "viewCount": 43,
                                 "attachments": [
                                   {
@@ -356,7 +358,19 @@ public class NoticeController {
                                 ],
                                 "targetCompanies": ["어썸리드"],
                                 "targetDepartmentIds": [1, 2],
-                                "targetUserIds": [10, 20]
+                                "targetUserIds": [10, 20],
+                                "prevNotice": {
+                                  "id": 9,
+                                  "title": "이전 공지 제목",
+                                  "authorName": "김철수",
+                                  "createdDate": "2025-01-09T10:00:00"
+                                },
+                                "nextNotice": {
+                                  "id": 11,
+                                  "title": "다음 공지 제목",
+                                  "authorName": "박영희",
+                                  "createdDate": "2025-01-11T10:00:00"
+                                }
                               }
                             }
                             """))),
@@ -381,8 +395,9 @@ public class NoticeController {
     @GetMapping("/{noticeId}")
     public ResponseEntity<ApiResponse<NoticeDetailDto>> getNotice(
             @Parameter(description = "조회할 공지사항 ID", example = "1", required = true) @PathVariable
-                    Long noticeId) {
-        NoticeDetailDto dto = noticeService.getNotice(noticeId);
+                    Long noticeId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        NoticeDetailDto dto = noticeService.getNotice(noticeId, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(dto));
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/dto/response/NoticeDetailDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/dto/response/NoticeDetailDto.java
@@ -33,11 +33,11 @@ public class NoticeDetailDto {
     private String authorName;
 
     @Schema(
-            description = "수정일시 (KST, Asia/Seoul)",
+            description = "작성일시 (KST, Asia/Seoul)",
             type = "string",
             format = "date-time",
             example = "2026-02-27T10:30:00")
-    private LocalDateTime updatedDate;
+    private LocalDateTime createdDate;
 
     @Schema(description = "조회수", example = "42")
     private int viewCount;
@@ -60,6 +60,14 @@ public class NoticeDetailDto {
     @Schema(description = "대상 유저 ID 목록", example = "[10, 20]")
     private List<Long> targetUserIds;
 
+    @Setter
+    @Schema(description = "이전 공지사항 정보 (없으면 null)")
+    private NoticeInfo prevNotice;
+
+    @Setter
+    @Schema(description = "다음 공지사항 정보 (없으면 null)")
+    private NoticeInfo nextNotice;
+
     @Getter
     @Setter
     @Builder
@@ -81,5 +89,29 @@ public class NoticeDetailDto {
                 description = "파일 조회 URL",
                 example = "https://bucket.s3.amazonaws.com/notices/uuid_file.pdf")
         private String viewUrl; // S3에서 바로 열기 위한 URL
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "이전/다음 공지사항 요약 정보")
+    public static class NoticeInfo {
+
+        @Schema(description = "공지사항 ID", example = "1")
+        private Long id;
+
+        @Schema(description = "공지사항 제목", example = "2025년 1월 전체 회의 안내")
+        private String title;
+
+        @Schema(description = "작성자 이름", example = "홍길동")
+        private String authorName;
+
+        @Schema(
+                description = "작성일시 (KST, Asia/Seoul)",
+                type = "string",
+                format = "date-time",
+                example = "2026-02-27T10:30:00")
+        private LocalDateTime createdDate;
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/dto/response/NoticeSummaryDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/dto/response/NoticeSummaryDto.java
@@ -30,10 +30,13 @@ public class NoticeSummaryDto {
     @Schema(description = "상단 고정 여부", example = "true") // 추가됨
     private boolean isPinned;
 
+    @Schema(description = "작성자 이름", example = "홍길동")
+    private String authorName;
+
     @Schema(
-            description = "수정일시 (KST, Asia/Seoul)",
+            description = "작성일시 (KST, Asia/Seoul)",
             type = "string",
             format = "date-time",
             example = "2026-02-27T10:30:00")
-    private LocalDateTime updatedDate;
+    private LocalDateTime createdDate;
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/mapper/NoticeMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/mapper/NoticeMapper.java
@@ -30,10 +30,13 @@ public interface NoticeMapper {
 
     @Mapping(target = "authorName", expression = "java(notice.getAuthor().getDisplayName())")
     @Mapping(target = "type", expression = "java(notice.getType().name())")
+    @Mapping(target = "createdDate", source = "notice.createdDate")
     @Mapping(target = "attachments", source = "attachments")
     @Mapping(target = "targetCompanies", source = "notice.targetCompanies")
     @Mapping(target = "targetDepartmentIds", source = "notice.targetDepartments")
     @Mapping(target = "targetUserIds", source = "notice.targetUsers")
+    @Mapping(target = "prevNotice", ignore = true)
+    @Mapping(target = "nextNotice", ignore = true)
     NoticeDetailDto toNoticeDetailDto(Notice notice, @Context S3Service s3Service);
 
     @Mapping(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/respository/NoticeQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/respository/NoticeQueryRepository.java
@@ -20,12 +20,11 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-
-import java.time.LocalDateTime;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -123,8 +122,9 @@ public class NoticeQueryRepository {
                 .from(notice)
                 .innerJoin(notice.author, author)
                 .where(
-                        notice.createdDate.lt(createdDate).or(
-                                notice.createdDate.eq(createdDate).and(notice.id.lt(noticeId))),
+                        notice.createdDate
+                                .lt(createdDate)
+                                .or(notice.createdDate.eq(createdDate).and(notice.id.lt(noticeId))),
                         noticeAccessible(hasAccessNotice, userId))
                 .orderBy(notice.createdDate.desc(), notice.id.desc())
                 .limit(1)
@@ -147,8 +147,9 @@ public class NoticeQueryRepository {
                 .from(notice)
                 .innerJoin(notice.author, author)
                 .where(
-                        notice.createdDate.gt(createdDate).or(
-                                notice.createdDate.eq(createdDate).and(notice.id.gt(noticeId))),
+                        notice.createdDate
+                                .gt(createdDate)
+                                .or(notice.createdDate.eq(createdDate).and(notice.id.gt(noticeId))),
                         noticeAccessible(hasAccessNotice, userId))
                 .orderBy(notice.createdDate.asc(), notice.id.asc())
                 .limit(1)

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/respository/NoticeQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/respository/NoticeQueryRepository.java
@@ -2,10 +2,13 @@ package kr.co.awesomelead.groupware_backend.domain.notice.respository;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import kr.co.awesomelead.groupware_backend.domain.notice.dto.request.NoticeSearchConditionDto;
+import kr.co.awesomelead.groupware_backend.domain.notice.dto.response.NoticeDetailDto;
 import kr.co.awesomelead.groupware_backend.domain.notice.dto.response.NoticeSummaryDto;
 import kr.co.awesomelead.groupware_backend.domain.notice.entity.QNotice;
 import kr.co.awesomelead.groupware_backend.domain.notice.entity.QNoticeTarget;
@@ -17,6 +20,8 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
@@ -53,8 +58,9 @@ public class NoticeQueryRepository {
                                         notice.type,
                                         notice.title,
                                         notice.pinned,
-                                        notice.updatedDate))
-                        .orderBy(notice.pinned.desc(), notice.updatedDate.desc())
+                                        displayNameExpr(author),
+                                        notice.createdDate))
+                        .orderBy(notice.pinned.desc(), notice.createdDate.desc())
                         .offset(pageable.getOffset())
                         .limit(pageable.getPageSize())
                         .fetch();
@@ -81,6 +87,7 @@ public class NoticeQueryRepository {
 
     public List<NoticeSummaryDto> findTop3Notices(Long userId, boolean hasAccessNotice) {
         QNotice notice = QNotice.notice;
+        QUser author = QUser.user;
 
         return queryFactory
                 .select(
@@ -90,12 +97,69 @@ public class NoticeQueryRepository {
                                 notice.type,
                                 notice.title,
                                 notice.pinned,
-                                notice.updatedDate))
+                                displayNameExpr(author),
+                                notice.createdDate))
                 .from(notice)
+                .innerJoin(notice.author, author)
                 .where(noticeAccessible(hasAccessNotice, userId))
-                .orderBy(notice.pinned.desc(), notice.updatedDate.desc())
+                .orderBy(notice.pinned.desc(), notice.createdDate.desc())
                 .limit(3)
                 .fetch();
+    }
+
+    public NoticeDetailDto.NoticeInfo findPrevNotice(
+            Long noticeId, LocalDateTime createdDate, Long userId, boolean hasAccessNotice) {
+        QNotice notice = QNotice.notice;
+        QUser author = QUser.user;
+
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                NoticeDetailDto.NoticeInfo.class,
+                                notice.id,
+                                notice.title,
+                                displayNameExpr(author),
+                                notice.createdDate))
+                .from(notice)
+                .innerJoin(notice.author, author)
+                .where(
+                        notice.createdDate.lt(createdDate).or(
+                                notice.createdDate.eq(createdDate).and(notice.id.lt(noticeId))),
+                        noticeAccessible(hasAccessNotice, userId))
+                .orderBy(notice.createdDate.desc(), notice.id.desc())
+                .limit(1)
+                .fetchOne();
+    }
+
+    public NoticeDetailDto.NoticeInfo findNextNotice(
+            Long noticeId, LocalDateTime createdDate, Long userId, boolean hasAccessNotice) {
+        QNotice notice = QNotice.notice;
+        QUser author = QUser.user;
+
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                NoticeDetailDto.NoticeInfo.class,
+                                notice.id,
+                                notice.title,
+                                displayNameExpr(author),
+                                notice.createdDate))
+                .from(notice)
+                .innerJoin(notice.author, author)
+                .where(
+                        notice.createdDate.gt(createdDate).or(
+                                notice.createdDate.eq(createdDate).and(notice.id.gt(noticeId))),
+                        noticeAccessible(hasAccessNotice, userId))
+                .orderBy(notice.createdDate.asc(), notice.id.asc())
+                .limit(1)
+                .fetchOne();
+    }
+
+    private StringExpression displayNameExpr(QUser author) {
+        return new CaseBuilder()
+                .when(author.nameKor.isNotNull().and(author.nameKor.ne("")))
+                .then(author.nameKor)
+                .otherwise(author.nameEng);
     }
 
     private BooleanExpression noticeAccessible(boolean hasAccessNotice, Long userId) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/service/NoticeService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/service/NoticeService.java
@@ -130,7 +130,7 @@ public class NoticeService {
     }
 
     @Transactional
-    public NoticeDetailDto getNotice(Long noticeId) {
+    public NoticeDetailDto getNotice(Long noticeId, Long userId) {
         Notice notice =
                 noticeRepository
                         .findByIdWithDetails(noticeId)
@@ -140,7 +140,21 @@ public class NoticeService {
         notice.increaseViewCount();
         noticeRepository.save(notice);
 
-        return noticeMapper.toNoticeDetailDto(notice, s3Service);
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        boolean hasAccessNotice = user.hasAuthority(Authority.ACCESS_NOTICE);
+
+        NoticeDetailDto dto = noticeMapper.toNoticeDetailDto(notice, s3Service);
+        dto.setPrevNotice(
+                noticeQueryRepository.findPrevNotice(
+                        noticeId, notice.getCreatedDate(), userId, hasAccessNotice));
+        dto.setNextNotice(
+                noticeQueryRepository.findNextNotice(
+                        noticeId, notice.getCreatedDate(), userId, hasAccessNotice));
+
+        return dto;
     }
 
     @Transactional

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/notice/NoticeServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/notice/NoticeServiceTest.java
@@ -3,6 +3,7 @@ package kr.co.awesomelead.groupware_backend.domain.notice;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
@@ -241,11 +242,16 @@ class NoticeServiceTest {
             Notice notice = Notice.builder().title("상세조회").build();
             ReflectionTestUtils.setField(notice, "viewCount", 0);
             given(noticeRepository.findByIdWithDetails(1L)).willReturn(Optional.of(notice));
+            given(userRepository.findById(1L)).willReturn(Optional.of(adminUser));
             given(noticeMapper.toNoticeDetailDto(any(), any()))
                     .willReturn(NoticeDetailDto.builder().title("상세조회").build());
+            given(noticeQueryRepository.findPrevNotice(any(), any(), any(), anyBoolean()))
+                    .willReturn(null);
+            given(noticeQueryRepository.findNextNotice(any(), any(), any(), anyBoolean()))
+                    .willReturn(null);
 
             // when
-            NoticeDetailDto result = noticeService.getNotice(1L);
+            NoticeDetailDto result = noticeService.getNotice(1L, 1L);
 
             // then
             assertThat(notice.getViewCount()).isEqualTo(1);
@@ -261,6 +267,7 @@ class NoticeServiceTest {
             Notice notice = Notice.builder().title("대상조회").build();
             ReflectionTestUtils.setField(notice, "viewCount", 0);
             given(noticeRepository.findByIdWithDetails(1L)).willReturn(Optional.of(notice));
+            given(userRepository.findById(1L)).willReturn(Optional.of(adminUser));
             given(noticeMapper.toNoticeDetailDto(any(), any()))
                     .willReturn(
                             NoticeDetailDto.builder()
@@ -269,9 +276,13 @@ class NoticeServiceTest {
                                     .targetDepartmentIds(List.of(10L, 20L))
                                     .targetUserIds(List.of(99L))
                                     .build());
+            given(noticeQueryRepository.findPrevNotice(any(), any(), any(), anyBoolean()))
+                    .willReturn(null);
+            given(noticeQueryRepository.findNextNotice(any(), any(), any(), anyBoolean()))
+                    .willReturn(null);
 
             // when
-            NoticeDetailDto result = noticeService.getNotice(1L);
+            NoticeDetailDto result = noticeService.getNotice(1L, 1L);
 
             // then
             assertThat(result.getTargetCompanies()).containsExactly(Company.AWESOME);
@@ -286,20 +297,64 @@ class NoticeServiceTest {
             Notice notice = Notice.builder().title("타입조회").build();
             ReflectionTestUtils.setField(notice, "viewCount", 0);
             given(noticeRepository.findByIdWithDetails(1L)).willReturn(Optional.of(notice));
+            given(userRepository.findById(1L)).willReturn(Optional.of(adminUser));
             given(noticeMapper.toNoticeDetailDto(any(), any()))
                     .willReturn(
                             NoticeDetailDto.builder()
                                     .title("타입조회")
                                     .type(NoticeType.REGULAR.name())
                                     .build());
+            given(noticeQueryRepository.findPrevNotice(any(), any(), any(), anyBoolean()))
+                    .willReturn(null);
+            given(noticeQueryRepository.findNextNotice(any(), any(), any(), anyBoolean()))
+                    .willReturn(null);
 
             // when
-            NoticeDetailDto result = noticeService.getNotice(1L);
+            NoticeDetailDto result = noticeService.getNotice(1L, 1L);
 
             // then
             assertThat(result.getType()).isEqualTo("REGULAR");
             assertThat(result.getType())
                     .isIn(NoticeType.REGULAR.name(), NoticeType.MENU.name(), NoticeType.ETC.name());
+        }
+
+        @Test
+        @DisplayName("이전/다음 공지사항 정보를 포함하여 반환한다")
+        void it_returns_dto_with_prev_next_notice() {
+            // given
+            Notice notice = Notice.builder().title("이전다음조회").build();
+            ReflectionTestUtils.setField(notice, "viewCount", 0);
+
+            NoticeDetailDto.NoticeInfo prevInfo =
+                    NoticeDetailDto.NoticeInfo.builder()
+                            .id(9L)
+                            .title("이전 공지")
+                            .authorName("홍길동")
+                            .build();
+            NoticeDetailDto.NoticeInfo nextInfo =
+                    NoticeDetailDto.NoticeInfo.builder()
+                            .id(11L)
+                            .title("다음 공지")
+                            .authorName("이순신")
+                            .build();
+
+            given(noticeRepository.findByIdWithDetails(10L)).willReturn(Optional.of(notice));
+            given(userRepository.findById(1L)).willReturn(Optional.of(adminUser));
+            given(noticeMapper.toNoticeDetailDto(any(), any()))
+                    .willReturn(NoticeDetailDto.builder().title("이전다음조회").build());
+            given(noticeQueryRepository.findPrevNotice(any(), any(), any(), anyBoolean()))
+                    .willReturn(prevInfo);
+            given(noticeQueryRepository.findNextNotice(any(), any(), any(), anyBoolean()))
+                    .willReturn(nextInfo);
+
+            // when
+            NoticeDetailDto result = noticeService.getNotice(10L, 1L);
+
+            // then
+            assertThat(result.getPrevNotice()).isNotNull();
+            assertThat(result.getPrevNotice().getId()).isEqualTo(9L);
+            assertThat(result.getNextNotice()).isNotNull();
+            assertThat(result.getNextNotice().getId()).isEqualTo(11L);
         }
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #264

## 📝작업 내용

- NoticeSummaryDto: `updatedDate` → `createdDate` 변경, `authorName` 필드 추가
- NoticeDetailDto: `createdDate` 변경, `prevNotice`/`nextNotice` 필드 및 `NoticeInfo` 내부 클래스 추가
- NoticeQueryRepository
    - `displayNameExpr` 추가 (`User.getDisplayName()` 로직을 QueryDSL `CaseBuilder`로 구현)
    - 정렬 기준 `updatedDate` → `createdDate` 변경
    - `findPrevNotice`/`findNextNotice` 메서드 추가 (목록과 동일한 권한 필터 적용)
- NoticeMapper: `createdDate` 매핑, `prevNotice`/`nextNotice` ignore 처리
- NoticeService.getNotice: `userId` 파라미터 추가, 이전/다음 공지 조회 후 DTO에 주입
- NoticeController.getNotice: `@AuthenticationPrincipal` 추가

## 📸 스크린샷 (선택)

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)

- X