### PR TITLE
feat(269): EduReport 서명 현황 목록 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ dependencies {
 }
 
 // Querydsl 설정부 (QClass 생성 위치 지정)
-def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
+def querydslDir = "$projectDir/src/main/generated"
 
 sourceSets {
     main {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
@@ -9,9 +9,10 @@ import io.swagger.v3.oas.annotations.media.Encoding;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-
 import jakarta.validation.Valid;
-
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
 import kr.co.awesomelead.groupware_backend.domain.education.dto.request.DepartmentEduReportCreateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.education.dto.request.EduReportStatusUpdateRequestDto;
@@ -19,13 +20,12 @@ import kr.co.awesomelead.groupware_backend.domain.education.dto.request.EduRepor
 import kr.co.awesomelead.groupware_backend.domain.education.dto.request.PsmEduReportCreateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.education.dto.request.SafetyEduReportCreateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.education.dto.response.EduReportDetailDto;
+import kr.co.awesomelead.groupware_backend.domain.education.dto.response.EduReportSignatureStatusDto;
 import kr.co.awesomelead.groupware_backend.domain.education.dto.response.EduReportSummaryDto;
 import kr.co.awesomelead.groupware_backend.domain.education.service.EduReportService;
 import kr.co.awesomelead.groupware_backend.domain.user.dto.CustomUserDetails;
 import kr.co.awesomelead.groupware_backend.global.common.response.ApiResponse;
-
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -42,10 +42,6 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
-import java.io.IOException;
-import java.net.URI;
-import java.util.List;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/educations")
@@ -54,330 +50,330 @@ public class EduReportController {
     private final EduReportService eduReportService;
 
     @Operation(
-            tags = {"부서교육"},
-            summary = "부서 교육 게시물 생성",
-            description =
-                    """
-            `multipart/form-data`로 부서 교육 게시물을 생성합니다.
+        tags = {"부서교육"},
+        summary = "부서 교육 게시물 생성",
+        description =
+            """
+                `multipart/form-data`로 부서 교육 게시물을 생성합니다.
 
-            - `requestDto`(JSON 파트)는 필수입니다.
-            - `files`(파일 파트)는 선택입니다.
-            - 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 있어야 생성할 수 있습니다.
-            """,
-            requestBody =
-                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                            required = true,
-                            content =
-                                    @Content(
-                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-                                            schema =
-                                                    @Schema(
-                                                            implementation =
-                                                                    DepartmentEduReportCreateMultipartRequestDoc
-                                                                            .class),
-                                            encoding = {
-                                                @Encoding(
-                                                        name = "requestDto",
-                                                        contentType =
-                                                                MediaType.APPLICATION_JSON_VALUE),
-                                                @Encoding(name = "files", contentType = "*/*")
-                                            })))
+                - `requestDto`(JSON 파트)는 필수입니다.
+                - `files`(파일 파트)는 선택입니다.
+                - 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 있어야 생성할 수 있습니다.
+                """,
+        requestBody =
+        @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            required = true,
+            content =
+            @Content(
+                mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                schema =
+                @Schema(
+                    implementation =
+                        DepartmentEduReportCreateMultipartRequestDoc
+                            .class),
+                encoding = {
+                    @Encoding(
+                        name = "requestDto",
+                        contentType =
+                            MediaType.APPLICATION_JSON_VALUE),
+                    @Encoding(name = "files", contentType = "*/*")
+                })))
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "201",
-                description = "생성 성공",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                schema = @Schema(implementation = ApiResponse.class),
-                                examples =
-                                        @ExampleObject(
-                                                value =
-                                                        """
-          {
-            "isSuccess": true,
-            "code": "COMMON201",
-            "message": "성공적으로 생성되었습니다.",
-            "result": 1
-          }
-          """))),
+            responseCode = "201",
+            description = "생성 성공",
+            content =
+            @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ApiResponse.class),
+                examples =
+                @ExampleObject(
+                    value =
+                        """
+                            {
+                              "isSuccess": true,
+                              "code": "COMMON201",
+                              "message": "성공적으로 생성되었습니다.",
+                              "result": 1
+                            }
+                            """))),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "403",
-                description = "권한 없음",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples =
-                                        @ExampleObject(
-                                                value =
-                                                        """
-          {
-            "isSuccess": false,
-            "code": "NO_AUTHORITY_FOR_EDU_REPORT",
-            "message": "교육 게시물 관리 권한이 없습니다.",
-            "result": null
-          }
-          """))),
+            responseCode = "403",
+            description = "권한 없음",
+            content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                @ExampleObject(
+                    value =
+                        """
+                            {
+                              "isSuccess": false,
+                              "code": "NO_AUTHORITY_FOR_EDU_REPORT",
+                              "message": "교육 게시물 관리 권한이 없습니다.",
+                              "result": null
+                            }
+                            """))),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples =
-                                        @ExampleObject(
-                                                value =
-                                                        """
-          {
-            "isSuccess": false,
-            "code": "DEPARTMENT_NOT_FOUND",
-            "message": "해당 부서를 찾을 수 없습니다.",
-            "result": null
-          }
-          """)))
+            responseCode = "404",
+            description = "리소스 없음",
+            content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                @ExampleObject(
+                    value =
+                        """
+                            {
+                              "isSuccess": false,
+                              "code": "DEPARTMENT_NOT_FOUND",
+                              "message": "해당 부서를 찾을 수 없습니다.",
+                              "result": null
+                            }
+                            """)))
     })
     @PostMapping(value = "/department", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Long>> createDepartmentEduReport(
-            @Parameter(description = "부서 교육 게시물 생성 정보(JSON)", required = true)
-                    @RequestPart("requestDto")
-                    @Valid
-                    DepartmentEduReportCreateRequestDto requestDto,
-            @Parameter(description = "첨부 파일 목록(선택)") @RequestPart(value = "files", required = false)
-                    List<MultipartFile> files,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
-            throws IOException {
+        @Parameter(description = "부서 교육 게시물 생성 정보(JSON)", required = true)
+        @RequestPart("requestDto")
+        @Valid
+        DepartmentEduReportCreateRequestDto requestDto,
+        @Parameter(description = "첨부 파일 목록(선택)") @RequestPart(value = "files", required = false)
+        List<MultipartFile> files,
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
+        throws IOException {
 
         Long reportId =
-                eduReportService.createDepartmentEduReport(requestDto, files, userDetails.getId());
+            eduReportService.createDepartmentEduReport(requestDto, files, userDetails.getId());
 
         URI location =
-                ServletUriComponentsBuilder.fromCurrentContextPath()
-                        .path("/api/educations/department/{id}")
-                        .buildAndExpand(reportId)
-                        .toUri();
+            ServletUriComponentsBuilder.fromCurrentContextPath()
+                .path("/api/educations/department/{id}")
+                .buildAndExpand(reportId)
+                .toUri();
 
         return ResponseEntity.created(location).body(ApiResponse.onCreated(reportId));
     }
 
     @Operation(
-            tags = {"PSM"},
-            summary = "PSM 게시물 생성",
-            description =
-                    """
-            `multipart/form-data`로 PSM 게시물을 생성합니다.
+        tags = {"PSM"},
+        summary = "PSM 게시물 생성",
+        description =
+            """
+                `multipart/form-data`로 PSM 게시물을 생성합니다.
 
-            - `requestDto`(JSON 파트)는 필수입니다.
-            - `files`(파일 파트)는 선택입니다.
-            - PSM 관리 권한(`MANAGE_PSM`)이 있어야 생성할 수 있습니다.
-            - `companyScope`를 지정하면 해당 회사 게시물, `null`이면 모든 회사 공통 게시물로 생성됩니다.
-            """,
-            requestBody =
-                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                            required = true,
-                            content =
-                                    @Content(
-                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-                                            schema =
-                                                    @Schema(
-                                                            implementation =
-                                                                    PsmEduReportCreateMultipartRequestDoc
-                                                                            .class),
-                                            encoding = {
-                                                @Encoding(
-                                                        name = "requestDto",
-                                                        contentType =
-                                                                MediaType.APPLICATION_JSON_VALUE),
-                                                @Encoding(name = "files", contentType = "*/*")
-                                            })))
+                - `requestDto`(JSON 파트)는 필수입니다.
+                - `files`(파일 파트)는 선택입니다.
+                - PSM 관리 권한(`MANAGE_PSM`)이 있어야 생성할 수 있습니다.
+                - `companyScope`를 지정하면 해당 회사 게시물, `null`이면 모든 회사 공통 게시물로 생성됩니다.
+                """,
+        requestBody =
+        @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            required = true,
+            content =
+            @Content(
+                mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                schema =
+                @Schema(
+                    implementation =
+                        PsmEduReportCreateMultipartRequestDoc
+                            .class),
+                encoding = {
+                    @Encoding(
+                        name = "requestDto",
+                        contentType =
+                            MediaType.APPLICATION_JSON_VALUE),
+                    @Encoding(name = "files", contentType = "*/*")
+                })))
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "201",
-                description = "생성 성공",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples =
-                                        @ExampleObject(
-                                                value =
-                                                        """
-          {
-            "isSuccess": true,
-            "code": "COMMON201",
-            "message": "성공적으로 생성되었습니다.",
-            "result": 2
-          }
-          """))),
+            responseCode = "201",
+            description = "생성 성공",
+            content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                @ExampleObject(
+                    value =
+                        """
+                            {
+                              "isSuccess": true,
+                              "code": "COMMON201",
+                              "message": "성공적으로 생성되었습니다.",
+                              "result": 2
+                            }
+                            """))),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "403",
-                description = "권한 없음",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples =
-                                        @ExampleObject(
-                                                value =
-                                                        """
-          {
-            "isSuccess": false,
-            "code": "NO_AUTHORITY_FOR_PSM_MANAGE",
-            "message": "PSM 관리 권한이 없습니다.",
-            "result": null
-          }
-          """))),
+            responseCode = "403",
+            description = "권한 없음",
+            content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                @ExampleObject(
+                    value =
+                        """
+                            {
+                              "isSuccess": false,
+                              "code": "NO_AUTHORITY_FOR_PSM_MANAGE",
+                              "message": "PSM 관리 권한이 없습니다.",
+                              "result": null
+                            }
+                            """))),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples =
-                                        @ExampleObject(
-                                                value =
-                                                        """
-          {
-            "isSuccess": false,
-            "code": "EDUCATION_CATEGORY_NOT_FOUND",
-            "message": "해당 교육 카테고리를 찾을 수 없습니다.",
-            "result": null
-          }
-          """)))
+            responseCode = "404",
+            description = "리소스 없음",
+            content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                @ExampleObject(
+                    value =
+                        """
+                            {
+                              "isSuccess": false,
+                              "code": "EDUCATION_CATEGORY_NOT_FOUND",
+                              "message": "해당 교육 카테고리를 찾을 수 없습니다.",
+                              "result": null
+                            }
+                            """)))
     })
     @PostMapping(value = "/psm", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Long>> createPsmEduReport(
-            @Parameter(description = "PSM 게시물 생성 정보(JSON)", required = true)
-                    @RequestPart("requestDto")
-                    @Valid
-                    PsmEduReportCreateRequestDto requestDto,
-            @Parameter(description = "첨부 파일 목록(선택)") @RequestPart(value = "files", required = false)
-                    List<MultipartFile> files,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
-            throws IOException {
+        @Parameter(description = "PSM 게시물 생성 정보(JSON)", required = true)
+        @RequestPart("requestDto")
+        @Valid
+        PsmEduReportCreateRequestDto requestDto,
+        @Parameter(description = "첨부 파일 목록(선택)") @RequestPart(value = "files", required = false)
+        List<MultipartFile> files,
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
+        throws IOException {
 
         Long reportId = eduReportService.createPsmEduReport(requestDto, files, userDetails.getId());
 
         URI location =
-                ServletUriComponentsBuilder.fromCurrentContextPath()
-                        .path("/api/educations/psm/{id}")
-                        .buildAndExpand(reportId)
-                        .toUri();
+            ServletUriComponentsBuilder.fromCurrentContextPath()
+                .path("/api/educations/psm/{id}")
+                .buildAndExpand(reportId)
+                .toUri();
 
         return ResponseEntity.created(location).body(ApiResponse.onCreated(reportId));
     }
 
     @Operation(
-            tags = {"안전보건"},
-            summary = "안전 보건 게시물 생성",
-            description =
-                    """
-            `multipart/form-data`로 안전 보건 게시물을 생성합니다.
+        tags = {"안전보건"},
+        summary = "안전 보건 게시물 생성",
+        description =
+            """
+                `multipart/form-data`로 안전 보건 게시물을 생성합니다.
 
-            - `requestDto`(JSON 파트)는 필수입니다.
-            - `files`(파일 파트)는 선택입니다.
-            - 안전 보건 관리 권한(`MANAGE_SAFETY`)이 있어야 생성할 수 있습니다.
-            - `companyScope`를 지정하면 해당 회사 게시물, `null`이면 모든 회사 공통 게시물로 생성됩니다.
-            """,
-            requestBody =
-                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                            required = true,
-                            content =
-                                    @Content(
-                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-                                            schema =
-                                                    @Schema(
-                                                            implementation =
-                                                                    SafetyEduReportCreateMultipartRequestDoc
-                                                                            .class),
-                                            encoding = {
-                                                @Encoding(
-                                                        name = "requestDto",
-                                                        contentType =
-                                                                MediaType.APPLICATION_JSON_VALUE),
-                                                @Encoding(name = "files", contentType = "*/*")
-                                            })))
+                - `requestDto`(JSON 파트)는 필수입니다.
+                - `files`(파일 파트)는 선택입니다.
+                - 안전 보건 관리 권한(`MANAGE_SAFETY`)이 있어야 생성할 수 있습니다.
+                - `companyScope`를 지정하면 해당 회사 게시물, `null`이면 모든 회사 공통 게시물로 생성됩니다.
+                """,
+        requestBody =
+        @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            required = true,
+            content =
+            @Content(
+                mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                schema =
+                @Schema(
+                    implementation =
+                        SafetyEduReportCreateMultipartRequestDoc
+                            .class),
+                encoding = {
+                    @Encoding(
+                        name = "requestDto",
+                        contentType =
+                            MediaType.APPLICATION_JSON_VALUE),
+                    @Encoding(name = "files", contentType = "*/*")
+                })))
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "201",
-                description = "생성 성공",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples =
-                                        @ExampleObject(
-                                                value =
-                                                        """
-          {
-            "isSuccess": true,
-            "code": "COMMON201",
-            "message": "성공적으로 생성되었습니다.",
-            "result": 3
-          }
-          """))),
+            responseCode = "201",
+            description = "생성 성공",
+            content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                @ExampleObject(
+                    value =
+                        """
+                            {
+                              "isSuccess": true,
+                              "code": "COMMON201",
+                              "message": "성공적으로 생성되었습니다.",
+                              "result": 3
+                            }
+                            """))),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "403",
-                description = "권한 없음",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples =
-                                        @ExampleObject(
-                                                value =
-                                                        """
-          {
-            "isSuccess": false,
-            "code": "NO_AUTHORITY_FOR_SAFETY_WRITE",
-            "message": "안전 보건 관리 권한이 없습니다.",
-            "result": null
-          }
-          """))),
+            responseCode = "403",
+            description = "권한 없음",
+            content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                @ExampleObject(
+                    value =
+                        """
+                            {
+                              "isSuccess": false,
+                              "code": "NO_AUTHORITY_FOR_SAFETY_WRITE",
+                              "message": "안전 보건 관리 권한이 없습니다.",
+                              "result": null
+                            }
+                            """))),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples =
-                                        @ExampleObject(
-                                                value =
-                                                        """
-          {
-            "isSuccess": false,
-            "code": "EDUCATION_CATEGORY_NOT_FOUND",
-            "message": "해당 교육 카테고리를 찾을 수 없습니다.",
-            "result": null
-          }
-          """)))
+            responseCode = "404",
+            description = "리소스 없음",
+            content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                @ExampleObject(
+                    value =
+                        """
+                            {
+                              "isSuccess": false,
+                              "code": "EDUCATION_CATEGORY_NOT_FOUND",
+                              "message": "해당 교육 카테고리를 찾을 수 없습니다.",
+                              "result": null
+                            }
+                            """)))
     })
     @PostMapping(value = "/safety", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Long>> createSafetyEduReport(
-            @Parameter(description = "안전 보건 게시물 생성 정보(JSON)", required = true)
-                    @RequestPart("requestDto")
-                    @Valid
-                    SafetyEduReportCreateRequestDto requestDto,
-            @Parameter(description = "첨부 파일 목록(선택)") @RequestPart(value = "files", required = false)
-                    List<MultipartFile> files,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
-            throws IOException {
+        @Parameter(description = "안전 보건 게시물 생성 정보(JSON)", required = true)
+        @RequestPart("requestDto")
+        @Valid
+        SafetyEduReportCreateRequestDto requestDto,
+        @Parameter(description = "첨부 파일 목록(선택)") @RequestPart(value = "files", required = false)
+        List<MultipartFile> files,
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
+        throws IOException {
 
         Long reportId =
-                eduReportService.createSafetyEduReport(requestDto, files, userDetails.getId());
+            eduReportService.createSafetyEduReport(requestDto, files, userDetails.getId());
 
         URI location =
-                ServletUriComponentsBuilder.fromCurrentContextPath()
-                        .path("/api/educations/safety/{id}")
-                        .buildAndExpand(reportId)
-                        .toUri();
+            ServletUriComponentsBuilder.fromCurrentContextPath()
+                .path("/api/educations/safety/{id}")
+                .buildAndExpand(reportId)
+                .toUri();
 
         return ResponseEntity.created(location).body(ApiResponse.onCreated(reportId));
     }
 
     @Schema(
-            name = "DepartmentEduReportCreateMultipartRequestDoc",
-            description = "부서 교육 게시물 생성 multipart 요청")
+        name = "DepartmentEduReportCreateMultipartRequestDoc",
+        description = "부서 교육 게시물 생성 multipart 요청")
     static class DepartmentEduReportCreateMultipartRequestDoc {
 
         @Schema(
-                description = "부서 교육 게시물 생성 정보(JSON 파트)",
-                requiredMode = Schema.RequiredMode.REQUIRED)
+            description = "부서 교육 게시물 생성 정보(JSON 파트)",
+            requiredMode = Schema.RequiredMode.REQUIRED)
         public DepartmentEduReportCreateRequestDto requestDto;
 
         @ArraySchema(schema = @Schema(type = "string", format = "binary"))
@@ -395,13 +391,13 @@ public class EduReportController {
     }
 
     @Schema(
-            name = "SafetyEduReportCreateMultipartRequestDoc",
-            description = "안전 보건 게시물 생성 multipart 요청")
+        name = "SafetyEduReportCreateMultipartRequestDoc",
+        description = "안전 보건 게시물 생성 multipart 요청")
     static class SafetyEduReportCreateMultipartRequestDoc {
 
         @Schema(
-                description = "안전 보건 게시물 생성 정보(JSON 파트)",
-                requiredMode = Schema.RequiredMode.REQUIRED)
+            description = "안전 보건 게시물 생성 정보(JSON 파트)",
+            requiredMode = Schema.RequiredMode.REQUIRED)
         public SafetyEduReportCreateRequestDto requestDto;
 
         @ArraySchema(schema = @Schema(type = "string", format = "binary"))
@@ -419,899 +415,935 @@ public class EduReportController {
     }
 
     @Operation(
-            tags = {"부서교육"},
-            summary = "부서 교육 게시물 목록 조회",
-            description =
-                    """
-            부서 교육 게시물 목록을 조회합니다.
+        tags = {"부서교육"},
+        summary = "부서 교육 게시물 목록 조회",
+        description =
+            """
+                부서 교육 게시물 목록을 조회합니다.
 
-            - `MANAGE_DEPARTMENT_EDUCATION` 권한 사용자는 `departmentName`으로 전체 부서 대상 필터 조회가 가능합니다.
-            - `MANAGE_DEPARTMENT_EDUCATION` 권한이 없는 사용자는 본인 소속 부서 게시물만 조회됩니다.
-            """)
+                - `MANAGE_DEPARTMENT_EDUCATION` 권한 사용자는 `departmentName`으로 전체 부서 대상 필터 조회가 가능합니다.
+                - `MANAGE_DEPARTMENT_EDUCATION` 권한이 없는 사용자는 본인 소속 부서 게시물만 조회됩니다.
+                """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "조회 성공",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples =
-                                        @ExampleObject(
-                                                value =
-                                                        """
-          {
-            "isSuccess": true,
-            "code": "COMMON200",
-            "message": "요청에 성공했습니다.",
-            "result": [
-              {
-                "id": 202,
-                "title": "경영지원부 교육",
-                "eduType": "부서 교육",
-                "eduDate": "2026-03-16",
-                "content": "부서교육 게시글입니다.",
-                "attendance": false,
-                "pinned": false,
-                "signatureRequired": true,
-                "status": "OPEN",
-                "categoryId": null,
-                "categoryName": null
-              }
-            ]
-          }
-          """))),
+            responseCode = "200",
+            description = "조회 성공",
+            content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                @ExampleObject(
+                    value =
+                        """
+                            {
+                              "isSuccess": true,
+                              "code": "COMMON200",
+                              "message": "요청에 성공했습니다.",
+                              "result": [
+                                {
+                                  "id": 202,
+                                  "title": "경영지원부 교육",
+                                  "eduType": "부서 교육",
+                                  "eduDate": "2026-03-16",
+                                  "content": "부서교육 게시글입니다.",
+                                  "attendance": false,
+                                  "pinned": false,
+                                  "signatureRequired": true,
+                                  "status": "OPEN",
+                                  "categoryId": null,
+                                  "categoryName": null
+                                }
+                              ]
+                            }
+                            """))),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples = {
-                                    @ExampleObject(
-                                            name = "사용자 없음",
-                                            value =
-                                                    """
-          {
-            "isSuccess": false,
-            "code": "USER_NOT_FOUND",
-            "message": "해당 사용자를 찾을 수 없습니다.",
-            "result": null
-          }
-          """),
-                                    @ExampleObject(
-                                            name = "부서 없음",
-                                            value =
-                                                    """
-          {
-            "isSuccess": false,
-            "code": "DEPARTMENT_NOT_FOUND",
-            "message": "해당 부서를 찾을 수 없습니다.",
-            "result": null
-          }
-          """)
-                                }))
+            responseCode = "404",
+            description = "리소스 없음",
+            content =
+            @Content(
+                mediaType = "application/json",
+                examples = {
+                    @ExampleObject(
+                        name = "사용자 없음",
+                        value =
+                            """
+                                {
+                                  "isSuccess": false,
+                                  "code": "USER_NOT_FOUND",
+                                  "message": "해당 사용자를 찾을 수 없습니다.",
+                                  "result": null
+                                }
+                                """),
+                    @ExampleObject(
+                        name = "부서 없음",
+                        value =
+                            """
+                                {
+                                  "isSuccess": false,
+                                  "code": "DEPARTMENT_NOT_FOUND",
+                                  "message": "해당 부서를 찾을 수 없습니다.",
+                                  "result": null
+                                }
+                                """)
+                }))
     })
     @GetMapping("/department")
     public ResponseEntity<ApiResponse<List<EduReportSummaryDto>>> getDepartmentEduReports(
-            @Parameter(description = "부서명 필터(권한 사용자 전용)", example = "SALES_DEPT")
-                    @RequestParam(required = false)
-                    DepartmentName departmentName,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        @Parameter(description = "부서명 필터(권한 사용자 전용)", example = "SALES_DEPT")
+        @RequestParam(required = false)
+        DepartmentName departmentName,
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         List<EduReportSummaryDto> reports =
-                eduReportService.getDepartmentEduReports(departmentName, userDetails.getId());
+            eduReportService.getDepartmentEduReports(departmentName, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(reports));
     }
 
     @Operation(
-            tags = {"PSM"},
-            summary = "PSM 게시물 목록 조회",
-            description =
-                    """
-            PSM 게시물 목록을 조회합니다.
+        tags = {"PSM"},
+        summary = "PSM 게시물 목록 조회",
+        description =
+            """
+                PSM 게시물 목록을 조회합니다.
 
-            - `MANAGE_PSM` 권한 사용자는 모든 회사의 PSM 게시물을 조회할 수 있습니다.
-            - `MANAGE_PSM` 권한이 없는 사용자는 본인 소속 회사의 PSM 게시물만 조회됩니다.
-            """)
+                - `MANAGE_PSM` 권한 사용자는 모든 회사의 PSM 게시물을 조회할 수 있습니다.
+                - `MANAGE_PSM` 권한이 없는 사용자는 본인 소속 회사의 PSM 게시물만 조회됩니다.
+                """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "조회 성공",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples =
-                                        @ExampleObject(
-                                                value =
-                                                        """
-          {
-            "isSuccess": true,
-            "code": "COMMON200",
-            "message": "요청에 성공했습니다.",
-            "result": [
-              {
-                "id": 301,
-                "title": "PSM 변경관리 교육",
-                "eduType": "PSM",
-                "eduDate": "2026-04-14",
-                "content": "PSM 교육 게시글입니다.",
-                "attendance": false,
-                "pinned": false,
-                "signatureRequired": false,
-                "status": "OPEN",
-                "categoryId": 2,
-                "categoryName": "변경관리"
-              }
-            ]
-          }
-          """))),
+            responseCode = "200",
+            description = "조회 성공",
+            content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                @ExampleObject(
+                    value =
+                        """
+                            {
+                              "isSuccess": true,
+                              "code": "COMMON200",
+                              "message": "요청에 성공했습니다.",
+                              "result": [
+                                {
+                                  "id": 301,
+                                  "title": "PSM 변경관리 교육",
+                                  "eduType": "PSM",
+                                  "eduDate": "2026-04-14",
+                                  "content": "PSM 교육 게시글입니다.",
+                                  "attendance": false,
+                                  "pinned": false,
+                                  "signatureRequired": false,
+                                  "status": "OPEN",
+                                  "categoryId": 2,
+                                  "categoryName": "변경관리"
+                                }
+                              ]
+                            }
+                            """))),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples = {
-                                    @ExampleObject(
-                                            name = "사용자 없음",
-                                            value =
-                                                    """
-          {
-            "isSuccess": false,
-            "code": "USER_NOT_FOUND",
-            "message": "해당 사용자를 찾을 수 없습니다.",
-            "result": null
-          }
-          """)
-                                }))
+            responseCode = "404",
+            description = "리소스 없음",
+            content =
+            @Content(
+                mediaType = "application/json",
+                examples = {
+                    @ExampleObject(
+                        name = "사용자 없음",
+                        value =
+                            """
+                                {
+                                  "isSuccess": false,
+                                  "code": "USER_NOT_FOUND",
+                                  "message": "해당 사용자를 찾을 수 없습니다.",
+                                  "result": null
+                                }
+                                """)
+                }))
     })
     @GetMapping("/psm")
     public ResponseEntity<ApiResponse<List<EduReportSummaryDto>>> getPsmEduReports(
-            @Parameter(description = "카테고리 ID 필터(PSM)", example = "1")
-                    @RequestParam(required = false)
-                    Long categoryId,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        @Parameter(description = "카테고리 ID 필터(PSM)", example = "1")
+        @RequestParam(required = false)
+        Long categoryId,
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         List<EduReportSummaryDto> reports =
-                eduReportService.getPsmEduReports(categoryId, userDetails.getId());
+            eduReportService.getPsmEduReports(categoryId, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(reports));
     }
 
     @Operation(
-            tags = {"안전보건"},
-            summary = "안전 보건 게시물 목록 조회",
-            description =
-                    """
-            안전 보건 게시물 목록을 조회합니다.
+        tags = {"안전보건"},
+        summary = "안전 보건 게시물 목록 조회",
+        description =
+            """
+                안전 보건 게시물 목록을 조회합니다.
 
-            - `MANAGE_SAFETY` 권한 사용자는 모든 회사의 안전 보건 게시물을 조회할 수 있습니다.
-            - `MANAGE_SAFETY` 권한이 없는 사용자는 본인 소속 회사의 안전 보건 게시물만 조회됩니다.
-            """)
+                - `MANAGE_SAFETY` 권한 사용자는 모든 회사의 안전 보건 게시물을 조회할 수 있습니다.
+                - `MANAGE_SAFETY` 권한이 없는 사용자는 본인 소속 회사의 안전 보건 게시물만 조회됩니다.
+                """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "조회 성공",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples =
-                                        @ExampleObject(
-                                                value =
-                                                        """
-          {
-            "isSuccess": true,
-            "code": "COMMON200",
-            "message": "요청에 성공했습니다.",
-            "result": [
-              {
-                "id": 401,
-                "title": "안전 보건 정기교육",
-                "eduType": "안전 보건",
-                "eduDate": "2026-04-14",
-                "content": "안전 보건 교육 게시글입니다.",
-                "attendance": false,
-                "pinned": false,
-                "signatureRequired": true,
-                "status": "OPEN",
-                "categoryId": 3,
-                "categoryName": "정기교육"
-              }
-            ]
-          }
-          """))),
+            responseCode = "200",
+            description = "조회 성공",
+            content =
+            @Content(
+                mediaType = "application/json",
+                examples =
+                @ExampleObject(
+                    value =
+                        """
+                            {
+                              "isSuccess": true,
+                              "code": "COMMON200",
+                              "message": "요청에 성공했습니다.",
+                              "result": [
+                                {
+                                  "id": 401,
+                                  "title": "안전 보건 정기교육",
+                                  "eduType": "안전 보건",
+                                  "eduDate": "2026-04-14",
+                                  "content": "안전 보건 교육 게시글입니다.",
+                                  "attendance": false,
+                                  "pinned": false,
+                                  "signatureRequired": true,
+                                  "status": "OPEN",
+                                  "categoryId": 3,
+                                  "categoryName": "정기교육"
+                                }
+                              ]
+                            }
+                            """))),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples = {
-                                    @ExampleObject(
-                                            name = "사용자 없음",
-                                            value =
-                                                    """
-          {
-            "isSuccess": false,
-            "code": "USER_NOT_FOUND",
-            "message": "해당 사용자를 찾을 수 없습니다.",
-            "result": null
-          }
-          """)
-                                }))
+            responseCode = "404",
+            description = "리소스 없음",
+            content =
+            @Content(
+                mediaType = "application/json",
+                examples = {
+                    @ExampleObject(
+                        name = "사용자 없음",
+                        value =
+                            """
+                                {
+                                  "isSuccess": false,
+                                  "code": "USER_NOT_FOUND",
+                                  "message": "해당 사용자를 찾을 수 없습니다.",
+                                  "result": null
+                                }
+                                """)
+                }))
     })
     @GetMapping("/safety")
     public ResponseEntity<ApiResponse<List<EduReportSummaryDto>>> getSafetyEduReports(
-            @Parameter(description = "카테고리 ID 필터(안전 보건)", example = "1")
-                    @RequestParam(required = false)
-                    Long categoryId,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        @Parameter(description = "카테고리 ID 필터(안전 보건)", example = "1")
+        @RequestParam(required = false)
+        Long categoryId,
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         List<EduReportSummaryDto> reports =
-                eduReportService.getSafetyEduReports(categoryId, userDetails.getId());
+            eduReportService.getSafetyEduReports(categoryId, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(reports));
     }
 
     @Operation(
-            tags = {"부서교육"},
-            summary = "부서 교육 게시물 상세 조회",
-            description =
-                    """
-            부서 교육 게시물 상세 정보를 조회합니다.
+        tags = {"부서교육"},
+        summary = "부서 교육 게시물 상세 조회",
+        description =
+            """
+                부서 교육 게시물 상세 정보를 조회합니다.
 
-            - `MANAGE_DEPARTMENT_EDUCATION` 권한 사용자는 전체 부서의 부서 교육 게시물을 조회할 수 있습니다.
-            - 권한이 없는 사용자는 본인 소속 부서의 게시물만 조회할 수 있습니다.
-            - 권한이 없는 사용자가 타 부서 게시물을 조회하면 `EDU_REPORT_NOT_FOUND(404)`가 반환됩니다.
-            - `MANAGE_DEPARTMENT_EDUCATION` 권한 사용자는 `attendees`, `numberOfPeople`, `numberOfAttendees`를 조회할 수 있으며, 권한이 없는 사용자는 위 필드가 `null`로 반환됩니다.
-            """)
+                - `MANAGE_DEPARTMENT_EDUCATION` 권한 사용자는 전체 부서의 부서 교육 게시물을 조회할 수 있습니다.
+                - 권한이 없는 사용자는 본인 소속 부서의 게시물만 조회할 수 있습니다.
+                - 권한이 없는 사용자가 타 부서 게시물을 조회하면 `EDU_REPORT_NOT_FOUND(404)`가 반환됩니다.
+                - `MANAGE_DEPARTMENT_EDUCATION` 권한 사용자는 `attendees`, `numberOfPeople`, `numberOfAttendees`를 조회할 수 있으며, 권한이 없는 사용자는 위 필드가 `null`로 반환됩니다.
+                """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "조회 성공"),
+            responseCode = "200",
+            description = "조회 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples = {
-                                    @ExampleObject(
-                                            name = "게시물 없음",
-                                            value =
-                                                    """
-              {
-                "isSuccess": false,
-                "code": "EDU_REPORT_NOT_FOUND",
-                "message": "해당 교육 게시물을 찾을 수 없습니다.",
-                "result": null
-              }
-              """),
-                                    @ExampleObject(
-                                            name = "타 부서 접근",
-                                            value =
-                                                    """
-              {
-                "isSuccess": false,
-                "code": "EDU_REPORT_NOT_FOUND",
-                "message": "해당 교육 게시물을 찾을 수 없습니다.",
-                "result": null
-              }
-              """),
-                                    @ExampleObject(
-                                            name = "사용자 없음",
-                                            value =
-                                                    """
-              {
-                "isSuccess": false,
-                "code": "USER_NOT_FOUND",
-                "message": "해당 사용자를 찾을 수 없습니다.",
-                "result": null
-              }
-              """)
-                                }))
+            responseCode = "404",
+            description = "리소스 없음",
+            content =
+            @Content(
+                mediaType = "application/json",
+                examples = {
+                    @ExampleObject(
+                        name = "게시물 없음",
+                        value =
+                            """
+                                {
+                                  "isSuccess": false,
+                                  "code": "EDU_REPORT_NOT_FOUND",
+                                  "message": "해당 교육 게시물을 찾을 수 없습니다.",
+                                  "result": null
+                                }
+                                """),
+                    @ExampleObject(
+                        name = "타 부서 접근",
+                        value =
+                            """
+                                {
+                                  "isSuccess": false,
+                                  "code": "EDU_REPORT_NOT_FOUND",
+                                  "message": "해당 교육 게시물을 찾을 수 없습니다.",
+                                  "result": null
+                                }
+                                """),
+                    @ExampleObject(
+                        name = "사용자 없음",
+                        value =
+                            """
+                                {
+                                  "isSuccess": false,
+                                  "code": "USER_NOT_FOUND",
+                                  "message": "해당 사용자를 찾을 수 없습니다.",
+                                  "result": null
+                                }
+                                """)
+                }))
     })
     @GetMapping("/department/{educationId}")
     public ResponseEntity<ApiResponse<EduReportDetailDto>> getDepartmentEduReport(
-            @Parameter(description = "조회할 부서 교육 게시물 ID", example = "1") @PathVariable
-                    Long educationId,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        @Parameter(description = "조회할 부서 교육 게시물 ID", example = "1") @PathVariable
+        Long educationId,
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         EduReportDetailDto report =
-                eduReportService.getDepartmentEduReport(educationId, userDetails.getId());
+            eduReportService.getDepartmentEduReport(educationId, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(report));
     }
 
     @Operation(
-            tags = {"PSM"},
-            summary = "PSM 게시물 상세 조회",
-            description =
-                    """
-            PSM 게시물 상세 정보를 조회합니다.
+        tags = {"PSM"},
+        summary = "PSM 게시물 상세 조회",
+        description =
+            """
+                PSM 게시물 상세 정보를 조회합니다.
 
-            - `MANAGE_PSM` 권한 사용자는 모든 회사의 PSM 게시물을 조회할 수 있습니다.
-            - 권한이 없는 사용자는 본인 소속 회사 게시물과 공통 게시물(`companyScope=null`)만 조회할 수 있습니다.
-            - 권한이 없는 사용자가 타 회사 게시물을 조회하면 `EDU_REPORT_NOT_FOUND(404)`가 반환됩니다.
-            """)
+                - `MANAGE_PSM` 권한 사용자는 모든 회사의 PSM 게시물을 조회할 수 있습니다.
+                - 권한이 없는 사용자는 본인 소속 회사 게시물과 공통 게시물(`companyScope=null`)만 조회할 수 있습니다.
+                - 권한이 없는 사용자가 타 회사 게시물을 조회하면 `EDU_REPORT_NOT_FOUND(404)`가 반환됩니다.
+                """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "조회 성공"),
+            responseCode = "200",
+            description = "조회 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples = {
-                                    @ExampleObject(
-                                            name = "게시물 없음",
-                                            value =
-                                                    """
-              {
-                "isSuccess": false,
-                "code": "EDU_REPORT_NOT_FOUND",
-                "message": "해당 교육 게시물을 찾을 수 없습니다.",
-                "result": null
-              }
-              """),
-                                    @ExampleObject(
-                                            name = "타 회사 접근",
-                                            value =
-                                                    """
-              {
-                "isSuccess": false,
-                "code": "EDU_REPORT_NOT_FOUND",
-                "message": "해당 교육 게시물을 찾을 수 없습니다.",
-                "result": null
-              }
-              """),
-                                    @ExampleObject(
-                                            name = "사용자 없음",
-                                            value =
-                                                    """
-              {
-                "isSuccess": false,
-                "code": "USER_NOT_FOUND",
-                "message": "해당 사용자를 찾을 수 없습니다.",
-                "result": null
-              }
-              """)
-                                }))
+            responseCode = "404",
+            description = "리소스 없음",
+            content =
+            @Content(
+                mediaType = "application/json",
+                examples = {
+                    @ExampleObject(
+                        name = "게시물 없음",
+                        value =
+                            """
+                                {
+                                  "isSuccess": false,
+                                  "code": "EDU_REPORT_NOT_FOUND",
+                                  "message": "해당 교육 게시물을 찾을 수 없습니다.",
+                                  "result": null
+                                }
+                                """),
+                    @ExampleObject(
+                        name = "타 회사 접근",
+                        value =
+                            """
+                                {
+                                  "isSuccess": false,
+                                  "code": "EDU_REPORT_NOT_FOUND",
+                                  "message": "해당 교육 게시물을 찾을 수 없습니다.",
+                                  "result": null
+                                }
+                                """),
+                    @ExampleObject(
+                        name = "사용자 없음",
+                        value =
+                            """
+                                {
+                                  "isSuccess": false,
+                                  "code": "USER_NOT_FOUND",
+                                  "message": "해당 사용자를 찾을 수 없습니다.",
+                                  "result": null
+                                }
+                                """)
+                }))
     })
     @GetMapping("/psm/{educationId}")
     public ResponseEntity<ApiResponse<EduReportDetailDto>> getPsmEduReport(
-            @Parameter(description = "조회할 PSM 게시물 ID", example = "1") @PathVariable
-                    Long educationId,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        @Parameter(description = "조회할 PSM 게시물 ID", example = "1") @PathVariable
+        Long educationId,
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         EduReportDetailDto report =
-                eduReportService.getPsmEduReport(educationId, userDetails.getId());
+            eduReportService.getPsmEduReport(educationId, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(report));
     }
 
     @Operation(
-            tags = {"안전보건"},
-            summary = "안전 보건 게시물 상세 조회",
-            description =
-                    """
-            안전 보건 게시물 상세 정보를 조회합니다.
+        tags = {"안전보건"},
+        summary = "안전 보건 게시물 상세 조회",
+        description =
+            """
+                안전 보건 게시물 상세 정보를 조회합니다.
 
-            - `MANAGE_SAFETY` 권한 사용자는 모든 회사의 안전 보건 게시물을 조회할 수 있습니다.
-            - 권한이 없는 사용자는 본인 소속 회사 게시물과 공통 게시물(`companyScope=null`)만 조회할 수 있습니다.
-            - 권한이 없는 사용자가 타 회사 게시물을 조회하면 `EDU_REPORT_NOT_FOUND(404)`가 반환됩니다.
-            """)
+                - `MANAGE_SAFETY` 권한 사용자는 모든 회사의 안전 보건 게시물을 조회할 수 있습니다.
+                - 권한이 없는 사용자는 본인 소속 회사 게시물과 공통 게시물(`companyScope=null`)만 조회할 수 있습니다.
+                - 권한이 없는 사용자가 타 회사 게시물을 조회하면 `EDU_REPORT_NOT_FOUND(404)`가 반환됩니다.
+                """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "조회 성공"),
+            responseCode = "200",
+            description = "조회 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples = {
-                                    @ExampleObject(
-                                            name = "게시물 없음",
-                                            value =
-                                                    """
-              {
-                "isSuccess": false,
-                "code": "EDU_REPORT_NOT_FOUND",
-                "message": "해당 교육 게시물을 찾을 수 없습니다.",
-                "result": null
-              }
-              """),
-                                    @ExampleObject(
-                                            name = "타 회사 접근",
-                                            value =
-                                                    """
-              {
-                "isSuccess": false,
-                "code": "EDU_REPORT_NOT_FOUND",
-                "message": "해당 교육 게시물을 찾을 수 없습니다.",
-                "result": null
-              }
-              """),
-                                    @ExampleObject(
-                                            name = "사용자 없음",
-                                            value =
-                                                    """
-              {
-                "isSuccess": false,
-                "code": "USER_NOT_FOUND",
-                "message": "해당 사용자를 찾을 수 없습니다.",
-                "result": null
-              }
-              """)
-                                }))
+            responseCode = "404",
+            description = "리소스 없음",
+            content =
+            @Content(
+                mediaType = "application/json",
+                examples = {
+                    @ExampleObject(
+                        name = "게시물 없음",
+                        value =
+                            """
+                                {
+                                  "isSuccess": false,
+                                  "code": "EDU_REPORT_NOT_FOUND",
+                                  "message": "해당 교육 게시물을 찾을 수 없습니다.",
+                                  "result": null
+                                }
+                                """),
+                    @ExampleObject(
+                        name = "타 회사 접근",
+                        value =
+                            """
+                                {
+                                  "isSuccess": false,
+                                  "code": "EDU_REPORT_NOT_FOUND",
+                                  "message": "해당 교육 게시물을 찾을 수 없습니다.",
+                                  "result": null
+                                }
+                                """),
+                    @ExampleObject(
+                        name = "사용자 없음",
+                        value =
+                            """
+                                {
+                                  "isSuccess": false,
+                                  "code": "USER_NOT_FOUND",
+                                  "message": "해당 사용자를 찾을 수 없습니다.",
+                                  "result": null
+                                }
+                                """)
+                }))
     })
     @GetMapping("/safety/{educationId}")
     public ResponseEntity<ApiResponse<EduReportDetailDto>> getSafetyEduReport(
-            @Parameter(description = "조회할 안전 보건 게시물 ID", example = "1") @PathVariable
-                    Long educationId,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        @Parameter(description = "조회할 안전 보건 게시물 ID", example = "1") @PathVariable
+        Long educationId,
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         EduReportDetailDto report =
-                eduReportService.getSafetyEduReport(educationId, userDetails.getId());
+            eduReportService.getSafetyEduReport(educationId, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(report));
     }
 
     @Operation(
-            tags = {"부서교육"},
-            summary = "부서 교육 게시물 수정",
-            description =
-                    """
-            `multipart/form-data`로 부서 교육 게시물을 수정합니다.
+        tags = {"부서교육"},
+        summary = "부서 교육 게시물 수정",
+        description =
+            """
+                `multipart/form-data`로 부서 교육 게시물을 수정합니다.
 
-            - 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 필요합니다.
-            - `OPEN` 상태에서만 수정 가능합니다.
-            - 출석 완료자가 1명이라도 있으면 수정할 수 없습니다.
-            - `requestDto`(JSON 파트)는 필수이며, `files`(파일 파트)는 선택입니다.
-            - `requestDto.deleteAttachmentIds`로 기존 첨부파일 삭제가 가능합니다.
-            """,
-            requestBody =
-                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                            required = true,
-                            content =
-                                    @Content(
-                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-                                            schema =
-                                                    @Schema(
-                                                            implementation =
-                                                                    EduReportUpdateMultipartRequestDoc
-                                                                            .class),
-                                            encoding = {
-                                                @Encoding(
-                                                        name = "requestDto",
-                                                        contentType =
-                                                                MediaType.APPLICATION_JSON_VALUE),
-                                                @Encoding(name = "files", contentType = "*/*")
-                                            })))
+                - 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 필요합니다.
+                - `OPEN` 상태에서만 수정 가능합니다.
+                - 출석 완료자가 1명이라도 있으면 수정할 수 없습니다.
+                - `requestDto`(JSON 파트)는 필수이며, `files`(파일 파트)는 선택입니다.
+                - `requestDto.deleteAttachmentIds`로 기존 첨부파일 삭제가 가능합니다.
+                """,
+        requestBody =
+        @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            required = true,
+            content =
+            @Content(
+                mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                schema =
+                @Schema(
+                    implementation =
+                        EduReportUpdateMultipartRequestDoc
+                            .class),
+                encoding = {
+                    @Encoding(
+                        name = "requestDto",
+                        contentType =
+                            MediaType.APPLICATION_JSON_VALUE),
+                    @Encoding(name = "files", contentType = "*/*")
+                })))
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "수정 성공"),
+            responseCode = "200",
+            description = "수정 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "400",
-                description = "잘못된 요청"),
+            responseCode = "400",
+            description = "잘못된 요청"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "403",
-                description = "권한 없음"),
+            responseCode = "403",
+            description = "권한 없음"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음")
+            responseCode = "404",
+            description = "리소스 없음")
     })
     @PatchMapping(
-            value = "/department/{educationId}",
-            consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+        value = "/department/{educationId}",
+        consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Long>> updateDepartmentEducation(
-            @Parameter(description = "수정할 부서 교육 게시물 ID", example = "1") @PathVariable
-                    Long educationId,
-            @Parameter(description = "부서 교육 수정 정보(JSON)", required = true)
-                    @RequestPart("requestDto")
-                    @Valid
-                    EduReportUpdateRequestDto requestDto,
-            @Parameter(description = "추가할 첨부 파일 목록(선택)")
-                    @RequestPart(value = "files", required = false)
-                    List<MultipartFile> files,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        @Parameter(description = "수정할 부서 교육 게시물 ID", example = "1") @PathVariable
+        Long educationId,
+        @Parameter(description = "부서 교육 수정 정보(JSON)", required = true)
+        @RequestPart("requestDto")
+        @Valid
+        EduReportUpdateRequestDto requestDto,
+        @Parameter(description = "추가할 첨부 파일 목록(선택)")
+        @RequestPart(value = "files", required = false)
+        List<MultipartFile> files,
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long updatedId =
-                eduReportService.updateDepartmentEduReport(
-                        educationId, requestDto, files, userDetails.getId());
+            eduReportService.updateDepartmentEduReport(
+                educationId, requestDto, files, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
     }
 
     @Hidden
     @PatchMapping(value = "/department/{educationId}", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiResponse<Long>> updateDepartmentEducationJsonFallback(
-            @PathVariable Long educationId,
-            @Valid @RequestBody EduReportUpdateRequestDto requestDto,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        @PathVariable Long educationId,
+        @Valid @RequestBody EduReportUpdateRequestDto requestDto,
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long updatedId =
-                eduReportService.updateDepartmentEduReport(
-                        educationId, requestDto, userDetails.getId());
+            eduReportService.updateDepartmentEduReport(
+                educationId, requestDto, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
     }
 
     @Operation(
-            tags = {"PSM"},
-            summary = "PSM 게시물 수정",
-            description =
-                    """
-            `multipart/form-data`로 PSM 게시물을 수정합니다.
+        tags = {"PSM"},
+        summary = "PSM 게시물 수정",
+        description =
+            """
+                `multipart/form-data`로 PSM 게시물을 수정합니다.
 
-            - PSM 관리 권한(`MANAGE_PSM`)이 필요합니다.
-            - `OPEN` 상태에서만 수정 가능합니다.
-            - 출석 완료자가 1명이라도 있으면 수정할 수 없습니다.
-            - `requestDto`(JSON 파트)는 필수이며, `files`(파일 파트)는 선택입니다.
-            - `requestDto.deleteAttachmentIds`로 기존 첨부파일 삭제가 가능합니다.
-            """,
-            requestBody =
-                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                            required = true,
-                            content =
-                                    @Content(
-                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-                                            schema =
-                                                    @Schema(
-                                                            implementation =
-                                                                    EduReportUpdateMultipartRequestDoc
-                                                                            .class),
-                                            encoding = {
-                                                @Encoding(
-                                                        name = "requestDto",
-                                                        contentType =
-                                                                MediaType.APPLICATION_JSON_VALUE),
-                                                @Encoding(name = "files", contentType = "*/*")
-                                            })))
+                - PSM 관리 권한(`MANAGE_PSM`)이 필요합니다.
+                - `OPEN` 상태에서만 수정 가능합니다.
+                - 출석 완료자가 1명이라도 있으면 수정할 수 없습니다.
+                - `requestDto`(JSON 파트)는 필수이며, `files`(파일 파트)는 선택입니다.
+                - `requestDto.deleteAttachmentIds`로 기존 첨부파일 삭제가 가능합니다.
+                """,
+        requestBody =
+        @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            required = true,
+            content =
+            @Content(
+                mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                schema =
+                @Schema(
+                    implementation =
+                        EduReportUpdateMultipartRequestDoc
+                            .class),
+                encoding = {
+                    @Encoding(
+                        name = "requestDto",
+                        contentType =
+                            MediaType.APPLICATION_JSON_VALUE),
+                    @Encoding(name = "files", contentType = "*/*")
+                })))
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "수정 성공"),
+            responseCode = "200",
+            description = "수정 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "400",
-                description = "잘못된 요청"),
+            responseCode = "400",
+            description = "잘못된 요청"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "403",
-                description = "권한 없음"),
+            responseCode = "403",
+            description = "권한 없음"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음")
+            responseCode = "404",
+            description = "리소스 없음")
     })
     @PatchMapping(value = "/psm/{educationId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Long>> updatePsmEducation(
-            @Parameter(description = "수정할 PSM 게시물 ID", example = "1") @PathVariable
-                    Long educationId,
-            @Parameter(description = "PSM 수정 정보(JSON)", required = true)
-                    @RequestPart("requestDto")
-                    @Valid
-                    EduReportUpdateRequestDto requestDto,
-            @Parameter(description = "추가할 첨부 파일 목록(선택)")
-                    @RequestPart(value = "files", required = false)
-                    List<MultipartFile> files,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        @Parameter(description = "수정할 PSM 게시물 ID", example = "1") @PathVariable
+        Long educationId,
+        @Parameter(description = "PSM 수정 정보(JSON)", required = true)
+        @RequestPart("requestDto")
+        @Valid
+        EduReportUpdateRequestDto requestDto,
+        @Parameter(description = "추가할 첨부 파일 목록(선택)")
+        @RequestPart(value = "files", required = false)
+        List<MultipartFile> files,
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long updatedId =
-                eduReportService.updatePsmEduReport(
-                        educationId, requestDto, files, userDetails.getId());
+            eduReportService.updatePsmEduReport(
+                educationId, requestDto, files, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
     }
 
     @Hidden
     @PatchMapping(value = "/psm/{educationId}", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiResponse<Long>> updatePsmEducationJsonFallback(
-            @PathVariable Long educationId,
-            @Valid @RequestBody EduReportUpdateRequestDto requestDto,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        @PathVariable Long educationId,
+        @Valid @RequestBody EduReportUpdateRequestDto requestDto,
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long updatedId =
-                eduReportService.updatePsmEduReport(educationId, requestDto, userDetails.getId());
+            eduReportService.updatePsmEduReport(educationId, requestDto, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
     }
 
     @Operation(
-            tags = {"안전보건"},
-            summary = "안전 보건 게시물 수정",
-            description =
-                    """
-            `multipart/form-data`로 안전 보건 게시물을 수정합니다.
+        tags = {"안전보건"},
+        summary = "안전 보건 게시물 수정",
+        description =
+            """
+                `multipart/form-data`로 안전 보건 게시물을 수정합니다.
 
-            - 안전 보건 관리 권한(`MANAGE_SAFETY`)이 필요합니다.
-            - `OPEN` 상태에서만 수정 가능합니다.
-            - 출석 완료자가 1명이라도 있으면 수정할 수 없습니다.
-            - `requestDto`(JSON 파트)는 필수이며, `files`(파일 파트)는 선택입니다.
-            - `requestDto.deleteAttachmentIds`로 기존 첨부파일 삭제가 가능합니다.
-            """,
-            requestBody =
-                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                            required = true,
-                            content =
-                                    @Content(
-                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-                                            schema =
-                                                    @Schema(
-                                                            implementation =
-                                                                    EduReportUpdateMultipartRequestDoc
-                                                                            .class),
-                                            encoding = {
-                                                @Encoding(
-                                                        name = "requestDto",
-                                                        contentType =
-                                                                MediaType.APPLICATION_JSON_VALUE),
-                                                @Encoding(name = "files", contentType = "*/*")
-                                            })))
+                - 안전 보건 관리 권한(`MANAGE_SAFETY`)이 필요합니다.
+                - `OPEN` 상태에서만 수정 가능합니다.
+                - 출석 완료자가 1명이라도 있으면 수정할 수 없습니다.
+                - `requestDto`(JSON 파트)는 필수이며, `files`(파일 파트)는 선택입니다.
+                - `requestDto.deleteAttachmentIds`로 기존 첨부파일 삭제가 가능합니다.
+                """,
+        requestBody =
+        @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            required = true,
+            content =
+            @Content(
+                mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                schema =
+                @Schema(
+                    implementation =
+                        EduReportUpdateMultipartRequestDoc
+                            .class),
+                encoding = {
+                    @Encoding(
+                        name = "requestDto",
+                        contentType =
+                            MediaType.APPLICATION_JSON_VALUE),
+                    @Encoding(name = "files", contentType = "*/*")
+                })))
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "수정 성공"),
+            responseCode = "200",
+            description = "수정 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "400",
-                description = "잘못된 요청"),
+            responseCode = "400",
+            description = "잘못된 요청"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "403",
-                description = "권한 없음"),
+            responseCode = "403",
+            description = "권한 없음"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음")
+            responseCode = "404",
+            description = "리소스 없음")
     })
     @PatchMapping(value = "/safety/{educationId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Long>> updateSafetyEducation(
-            @Parameter(description = "수정할 안전 보건 게시물 ID", example = "1") @PathVariable
-                    Long educationId,
-            @Parameter(description = "안전 보건 수정 정보(JSON)", required = true)
-                    @RequestPart("requestDto")
-                    @Valid
-                    EduReportUpdateRequestDto requestDto,
-            @Parameter(description = "추가할 첨부 파일 목록(선택)")
-                    @RequestPart(value = "files", required = false)
-                    List<MultipartFile> files,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        @Parameter(description = "수정할 안전 보건 게시물 ID", example = "1") @PathVariable
+        Long educationId,
+        @Parameter(description = "안전 보건 수정 정보(JSON)", required = true)
+        @RequestPart("requestDto")
+        @Valid
+        EduReportUpdateRequestDto requestDto,
+        @Parameter(description = "추가할 첨부 파일 목록(선택)")
+        @RequestPart(value = "files", required = false)
+        List<MultipartFile> files,
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long updatedId =
-                eduReportService.updateSafetyEduReport(
-                        educationId, requestDto, files, userDetails.getId());
+            eduReportService.updateSafetyEduReport(
+                educationId, requestDto, files, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
     }
 
     @Hidden
     @PatchMapping(value = "/safety/{educationId}", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiResponse<Long>> updateSafetyEducationJsonFallback(
-            @PathVariable Long educationId,
-            @Valid @RequestBody EduReportUpdateRequestDto requestDto,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        @PathVariable Long educationId,
+        @Valid @RequestBody EduReportUpdateRequestDto requestDto,
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long updatedId =
-                eduReportService.updateSafetyEduReport(
-                        educationId, requestDto, userDetails.getId());
+            eduReportService.updateSafetyEduReport(
+                educationId, requestDto, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
     }
 
     @Operation(
-            tags = {"부서교육"},
-            summary = "부서 교육 게시물 상태 변경",
-            description =
-                    """
-            부서 교육 게시물 상태를 `OPEN`/`CLOSED`로 변경합니다.
+        tags = {"부서교육"},
+        summary = "부서 교육 게시물 상태 변경",
+        description =
+            """
+                부서 교육 게시물 상태를 `OPEN`/`CLOSED`로 변경합니다.
 
-            - 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 필요합니다.
-            """)
+                - 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 필요합니다.
+                """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "상태 변경 성공"),
+            responseCode = "200",
+            description = "상태 변경 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "400",
-                description = "잘못된 요청"),
+            responseCode = "400",
+            description = "잘못된 요청"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "403",
-                description = "권한 없음"),
+            responseCode = "403",
+            description = "권한 없음"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음")
+            responseCode = "404",
+            description = "리소스 없음")
     })
     @PatchMapping("/department/{educationId}/status")
     public ResponseEntity<ApiResponse<Long>> updateDepartmentEducationStatus(
-            @Parameter(description = "상태 변경할 부서 교육 게시물 ID", example = "1") @PathVariable
-                    Long educationId,
-            @Valid @RequestBody EduReportStatusUpdateRequestDto requestDto,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        @Parameter(description = "상태 변경할 부서 교육 게시물 ID", example = "1") @PathVariable
+        Long educationId,
+        @Valid @RequestBody EduReportStatusUpdateRequestDto requestDto,
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long updatedId =
-                eduReportService.updateDepartmentEduReportStatus(
-                        educationId, requestDto, userDetails.getId());
+            eduReportService.updateDepartmentEduReportStatus(
+                educationId, requestDto, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
     }
 
     @Operation(
-            tags = {"PSM"},
-            summary = "PSM 게시물 상태 변경",
-            description =
-                    """
-            PSM 게시물 상태를 `OPEN`/`CLOSED`로 변경합니다.
+        tags = {"PSM"},
+        summary = "PSM 게시물 상태 변경",
+        description =
+            """
+                PSM 게시물 상태를 `OPEN`/`CLOSED`로 변경합니다.
 
-            - PSM 관리 권한(`MANAGE_PSM`)이 필요합니다.
-            """)
+                - PSM 관리 권한(`MANAGE_PSM`)이 필요합니다.
+                """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "상태 변경 성공"),
+            responseCode = "200",
+            description = "상태 변경 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "400",
-                description = "잘못된 요청"),
+            responseCode = "400",
+            description = "잘못된 요청"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "403",
-                description = "권한 없음"),
+            responseCode = "403",
+            description = "권한 없음"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음")
+            responseCode = "404",
+            description = "리소스 없음")
     })
     @PatchMapping("/psm/{educationId}/status")
     public ResponseEntity<ApiResponse<Long>> updatePsmEducationStatus(
-            @Parameter(description = "상태 변경할 PSM 게시물 ID", example = "1") @PathVariable
-                    Long educationId,
-            @Valid @RequestBody EduReportStatusUpdateRequestDto requestDto,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        @Parameter(description = "상태 변경할 PSM 게시물 ID", example = "1") @PathVariable
+        Long educationId,
+        @Valid @RequestBody EduReportStatusUpdateRequestDto requestDto,
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long updatedId =
-                eduReportService.updatePsmEduReportStatus(
-                        educationId, requestDto, userDetails.getId());
+            eduReportService.updatePsmEduReportStatus(
+                educationId, requestDto, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
     }
 
     @Operation(
-            tags = {"안전보건"},
-            summary = "안전 보건 게시물 상태 변경",
-            description =
-                    """
-            안전 보건 게시물 상태를 `OPEN`/`CLOSED`로 변경합니다.
+        tags = {"안전보건"},
+        summary = "안전 보건 게시물 상태 변경",
+        description =
+            """
+                안전 보건 게시물 상태를 `OPEN`/`CLOSED`로 변경합니다.
 
-            - 안전 보건 관리 권한(`MANAGE_SAFETY`)이 필요합니다.
-            """)
+                - 안전 보건 관리 권한(`MANAGE_SAFETY`)이 필요합니다.
+                """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "상태 변경 성공"),
+            responseCode = "200",
+            description = "상태 변경 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "400",
-                description = "잘못된 요청"),
+            responseCode = "400",
+            description = "잘못된 요청"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "403",
-                description = "권한 없음"),
+            responseCode = "403",
+            description = "권한 없음"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음")
+            responseCode = "404",
+            description = "리소스 없음")
     })
     @PatchMapping("/safety/{educationId}/status")
     public ResponseEntity<ApiResponse<Long>> updateSafetyEducationStatus(
-            @Parameter(description = "상태 변경할 안전 보건 게시물 ID", example = "1") @PathVariable
-                    Long educationId,
-            @Valid @RequestBody EduReportStatusUpdateRequestDto requestDto,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        @Parameter(description = "상태 변경할 안전 보건 게시물 ID", example = "1") @PathVariable
+        Long educationId,
+        @Valid @RequestBody EduReportStatusUpdateRequestDto requestDto,
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long updatedId =
-                eduReportService.updateSafetyEduReportStatus(
-                        educationId, requestDto, userDetails.getId());
+            eduReportService.updateSafetyEduReportStatus(
+                educationId, requestDto, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
     }
 
     @Operation(
-            tags = {"부서교육"},
-            summary = "부서 교육 게시물 삭제",
-            description = "부서 교육 게시물을 삭제합니다. 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 필요합니다.")
+        tags = {"부서교육"},
+        summary = "부서 교육 게시물 삭제",
+        description = "부서 교육 게시물을 삭제합니다. 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 필요합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "삭제 성공"),
+            responseCode = "200",
+            description = "삭제 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "403",
-                description = "권한 없음"),
+            responseCode = "403",
+            description = "권한 없음"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음")
+            responseCode = "404",
+            description = "리소스 없음")
     })
     @DeleteMapping("/department/{educationId}")
     public ResponseEntity<ApiResponse<Void>> deleteDepartmentEduReport(
-            @Parameter(description = "삭제할 부서 교육 게시물 ID", example = "1") @PathVariable
-                    Long educationId,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        @Parameter(description = "삭제할 부서 교육 게시물 ID", example = "1") @PathVariable
+        Long educationId,
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         eduReportService.deleteDepartmentEduReport(educationId, userDetails.getId());
         return ResponseEntity.ok().body(ApiResponse.onNoContent());
     }
 
     @Operation(
-            tags = {"PSM"},
-            summary = "PSM 게시물 삭제",
-            description = "PSM 게시물을 삭제합니다. PSM 관리 권한(`MANAGE_PSM`)이 필요합니다.")
+        tags = {"PSM"},
+        summary = "PSM 게시물 삭제",
+        description = "PSM 게시물을 삭제합니다. PSM 관리 권한(`MANAGE_PSM`)이 필요합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "삭제 성공"),
+            responseCode = "200",
+            description = "삭제 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "403",
-                description = "권한 없음"),
+            responseCode = "403",
+            description = "권한 없음"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음")
+            responseCode = "404",
+            description = "리소스 없음")
     })
     @DeleteMapping("/psm/{educationId}")
     public ResponseEntity<ApiResponse<Void>> deletePsmEduReport(
-            @Parameter(description = "삭제할 PSM 게시물 ID", example = "1") @PathVariable
-                    Long educationId,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        @Parameter(description = "삭제할 PSM 게시물 ID", example = "1") @PathVariable
+        Long educationId,
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         eduReportService.deletePsmEduReport(educationId, userDetails.getId());
         return ResponseEntity.ok().body(ApiResponse.onNoContent());
     }
 
     @Operation(
-            tags = {"안전보건"},
-            summary = "안전 보건 게시물 삭제",
-            description = "안전 보건 게시물을 삭제합니다. 안전 보건 관리 권한(`MANAGE_SAFETY`)이 필요합니다.")
+        tags = {"안전보건"},
+        summary = "안전 보건 게시물 삭제",
+        description = "안전 보건 게시물을 삭제합니다. 안전 보건 관리 권한(`MANAGE_SAFETY`)이 필요합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "삭제 성공"),
+            responseCode = "200",
+            description = "삭제 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "403",
-                description = "권한 없음"),
+            responseCode = "403",
+            description = "권한 없음"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음")
+            responseCode = "404",
+            description = "리소스 없음")
     })
     @DeleteMapping("/safety/{educationId}")
     public ResponseEntity<ApiResponse<Void>> deleteSafetyEduReport(
-            @Parameter(description = "삭제할 안전 보건 게시물 ID", example = "1") @PathVariable
-                    Long educationId,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        @Parameter(description = "삭제할 안전 보건 게시물 ID", example = "1") @PathVariable
+        Long educationId,
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         eduReportService.deleteSafetyEduReport(educationId, userDetails.getId());
         return ResponseEntity.ok().body(ApiResponse.onNoContent());
     }
 
     @Operation(
-            tags = {"부서교육"},
-            summary = "부서 교육 게시물 출석(서명) 처리",
-            description =
-                    """
-            부서 교육 게시물 출석을 처리합니다.
+        tags = {"부서교육"},
+        summary = "부서 교육 게시물 출석(서명) 처리",
+        description =
+            """
+                부서 교육 게시물 출석을 처리합니다.
 
-            - `signatureRequired=true` 게시물은 PNG 서명 파일(`signature`)이 필수입니다.
-            - `signatureRequired=false` 게시물은 파일 없이도 출석 처리됩니다.
-            - 동일 사용자 중복 출석은 허용되지 않습니다.
-            """,
-            requestBody =
-                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                            required = false,
-                            content =
-                                    @Content(
-                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-                                            schema =
-                                                    @Schema(
-                                                            implementation =
-                                                                    EduReportAttendanceMultipartRequestDoc
-                                                                            .class),
-                                            encoding =
-                                                    @Encoding(
-                                                            name = "signature",
-                                                            contentType = "image/png"))))
+                - `signatureRequired=true` 게시물은 PNG 서명 파일(`signature`)이 필수입니다.
+                - `signatureRequired=false` 게시물은 파일 없이도 출석 처리됩니다.
+                - 동일 사용자 중복 출석은 허용되지 않습니다.
+                """,
+        requestBody =
+        @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            required = false,
+            content =
+            @Content(
+                mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                schema =
+                @Schema(
+                    implementation =
+                        EduReportAttendanceMultipartRequestDoc
+                            .class),
+                encoding =
+                @Encoding(
+                    name = "signature",
+                    contentType = "image/png"))))
     @ApiResponses(
-            value = {
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "200",
-                        description = "출석 처리 성공"),
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "400",
-                        description = "잘못된 요청"),
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "404",
-                        description = "리소스 없음")
-            })
+        value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "출석 처리 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "리소스 없음")
+        })
     @PostMapping(
-            value = "/department/{educationId}/attendance",
-            consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+        value = "/department/{educationId}/attendance",
+        consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Void>> markDepartmentAttendance(
-            @Parameter(description = "부서 교육 게시물 ID", example = "1") @PathVariable Long educationId,
-            @Parameter(description = "서명 PNG 파일(signatureRequired=true인 경우 필수)")
-                    @RequestPart(value = "signature", required = false)
-                    MultipartFile signature,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
-            throws IOException {
+        @Parameter(description = "부서 교육 게시물 ID", example = "1") @PathVariable Long educationId,
+        @Parameter(description = "서명 PNG 파일(signatureRequired=true인 경우 필수)")
+        @RequestPart(value = "signature", required = false)
+        MultipartFile signature,
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
+        throws IOException {
         eduReportService.markDepartmentAttendance(educationId, signature, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onNoContent());
+    }
+
+    @Operation(
+        tags = {"부서교육", "PSM", "안전보건"},
+        summary = "서명 현황 목록 조회",
+        description =
+            """
+                교육 보고서의 대상 직원별 서명 현황을 조회합니다.
+
+                - 교육 유형에 따라 권한 검증이 이루어집니다.
+                  - 부서교육: `MANAGE_DEPARTMENT_EDUCATION`
+                  - PSM: `MANAGE_PSM`
+                  - 안전보건: `MANAGE_SAFETY`
+                - `name` 파라미터로 한글명(nameKor) 또는 영문명(nameEng)에 대한 부분 일치 검색이 가능합니다.
+                """)
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "403",
+            description = "권한 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404",
+            description = "리소스 없음")
+    })
+    @GetMapping("/{educationId}/signatures")
+    public ResponseEntity<ApiResponse<List<EduReportSignatureStatusDto>>> getSignatureStatuses(
+        @Parameter(description = "교육 보고서 ID", example = "1") @PathVariable Long educationId,
+        @Parameter(description = "직원명 검색 필터 (한글명/영문명 부분 일치)", example = "홍")
+        @RequestParam(required = false)
+        String name,
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<EduReportSignatureStatusDto> result =
+            eduReportService.getSignatureStatuses(educationId, name, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
 
     @Schema(name = "EduReportAttendanceMultipartRequestDoc", description = "출석(서명) multipart 요청")
     static class EduReportAttendanceMultipartRequestDoc {
 
         @Schema(
-                description = "서명 PNG 파일(signatureRequired=true인 경우 필수)",
-                type = "string",
-                format = "binary")
+            description = "서명 PNG 파일(signatureRequired=true인 경우 필수)",
+            type = "string",
+            format = "binary")
         public String signature;
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
@@ -9,10 +9,9 @@ import io.swagger.v3.oas.annotations.media.Encoding;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
 import jakarta.validation.Valid;
-import java.io.IOException;
-import java.net.URI;
-import java.util.List;
+
 import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
 import kr.co.awesomelead.groupware_backend.domain.education.dto.request.DepartmentEduReportCreateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.education.dto.request.EduReportStatusUpdateRequestDto;
@@ -25,7 +24,9 @@ import kr.co.awesomelead.groupware_backend.domain.education.dto.response.EduRepo
 import kr.co.awesomelead.groupware_backend.domain.education.service.EduReportService;
 import kr.co.awesomelead.groupware_backend.domain.user.dto.CustomUserDetails;
 import kr.co.awesomelead.groupware_backend.global.common.response.ApiResponse;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -42,6 +43,10 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/educations")
@@ -50,46 +55,46 @@ public class EduReportController {
     private final EduReportService eduReportService;
 
     @Operation(
-        tags = {"부서교육"},
-        summary = "부서 교육 게시물 생성",
-        description =
-            """
+            tags = {"부서교육"},
+            summary = "부서 교육 게시물 생성",
+            description =
+                    """
                 `multipart/form-data`로 부서 교육 게시물을 생성합니다.
 
                 - `requestDto`(JSON 파트)는 필수입니다.
                 - `files`(파일 파트)는 선택입니다.
                 - 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 있어야 생성할 수 있습니다.
                 """,
-        requestBody =
-        @io.swagger.v3.oas.annotations.parameters.RequestBody(
-            required = true,
-            content =
-            @Content(
-                mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-                schema =
-                @Schema(
-                    implementation =
-                        DepartmentEduReportCreateMultipartRequestDoc
-                            .class),
-                encoding = {
-                    @Encoding(
-                        name = "requestDto",
-                        contentType =
-                            MediaType.APPLICATION_JSON_VALUE),
-                    @Encoding(name = "files", contentType = "*/*")
-                })))
+            requestBody =
+                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                                            schema =
+                                                    @Schema(
+                                                            implementation =
+                                                                    DepartmentEduReportCreateMultipartRequestDoc
+                                                                            .class),
+                                            encoding = {
+                                                @Encoding(
+                                                        name = "requestDto",
+                                                        contentType =
+                                                                MediaType.APPLICATION_JSON_VALUE),
+                                                @Encoding(name = "files", contentType = "*/*")
+                                            })))
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "201",
-            description = "생성 성공",
-            content =
-            @Content(
-                mediaType = "application/json",
-                schema = @Schema(implementation = ApiResponse.class),
-                examples =
-                @ExampleObject(
-                    value =
-                        """
+                responseCode = "201",
+                description = "생성 성공",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                schema = @Schema(implementation = ApiResponse.class),
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                             {
                               "isSuccess": true,
                               "code": "COMMON201",
@@ -98,15 +103,15 @@ public class EduReportController {
                             }
                             """))),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "403",
-            description = "권한 없음",
-            content =
-            @Content(
-                mediaType = "application/json",
-                examples =
-                @ExampleObject(
-                    value =
-                        """
+                responseCode = "403",
+                description = "권한 없음",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                             {
                               "isSuccess": false,
                               "code": "NO_AUTHORITY_FOR_EDU_REPORT",
@@ -115,15 +120,15 @@ public class EduReportController {
                             }
                             """))),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "404",
-            description = "리소스 없음",
-            content =
-            @Content(
-                mediaType = "application/json",
-                examples =
-                @ExampleObject(
-                    value =
-                        """
+                responseCode = "404",
+                description = "리소스 없음",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                             {
                               "isSuccess": false,
                               "code": "DEPARTMENT_NOT_FOUND",
@@ -134,32 +139,32 @@ public class EduReportController {
     })
     @PostMapping(value = "/department", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Long>> createDepartmentEduReport(
-        @Parameter(description = "부서 교육 게시물 생성 정보(JSON)", required = true)
-        @RequestPart("requestDto")
-        @Valid
-        DepartmentEduReportCreateRequestDto requestDto,
-        @Parameter(description = "첨부 파일 목록(선택)") @RequestPart(value = "files", required = false)
-        List<MultipartFile> files,
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
-        throws IOException {
+            @Parameter(description = "부서 교육 게시물 생성 정보(JSON)", required = true)
+                    @RequestPart("requestDto")
+                    @Valid
+                    DepartmentEduReportCreateRequestDto requestDto,
+            @Parameter(description = "첨부 파일 목록(선택)") @RequestPart(value = "files", required = false)
+                    List<MultipartFile> files,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
+            throws IOException {
 
         Long reportId =
-            eduReportService.createDepartmentEduReport(requestDto, files, userDetails.getId());
+                eduReportService.createDepartmentEduReport(requestDto, files, userDetails.getId());
 
         URI location =
-            ServletUriComponentsBuilder.fromCurrentContextPath()
-                .path("/api/educations/department/{id}")
-                .buildAndExpand(reportId)
-                .toUri();
+                ServletUriComponentsBuilder.fromCurrentContextPath()
+                        .path("/api/educations/department/{id}")
+                        .buildAndExpand(reportId)
+                        .toUri();
 
         return ResponseEntity.created(location).body(ApiResponse.onCreated(reportId));
     }
 
     @Operation(
-        tags = {"PSM"},
-        summary = "PSM 게시물 생성",
-        description =
-            """
+            tags = {"PSM"},
+            summary = "PSM 게시물 생성",
+            description =
+                    """
                 `multipart/form-data`로 PSM 게시물을 생성합니다.
 
                 - `requestDto`(JSON 파트)는 필수입니다.
@@ -167,35 +172,35 @@ public class EduReportController {
                 - PSM 관리 권한(`MANAGE_PSM`)이 있어야 생성할 수 있습니다.
                 - `companyScope`를 지정하면 해당 회사 게시물, `null`이면 모든 회사 공통 게시물로 생성됩니다.
                 """,
-        requestBody =
-        @io.swagger.v3.oas.annotations.parameters.RequestBody(
-            required = true,
-            content =
-            @Content(
-                mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-                schema =
-                @Schema(
-                    implementation =
-                        PsmEduReportCreateMultipartRequestDoc
-                            .class),
-                encoding = {
-                    @Encoding(
-                        name = "requestDto",
-                        contentType =
-                            MediaType.APPLICATION_JSON_VALUE),
-                    @Encoding(name = "files", contentType = "*/*")
-                })))
+            requestBody =
+                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                                            schema =
+                                                    @Schema(
+                                                            implementation =
+                                                                    PsmEduReportCreateMultipartRequestDoc
+                                                                            .class),
+                                            encoding = {
+                                                @Encoding(
+                                                        name = "requestDto",
+                                                        contentType =
+                                                                MediaType.APPLICATION_JSON_VALUE),
+                                                @Encoding(name = "files", contentType = "*/*")
+                                            })))
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "201",
-            description = "생성 성공",
-            content =
-            @Content(
-                mediaType = "application/json",
-                examples =
-                @ExampleObject(
-                    value =
-                        """
+                responseCode = "201",
+                description = "생성 성공",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                             {
                               "isSuccess": true,
                               "code": "COMMON201",
@@ -204,15 +209,15 @@ public class EduReportController {
                             }
                             """))),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "403",
-            description = "권한 없음",
-            content =
-            @Content(
-                mediaType = "application/json",
-                examples =
-                @ExampleObject(
-                    value =
-                        """
+                responseCode = "403",
+                description = "권한 없음",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                             {
                               "isSuccess": false,
                               "code": "NO_AUTHORITY_FOR_PSM_MANAGE",
@@ -221,15 +226,15 @@ public class EduReportController {
                             }
                             """))),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "404",
-            description = "리소스 없음",
-            content =
-            @Content(
-                mediaType = "application/json",
-                examples =
-                @ExampleObject(
-                    value =
-                        """
+                responseCode = "404",
+                description = "리소스 없음",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                             {
                               "isSuccess": false,
                               "code": "EDUCATION_CATEGORY_NOT_FOUND",
@@ -240,31 +245,31 @@ public class EduReportController {
     })
     @PostMapping(value = "/psm", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Long>> createPsmEduReport(
-        @Parameter(description = "PSM 게시물 생성 정보(JSON)", required = true)
-        @RequestPart("requestDto")
-        @Valid
-        PsmEduReportCreateRequestDto requestDto,
-        @Parameter(description = "첨부 파일 목록(선택)") @RequestPart(value = "files", required = false)
-        List<MultipartFile> files,
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
-        throws IOException {
+            @Parameter(description = "PSM 게시물 생성 정보(JSON)", required = true)
+                    @RequestPart("requestDto")
+                    @Valid
+                    PsmEduReportCreateRequestDto requestDto,
+            @Parameter(description = "첨부 파일 목록(선택)") @RequestPart(value = "files", required = false)
+                    List<MultipartFile> files,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
+            throws IOException {
 
         Long reportId = eduReportService.createPsmEduReport(requestDto, files, userDetails.getId());
 
         URI location =
-            ServletUriComponentsBuilder.fromCurrentContextPath()
-                .path("/api/educations/psm/{id}")
-                .buildAndExpand(reportId)
-                .toUri();
+                ServletUriComponentsBuilder.fromCurrentContextPath()
+                        .path("/api/educations/psm/{id}")
+                        .buildAndExpand(reportId)
+                        .toUri();
 
         return ResponseEntity.created(location).body(ApiResponse.onCreated(reportId));
     }
 
     @Operation(
-        tags = {"안전보건"},
-        summary = "안전 보건 게시물 생성",
-        description =
-            """
+            tags = {"안전보건"},
+            summary = "안전 보건 게시물 생성",
+            description =
+                    """
                 `multipart/form-data`로 안전 보건 게시물을 생성합니다.
 
                 - `requestDto`(JSON 파트)는 필수입니다.
@@ -272,35 +277,35 @@ public class EduReportController {
                 - 안전 보건 관리 권한(`MANAGE_SAFETY`)이 있어야 생성할 수 있습니다.
                 - `companyScope`를 지정하면 해당 회사 게시물, `null`이면 모든 회사 공통 게시물로 생성됩니다.
                 """,
-        requestBody =
-        @io.swagger.v3.oas.annotations.parameters.RequestBody(
-            required = true,
-            content =
-            @Content(
-                mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-                schema =
-                @Schema(
-                    implementation =
-                        SafetyEduReportCreateMultipartRequestDoc
-                            .class),
-                encoding = {
-                    @Encoding(
-                        name = "requestDto",
-                        contentType =
-                            MediaType.APPLICATION_JSON_VALUE),
-                    @Encoding(name = "files", contentType = "*/*")
-                })))
+            requestBody =
+                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                                            schema =
+                                                    @Schema(
+                                                            implementation =
+                                                                    SafetyEduReportCreateMultipartRequestDoc
+                                                                            .class),
+                                            encoding = {
+                                                @Encoding(
+                                                        name = "requestDto",
+                                                        contentType =
+                                                                MediaType.APPLICATION_JSON_VALUE),
+                                                @Encoding(name = "files", contentType = "*/*")
+                                            })))
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "201",
-            description = "생성 성공",
-            content =
-            @Content(
-                mediaType = "application/json",
-                examples =
-                @ExampleObject(
-                    value =
-                        """
+                responseCode = "201",
+                description = "생성 성공",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                             {
                               "isSuccess": true,
                               "code": "COMMON201",
@@ -309,15 +314,15 @@ public class EduReportController {
                             }
                             """))),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "403",
-            description = "권한 없음",
-            content =
-            @Content(
-                mediaType = "application/json",
-                examples =
-                @ExampleObject(
-                    value =
-                        """
+                responseCode = "403",
+                description = "권한 없음",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                             {
                               "isSuccess": false,
                               "code": "NO_AUTHORITY_FOR_SAFETY_WRITE",
@@ -326,15 +331,15 @@ public class EduReportController {
                             }
                             """))),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "404",
-            description = "리소스 없음",
-            content =
-            @Content(
-                mediaType = "application/json",
-                examples =
-                @ExampleObject(
-                    value =
-                        """
+                responseCode = "404",
+                description = "리소스 없음",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                             {
                               "isSuccess": false,
                               "code": "EDUCATION_CATEGORY_NOT_FOUND",
@@ -345,35 +350,35 @@ public class EduReportController {
     })
     @PostMapping(value = "/safety", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Long>> createSafetyEduReport(
-        @Parameter(description = "안전 보건 게시물 생성 정보(JSON)", required = true)
-        @RequestPart("requestDto")
-        @Valid
-        SafetyEduReportCreateRequestDto requestDto,
-        @Parameter(description = "첨부 파일 목록(선택)") @RequestPart(value = "files", required = false)
-        List<MultipartFile> files,
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
-        throws IOException {
+            @Parameter(description = "안전 보건 게시물 생성 정보(JSON)", required = true)
+                    @RequestPart("requestDto")
+                    @Valid
+                    SafetyEduReportCreateRequestDto requestDto,
+            @Parameter(description = "첨부 파일 목록(선택)") @RequestPart(value = "files", required = false)
+                    List<MultipartFile> files,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
+            throws IOException {
 
         Long reportId =
-            eduReportService.createSafetyEduReport(requestDto, files, userDetails.getId());
+                eduReportService.createSafetyEduReport(requestDto, files, userDetails.getId());
 
         URI location =
-            ServletUriComponentsBuilder.fromCurrentContextPath()
-                .path("/api/educations/safety/{id}")
-                .buildAndExpand(reportId)
-                .toUri();
+                ServletUriComponentsBuilder.fromCurrentContextPath()
+                        .path("/api/educations/safety/{id}")
+                        .buildAndExpand(reportId)
+                        .toUri();
 
         return ResponseEntity.created(location).body(ApiResponse.onCreated(reportId));
     }
 
     @Schema(
-        name = "DepartmentEduReportCreateMultipartRequestDoc",
-        description = "부서 교육 게시물 생성 multipart 요청")
+            name = "DepartmentEduReportCreateMultipartRequestDoc",
+            description = "부서 교육 게시물 생성 multipart 요청")
     static class DepartmentEduReportCreateMultipartRequestDoc {
 
         @Schema(
-            description = "부서 교육 게시물 생성 정보(JSON 파트)",
-            requiredMode = Schema.RequiredMode.REQUIRED)
+                description = "부서 교육 게시물 생성 정보(JSON 파트)",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         public DepartmentEduReportCreateRequestDto requestDto;
 
         @ArraySchema(schema = @Schema(type = "string", format = "binary"))
@@ -391,13 +396,13 @@ public class EduReportController {
     }
 
     @Schema(
-        name = "SafetyEduReportCreateMultipartRequestDoc",
-        description = "안전 보건 게시물 생성 multipart 요청")
+            name = "SafetyEduReportCreateMultipartRequestDoc",
+            description = "안전 보건 게시물 생성 multipart 요청")
     static class SafetyEduReportCreateMultipartRequestDoc {
 
         @Schema(
-            description = "안전 보건 게시물 생성 정보(JSON 파트)",
-            requiredMode = Schema.RequiredMode.REQUIRED)
+                description = "안전 보건 게시물 생성 정보(JSON 파트)",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         public SafetyEduReportCreateRequestDto requestDto;
 
         @ArraySchema(schema = @Schema(type = "string", format = "binary"))
@@ -415,10 +420,10 @@ public class EduReportController {
     }
 
     @Operation(
-        tags = {"부서교육"},
-        summary = "부서 교육 게시물 목록 조회",
-        description =
-            """
+            tags = {"부서교육"},
+            summary = "부서 교육 게시물 목록 조회",
+            description =
+                    """
                 부서 교육 게시물 목록을 조회합니다.
 
                 - `MANAGE_DEPARTMENT_EDUCATION` 권한 사용자는 `departmentName`으로 전체 부서 대상 필터 조회가 가능합니다.
@@ -426,15 +431,15 @@ public class EduReportController {
                 """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200",
-            description = "조회 성공",
-            content =
-            @Content(
-                mediaType = "application/json",
-                examples =
-                @ExampleObject(
-                    value =
-                        """
+                responseCode = "200",
+                description = "조회 성공",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                             {
                               "isSuccess": true,
                               "code": "COMMON200",
@@ -457,16 +462,16 @@ public class EduReportController {
                             }
                             """))),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "404",
-            description = "리소스 없음",
-            content =
-            @Content(
-                mediaType = "application/json",
-                examples = {
-                    @ExampleObject(
-                        name = "사용자 없음",
-                        value =
-                            """
+                responseCode = "404",
+                description = "리소스 없음",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples = {
+                                    @ExampleObject(
+                                            name = "사용자 없음",
+                                            value =
+                                                    """
                                 {
                                   "isSuccess": false,
                                   "code": "USER_NOT_FOUND",
@@ -474,10 +479,10 @@ public class EduReportController {
                                   "result": null
                                 }
                                 """),
-                    @ExampleObject(
-                        name = "부서 없음",
-                        value =
-                            """
+                                    @ExampleObject(
+                                            name = "부서 없음",
+                                            value =
+                                                    """
                                 {
                                   "isSuccess": false,
                                   "code": "DEPARTMENT_NOT_FOUND",
@@ -485,24 +490,24 @@ public class EduReportController {
                                   "result": null
                                 }
                                 """)
-                }))
+                                }))
     })
     @GetMapping("/department")
     public ResponseEntity<ApiResponse<List<EduReportSummaryDto>>> getDepartmentEduReports(
-        @Parameter(description = "부서명 필터(권한 사용자 전용)", example = "SALES_DEPT")
-        @RequestParam(required = false)
-        DepartmentName departmentName,
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @Parameter(description = "부서명 필터(권한 사용자 전용)", example = "SALES_DEPT")
+                    @RequestParam(required = false)
+                    DepartmentName departmentName,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         List<EduReportSummaryDto> reports =
-            eduReportService.getDepartmentEduReports(departmentName, userDetails.getId());
+                eduReportService.getDepartmentEduReports(departmentName, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(reports));
     }
 
     @Operation(
-        tags = {"PSM"},
-        summary = "PSM 게시물 목록 조회",
-        description =
-            """
+            tags = {"PSM"},
+            summary = "PSM 게시물 목록 조회",
+            description =
+                    """
                 PSM 게시물 목록을 조회합니다.
 
                 - `MANAGE_PSM` 권한 사용자는 모든 회사의 PSM 게시물을 조회할 수 있습니다.
@@ -510,15 +515,15 @@ public class EduReportController {
                 """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200",
-            description = "조회 성공",
-            content =
-            @Content(
-                mediaType = "application/json",
-                examples =
-                @ExampleObject(
-                    value =
-                        """
+                responseCode = "200",
+                description = "조회 성공",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                             {
                               "isSuccess": true,
                               "code": "COMMON200",
@@ -541,16 +546,16 @@ public class EduReportController {
                             }
                             """))),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "404",
-            description = "리소스 없음",
-            content =
-            @Content(
-                mediaType = "application/json",
-                examples = {
-                    @ExampleObject(
-                        name = "사용자 없음",
-                        value =
-                            """
+                responseCode = "404",
+                description = "리소스 없음",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples = {
+                                    @ExampleObject(
+                                            name = "사용자 없음",
+                                            value =
+                                                    """
                                 {
                                   "isSuccess": false,
                                   "code": "USER_NOT_FOUND",
@@ -558,24 +563,24 @@ public class EduReportController {
                                   "result": null
                                 }
                                 """)
-                }))
+                                }))
     })
     @GetMapping("/psm")
     public ResponseEntity<ApiResponse<List<EduReportSummaryDto>>> getPsmEduReports(
-        @Parameter(description = "카테고리 ID 필터(PSM)", example = "1")
-        @RequestParam(required = false)
-        Long categoryId,
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @Parameter(description = "카테고리 ID 필터(PSM)", example = "1")
+                    @RequestParam(required = false)
+                    Long categoryId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         List<EduReportSummaryDto> reports =
-            eduReportService.getPsmEduReports(categoryId, userDetails.getId());
+                eduReportService.getPsmEduReports(categoryId, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(reports));
     }
 
     @Operation(
-        tags = {"안전보건"},
-        summary = "안전 보건 게시물 목록 조회",
-        description =
-            """
+            tags = {"안전보건"},
+            summary = "안전 보건 게시물 목록 조회",
+            description =
+                    """
                 안전 보건 게시물 목록을 조회합니다.
 
                 - `MANAGE_SAFETY` 권한 사용자는 모든 회사의 안전 보건 게시물을 조회할 수 있습니다.
@@ -583,15 +588,15 @@ public class EduReportController {
                 """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200",
-            description = "조회 성공",
-            content =
-            @Content(
-                mediaType = "application/json",
-                examples =
-                @ExampleObject(
-                    value =
-                        """
+                responseCode = "200",
+                description = "조회 성공",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                             {
                               "isSuccess": true,
                               "code": "COMMON200",
@@ -614,16 +619,16 @@ public class EduReportController {
                             }
                             """))),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "404",
-            description = "리소스 없음",
-            content =
-            @Content(
-                mediaType = "application/json",
-                examples = {
-                    @ExampleObject(
-                        name = "사용자 없음",
-                        value =
-                            """
+                responseCode = "404",
+                description = "리소스 없음",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples = {
+                                    @ExampleObject(
+                                            name = "사용자 없음",
+                                            value =
+                                                    """
                                 {
                                   "isSuccess": false,
                                   "code": "USER_NOT_FOUND",
@@ -631,24 +636,24 @@ public class EduReportController {
                                   "result": null
                                 }
                                 """)
-                }))
+                                }))
     })
     @GetMapping("/safety")
     public ResponseEntity<ApiResponse<List<EduReportSummaryDto>>> getSafetyEduReports(
-        @Parameter(description = "카테고리 ID 필터(안전 보건)", example = "1")
-        @RequestParam(required = false)
-        Long categoryId,
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @Parameter(description = "카테고리 ID 필터(안전 보건)", example = "1")
+                    @RequestParam(required = false)
+                    Long categoryId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         List<EduReportSummaryDto> reports =
-            eduReportService.getSafetyEduReports(categoryId, userDetails.getId());
+                eduReportService.getSafetyEduReports(categoryId, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(reports));
     }
 
     @Operation(
-        tags = {"부서교육"},
-        summary = "부서 교육 게시물 상세 조회",
-        description =
-            """
+            tags = {"부서교육"},
+            summary = "부서 교육 게시물 상세 조회",
+            description =
+                    """
                 부서 교육 게시물 상세 정보를 조회합니다.
 
                 - `MANAGE_DEPARTMENT_EDUCATION` 권한 사용자는 전체 부서의 부서 교육 게시물을 조회할 수 있습니다.
@@ -658,19 +663,19 @@ public class EduReportController {
                 """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200",
-            description = "조회 성공"),
+                responseCode = "200",
+                description = "조회 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "404",
-            description = "리소스 없음",
-            content =
-            @Content(
-                mediaType = "application/json",
-                examples = {
-                    @ExampleObject(
-                        name = "게시물 없음",
-                        value =
-                            """
+                responseCode = "404",
+                description = "리소스 없음",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples = {
+                                    @ExampleObject(
+                                            name = "게시물 없음",
+                                            value =
+                                                    """
                                 {
                                   "isSuccess": false,
                                   "code": "EDU_REPORT_NOT_FOUND",
@@ -678,10 +683,10 @@ public class EduReportController {
                                   "result": null
                                 }
                                 """),
-                    @ExampleObject(
-                        name = "타 부서 접근",
-                        value =
-                            """
+                                    @ExampleObject(
+                                            name = "타 부서 접근",
+                                            value =
+                                                    """
                                 {
                                   "isSuccess": false,
                                   "code": "EDU_REPORT_NOT_FOUND",
@@ -689,10 +694,10 @@ public class EduReportController {
                                   "result": null
                                 }
                                 """),
-                    @ExampleObject(
-                        name = "사용자 없음",
-                        value =
-                            """
+                                    @ExampleObject(
+                                            name = "사용자 없음",
+                                            value =
+                                                    """
                                 {
                                   "isSuccess": false,
                                   "code": "USER_NOT_FOUND",
@@ -700,23 +705,23 @@ public class EduReportController {
                                   "result": null
                                 }
                                 """)
-                }))
+                                }))
     })
     @GetMapping("/department/{educationId}")
     public ResponseEntity<ApiResponse<EduReportDetailDto>> getDepartmentEduReport(
-        @Parameter(description = "조회할 부서 교육 게시물 ID", example = "1") @PathVariable
-        Long educationId,
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @Parameter(description = "조회할 부서 교육 게시물 ID", example = "1") @PathVariable
+                    Long educationId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         EduReportDetailDto report =
-            eduReportService.getDepartmentEduReport(educationId, userDetails.getId());
+                eduReportService.getDepartmentEduReport(educationId, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(report));
     }
 
     @Operation(
-        tags = {"PSM"},
-        summary = "PSM 게시물 상세 조회",
-        description =
-            """
+            tags = {"PSM"},
+            summary = "PSM 게시물 상세 조회",
+            description =
+                    """
                 PSM 게시물 상세 정보를 조회합니다.
 
                 - `MANAGE_PSM` 권한 사용자는 모든 회사의 PSM 게시물을 조회할 수 있습니다.
@@ -725,19 +730,19 @@ public class EduReportController {
                 """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200",
-            description = "조회 성공"),
+                responseCode = "200",
+                description = "조회 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "404",
-            description = "리소스 없음",
-            content =
-            @Content(
-                mediaType = "application/json",
-                examples = {
-                    @ExampleObject(
-                        name = "게시물 없음",
-                        value =
-                            """
+                responseCode = "404",
+                description = "리소스 없음",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples = {
+                                    @ExampleObject(
+                                            name = "게시물 없음",
+                                            value =
+                                                    """
                                 {
                                   "isSuccess": false,
                                   "code": "EDU_REPORT_NOT_FOUND",
@@ -745,10 +750,10 @@ public class EduReportController {
                                   "result": null
                                 }
                                 """),
-                    @ExampleObject(
-                        name = "타 회사 접근",
-                        value =
-                            """
+                                    @ExampleObject(
+                                            name = "타 회사 접근",
+                                            value =
+                                                    """
                                 {
                                   "isSuccess": false,
                                   "code": "EDU_REPORT_NOT_FOUND",
@@ -756,10 +761,10 @@ public class EduReportController {
                                   "result": null
                                 }
                                 """),
-                    @ExampleObject(
-                        name = "사용자 없음",
-                        value =
-                            """
+                                    @ExampleObject(
+                                            name = "사용자 없음",
+                                            value =
+                                                    """
                                 {
                                   "isSuccess": false,
                                   "code": "USER_NOT_FOUND",
@@ -767,23 +772,23 @@ public class EduReportController {
                                   "result": null
                                 }
                                 """)
-                }))
+                                }))
     })
     @GetMapping("/psm/{educationId}")
     public ResponseEntity<ApiResponse<EduReportDetailDto>> getPsmEduReport(
-        @Parameter(description = "조회할 PSM 게시물 ID", example = "1") @PathVariable
-        Long educationId,
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @Parameter(description = "조회할 PSM 게시물 ID", example = "1") @PathVariable
+                    Long educationId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         EduReportDetailDto report =
-            eduReportService.getPsmEduReport(educationId, userDetails.getId());
+                eduReportService.getPsmEduReport(educationId, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(report));
     }
 
     @Operation(
-        tags = {"안전보건"},
-        summary = "안전 보건 게시물 상세 조회",
-        description =
-            """
+            tags = {"안전보건"},
+            summary = "안전 보건 게시물 상세 조회",
+            description =
+                    """
                 안전 보건 게시물 상세 정보를 조회합니다.
 
                 - `MANAGE_SAFETY` 권한 사용자는 모든 회사의 안전 보건 게시물을 조회할 수 있습니다.
@@ -792,19 +797,19 @@ public class EduReportController {
                 """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200",
-            description = "조회 성공"),
+                responseCode = "200",
+                description = "조회 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "404",
-            description = "리소스 없음",
-            content =
-            @Content(
-                mediaType = "application/json",
-                examples = {
-                    @ExampleObject(
-                        name = "게시물 없음",
-                        value =
-                            """
+                responseCode = "404",
+                description = "리소스 없음",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples = {
+                                    @ExampleObject(
+                                            name = "게시물 없음",
+                                            value =
+                                                    """
                                 {
                                   "isSuccess": false,
                                   "code": "EDU_REPORT_NOT_FOUND",
@@ -812,10 +817,10 @@ public class EduReportController {
                                   "result": null
                                 }
                                 """),
-                    @ExampleObject(
-                        name = "타 회사 접근",
-                        value =
-                            """
+                                    @ExampleObject(
+                                            name = "타 회사 접근",
+                                            value =
+                                                    """
                                 {
                                   "isSuccess": false,
                                   "code": "EDU_REPORT_NOT_FOUND",
@@ -823,10 +828,10 @@ public class EduReportController {
                                   "result": null
                                 }
                                 """),
-                    @ExampleObject(
-                        name = "사용자 없음",
-                        value =
-                            """
+                                    @ExampleObject(
+                                            name = "사용자 없음",
+                                            value =
+                                                    """
                                 {
                                   "isSuccess": false,
                                   "code": "USER_NOT_FOUND",
@@ -834,23 +839,23 @@ public class EduReportController {
                                   "result": null
                                 }
                                 """)
-                }))
+                                }))
     })
     @GetMapping("/safety/{educationId}")
     public ResponseEntity<ApiResponse<EduReportDetailDto>> getSafetyEduReport(
-        @Parameter(description = "조회할 안전 보건 게시물 ID", example = "1") @PathVariable
-        Long educationId,
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @Parameter(description = "조회할 안전 보건 게시물 ID", example = "1") @PathVariable
+                    Long educationId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         EduReportDetailDto report =
-            eduReportService.getSafetyEduReport(educationId, userDetails.getId());
+                eduReportService.getSafetyEduReport(educationId, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(report));
     }
 
     @Operation(
-        tags = {"부서교육"},
-        summary = "부서 교육 게시물 수정",
-        description =
-            """
+            tags = {"부서교육"},
+            summary = "부서 교육 게시물 수정",
+            description =
+                    """
                 `multipart/form-data`로 부서 교육 게시물을 수정합니다.
 
                 - 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 필요합니다.
@@ -859,75 +864,75 @@ public class EduReportController {
                 - `requestDto`(JSON 파트)는 필수이며, `files`(파일 파트)는 선택입니다.
                 - `requestDto.deleteAttachmentIds`로 기존 첨부파일 삭제가 가능합니다.
                 """,
-        requestBody =
-        @io.swagger.v3.oas.annotations.parameters.RequestBody(
-            required = true,
-            content =
-            @Content(
-                mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-                schema =
-                @Schema(
-                    implementation =
-                        EduReportUpdateMultipartRequestDoc
-                            .class),
-                encoding = {
-                    @Encoding(
-                        name = "requestDto",
-                        contentType =
-                            MediaType.APPLICATION_JSON_VALUE),
-                    @Encoding(name = "files", contentType = "*/*")
-                })))
+            requestBody =
+                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                                            schema =
+                                                    @Schema(
+                                                            implementation =
+                                                                    EduReportUpdateMultipartRequestDoc
+                                                                            .class),
+                                            encoding = {
+                                                @Encoding(
+                                                        name = "requestDto",
+                                                        contentType =
+                                                                MediaType.APPLICATION_JSON_VALUE),
+                                                @Encoding(name = "files", contentType = "*/*")
+                                            })))
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200",
-            description = "수정 성공"),
+                responseCode = "200",
+                description = "수정 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "400",
-            description = "잘못된 요청"),
+                responseCode = "400",
+                description = "잘못된 요청"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "403",
-            description = "권한 없음"),
+                responseCode = "403",
+                description = "권한 없음"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "404",
-            description = "리소스 없음")
+                responseCode = "404",
+                description = "리소스 없음")
     })
     @PatchMapping(
-        value = "/department/{educationId}",
-        consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+            value = "/department/{educationId}",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Long>> updateDepartmentEducation(
-        @Parameter(description = "수정할 부서 교육 게시물 ID", example = "1") @PathVariable
-        Long educationId,
-        @Parameter(description = "부서 교육 수정 정보(JSON)", required = true)
-        @RequestPart("requestDto")
-        @Valid
-        EduReportUpdateRequestDto requestDto,
-        @Parameter(description = "추가할 첨부 파일 목록(선택)")
-        @RequestPart(value = "files", required = false)
-        List<MultipartFile> files,
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @Parameter(description = "수정할 부서 교육 게시물 ID", example = "1") @PathVariable
+                    Long educationId,
+            @Parameter(description = "부서 교육 수정 정보(JSON)", required = true)
+                    @RequestPart("requestDto")
+                    @Valid
+                    EduReportUpdateRequestDto requestDto,
+            @Parameter(description = "추가할 첨부 파일 목록(선택)")
+                    @RequestPart(value = "files", required = false)
+                    List<MultipartFile> files,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long updatedId =
-            eduReportService.updateDepartmentEduReport(
-                educationId, requestDto, files, userDetails.getId());
+                eduReportService.updateDepartmentEduReport(
+                        educationId, requestDto, files, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
     }
 
     @Hidden
     @PatchMapping(value = "/department/{educationId}", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiResponse<Long>> updateDepartmentEducationJsonFallback(
-        @PathVariable Long educationId,
-        @Valid @RequestBody EduReportUpdateRequestDto requestDto,
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @PathVariable Long educationId,
+            @Valid @RequestBody EduReportUpdateRequestDto requestDto,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long updatedId =
-            eduReportService.updateDepartmentEduReport(
-                educationId, requestDto, userDetails.getId());
+                eduReportService.updateDepartmentEduReport(
+                        educationId, requestDto, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
     }
 
     @Operation(
-        tags = {"PSM"},
-        summary = "PSM 게시물 수정",
-        description =
-            """
+            tags = {"PSM"},
+            summary = "PSM 게시물 수정",
+            description =
+                    """
                 `multipart/form-data`로 PSM 게시물을 수정합니다.
 
                 - PSM 관리 권한(`MANAGE_PSM`)이 필요합니다.
@@ -936,72 +941,72 @@ public class EduReportController {
                 - `requestDto`(JSON 파트)는 필수이며, `files`(파일 파트)는 선택입니다.
                 - `requestDto.deleteAttachmentIds`로 기존 첨부파일 삭제가 가능합니다.
                 """,
-        requestBody =
-        @io.swagger.v3.oas.annotations.parameters.RequestBody(
-            required = true,
-            content =
-            @Content(
-                mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-                schema =
-                @Schema(
-                    implementation =
-                        EduReportUpdateMultipartRequestDoc
-                            .class),
-                encoding = {
-                    @Encoding(
-                        name = "requestDto",
-                        contentType =
-                            MediaType.APPLICATION_JSON_VALUE),
-                    @Encoding(name = "files", contentType = "*/*")
-                })))
+            requestBody =
+                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                                            schema =
+                                                    @Schema(
+                                                            implementation =
+                                                                    EduReportUpdateMultipartRequestDoc
+                                                                            .class),
+                                            encoding = {
+                                                @Encoding(
+                                                        name = "requestDto",
+                                                        contentType =
+                                                                MediaType.APPLICATION_JSON_VALUE),
+                                                @Encoding(name = "files", contentType = "*/*")
+                                            })))
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200",
-            description = "수정 성공"),
+                responseCode = "200",
+                description = "수정 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "400",
-            description = "잘못된 요청"),
+                responseCode = "400",
+                description = "잘못된 요청"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "403",
-            description = "권한 없음"),
+                responseCode = "403",
+                description = "권한 없음"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "404",
-            description = "리소스 없음")
+                responseCode = "404",
+                description = "리소스 없음")
     })
     @PatchMapping(value = "/psm/{educationId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Long>> updatePsmEducation(
-        @Parameter(description = "수정할 PSM 게시물 ID", example = "1") @PathVariable
-        Long educationId,
-        @Parameter(description = "PSM 수정 정보(JSON)", required = true)
-        @RequestPart("requestDto")
-        @Valid
-        EduReportUpdateRequestDto requestDto,
-        @Parameter(description = "추가할 첨부 파일 목록(선택)")
-        @RequestPart(value = "files", required = false)
-        List<MultipartFile> files,
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @Parameter(description = "수정할 PSM 게시물 ID", example = "1") @PathVariable
+                    Long educationId,
+            @Parameter(description = "PSM 수정 정보(JSON)", required = true)
+                    @RequestPart("requestDto")
+                    @Valid
+                    EduReportUpdateRequestDto requestDto,
+            @Parameter(description = "추가할 첨부 파일 목록(선택)")
+                    @RequestPart(value = "files", required = false)
+                    List<MultipartFile> files,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long updatedId =
-            eduReportService.updatePsmEduReport(
-                educationId, requestDto, files, userDetails.getId());
+                eduReportService.updatePsmEduReport(
+                        educationId, requestDto, files, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
     }
 
     @Hidden
     @PatchMapping(value = "/psm/{educationId}", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiResponse<Long>> updatePsmEducationJsonFallback(
-        @PathVariable Long educationId,
-        @Valid @RequestBody EduReportUpdateRequestDto requestDto,
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @PathVariable Long educationId,
+            @Valid @RequestBody EduReportUpdateRequestDto requestDto,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long updatedId =
-            eduReportService.updatePsmEduReport(educationId, requestDto, userDetails.getId());
+                eduReportService.updatePsmEduReport(educationId, requestDto, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
     }
 
     @Operation(
-        tags = {"안전보건"},
-        summary = "안전 보건 게시물 수정",
-        description =
-            """
+            tags = {"안전보건"},
+            summary = "안전 보건 게시물 수정",
+            description =
+                    """
                 `multipart/form-data`로 안전 보건 게시물을 수정합니다.
 
                 - 안전 보건 관리 권한(`MANAGE_SAFETY`)이 필요합니다.
@@ -1010,302 +1015,302 @@ public class EduReportController {
                 - `requestDto`(JSON 파트)는 필수이며, `files`(파일 파트)는 선택입니다.
                 - `requestDto.deleteAttachmentIds`로 기존 첨부파일 삭제가 가능합니다.
                 """,
-        requestBody =
-        @io.swagger.v3.oas.annotations.parameters.RequestBody(
-            required = true,
-            content =
-            @Content(
-                mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-                schema =
-                @Schema(
-                    implementation =
-                        EduReportUpdateMultipartRequestDoc
-                            .class),
-                encoding = {
-                    @Encoding(
-                        name = "requestDto",
-                        contentType =
-                            MediaType.APPLICATION_JSON_VALUE),
-                    @Encoding(name = "files", contentType = "*/*")
-                })))
+            requestBody =
+                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                                            schema =
+                                                    @Schema(
+                                                            implementation =
+                                                                    EduReportUpdateMultipartRequestDoc
+                                                                            .class),
+                                            encoding = {
+                                                @Encoding(
+                                                        name = "requestDto",
+                                                        contentType =
+                                                                MediaType.APPLICATION_JSON_VALUE),
+                                                @Encoding(name = "files", contentType = "*/*")
+                                            })))
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200",
-            description = "수정 성공"),
+                responseCode = "200",
+                description = "수정 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "400",
-            description = "잘못된 요청"),
+                responseCode = "400",
+                description = "잘못된 요청"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "403",
-            description = "권한 없음"),
+                responseCode = "403",
+                description = "권한 없음"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "404",
-            description = "리소스 없음")
+                responseCode = "404",
+                description = "리소스 없음")
     })
     @PatchMapping(value = "/safety/{educationId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Long>> updateSafetyEducation(
-        @Parameter(description = "수정할 안전 보건 게시물 ID", example = "1") @PathVariable
-        Long educationId,
-        @Parameter(description = "안전 보건 수정 정보(JSON)", required = true)
-        @RequestPart("requestDto")
-        @Valid
-        EduReportUpdateRequestDto requestDto,
-        @Parameter(description = "추가할 첨부 파일 목록(선택)")
-        @RequestPart(value = "files", required = false)
-        List<MultipartFile> files,
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @Parameter(description = "수정할 안전 보건 게시물 ID", example = "1") @PathVariable
+                    Long educationId,
+            @Parameter(description = "안전 보건 수정 정보(JSON)", required = true)
+                    @RequestPart("requestDto")
+                    @Valid
+                    EduReportUpdateRequestDto requestDto,
+            @Parameter(description = "추가할 첨부 파일 목록(선택)")
+                    @RequestPart(value = "files", required = false)
+                    List<MultipartFile> files,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long updatedId =
-            eduReportService.updateSafetyEduReport(
-                educationId, requestDto, files, userDetails.getId());
+                eduReportService.updateSafetyEduReport(
+                        educationId, requestDto, files, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
     }
 
     @Hidden
     @PatchMapping(value = "/safety/{educationId}", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiResponse<Long>> updateSafetyEducationJsonFallback(
-        @PathVariable Long educationId,
-        @Valid @RequestBody EduReportUpdateRequestDto requestDto,
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @PathVariable Long educationId,
+            @Valid @RequestBody EduReportUpdateRequestDto requestDto,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long updatedId =
-            eduReportService.updateSafetyEduReport(
-                educationId, requestDto, userDetails.getId());
+                eduReportService.updateSafetyEduReport(
+                        educationId, requestDto, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
     }
 
     @Operation(
-        tags = {"부서교육"},
-        summary = "부서 교육 게시물 상태 변경",
-        description =
-            """
+            tags = {"부서교육"},
+            summary = "부서 교육 게시물 상태 변경",
+            description =
+                    """
                 부서 교육 게시물 상태를 `OPEN`/`CLOSED`로 변경합니다.
 
                 - 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 필요합니다.
                 """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200",
-            description = "상태 변경 성공"),
+                responseCode = "200",
+                description = "상태 변경 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "400",
-            description = "잘못된 요청"),
+                responseCode = "400",
+                description = "잘못된 요청"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "403",
-            description = "권한 없음"),
+                responseCode = "403",
+                description = "권한 없음"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "404",
-            description = "리소스 없음")
+                responseCode = "404",
+                description = "리소스 없음")
     })
     @PatchMapping("/department/{educationId}/status")
     public ResponseEntity<ApiResponse<Long>> updateDepartmentEducationStatus(
-        @Parameter(description = "상태 변경할 부서 교육 게시물 ID", example = "1") @PathVariable
-        Long educationId,
-        @Valid @RequestBody EduReportStatusUpdateRequestDto requestDto,
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @Parameter(description = "상태 변경할 부서 교육 게시물 ID", example = "1") @PathVariable
+                    Long educationId,
+            @Valid @RequestBody EduReportStatusUpdateRequestDto requestDto,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long updatedId =
-            eduReportService.updateDepartmentEduReportStatus(
-                educationId, requestDto, userDetails.getId());
+                eduReportService.updateDepartmentEduReportStatus(
+                        educationId, requestDto, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
     }
 
     @Operation(
-        tags = {"PSM"},
-        summary = "PSM 게시물 상태 변경",
-        description =
-            """
+            tags = {"PSM"},
+            summary = "PSM 게시물 상태 변경",
+            description =
+                    """
                 PSM 게시물 상태를 `OPEN`/`CLOSED`로 변경합니다.
 
                 - PSM 관리 권한(`MANAGE_PSM`)이 필요합니다.
                 """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200",
-            description = "상태 변경 성공"),
+                responseCode = "200",
+                description = "상태 변경 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "400",
-            description = "잘못된 요청"),
+                responseCode = "400",
+                description = "잘못된 요청"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "403",
-            description = "권한 없음"),
+                responseCode = "403",
+                description = "권한 없음"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "404",
-            description = "리소스 없음")
+                responseCode = "404",
+                description = "리소스 없음")
     })
     @PatchMapping("/psm/{educationId}/status")
     public ResponseEntity<ApiResponse<Long>> updatePsmEducationStatus(
-        @Parameter(description = "상태 변경할 PSM 게시물 ID", example = "1") @PathVariable
-        Long educationId,
-        @Valid @RequestBody EduReportStatusUpdateRequestDto requestDto,
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @Parameter(description = "상태 변경할 PSM 게시물 ID", example = "1") @PathVariable
+                    Long educationId,
+            @Valid @RequestBody EduReportStatusUpdateRequestDto requestDto,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long updatedId =
-            eduReportService.updatePsmEduReportStatus(
-                educationId, requestDto, userDetails.getId());
+                eduReportService.updatePsmEduReportStatus(
+                        educationId, requestDto, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
     }
 
     @Operation(
-        tags = {"안전보건"},
-        summary = "안전 보건 게시물 상태 변경",
-        description =
-            """
+            tags = {"안전보건"},
+            summary = "안전 보건 게시물 상태 변경",
+            description =
+                    """
                 안전 보건 게시물 상태를 `OPEN`/`CLOSED`로 변경합니다.
 
                 - 안전 보건 관리 권한(`MANAGE_SAFETY`)이 필요합니다.
                 """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200",
-            description = "상태 변경 성공"),
+                responseCode = "200",
+                description = "상태 변경 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "400",
-            description = "잘못된 요청"),
+                responseCode = "400",
+                description = "잘못된 요청"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "403",
-            description = "권한 없음"),
+                responseCode = "403",
+                description = "권한 없음"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "404",
-            description = "리소스 없음")
+                responseCode = "404",
+                description = "리소스 없음")
     })
     @PatchMapping("/safety/{educationId}/status")
     public ResponseEntity<ApiResponse<Long>> updateSafetyEducationStatus(
-        @Parameter(description = "상태 변경할 안전 보건 게시물 ID", example = "1") @PathVariable
-        Long educationId,
-        @Valid @RequestBody EduReportStatusUpdateRequestDto requestDto,
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @Parameter(description = "상태 변경할 안전 보건 게시물 ID", example = "1") @PathVariable
+                    Long educationId,
+            @Valid @RequestBody EduReportStatusUpdateRequestDto requestDto,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long updatedId =
-            eduReportService.updateSafetyEduReportStatus(
-                educationId, requestDto, userDetails.getId());
+                eduReportService.updateSafetyEduReportStatus(
+                        educationId, requestDto, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
     }
 
     @Operation(
-        tags = {"부서교육"},
-        summary = "부서 교육 게시물 삭제",
-        description = "부서 교육 게시물을 삭제합니다. 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 필요합니다.")
+            tags = {"부서교육"},
+            summary = "부서 교육 게시물 삭제",
+            description = "부서 교육 게시물을 삭제합니다. 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 필요합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200",
-            description = "삭제 성공"),
+                responseCode = "200",
+                description = "삭제 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "403",
-            description = "권한 없음"),
+                responseCode = "403",
+                description = "권한 없음"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "404",
-            description = "리소스 없음")
+                responseCode = "404",
+                description = "리소스 없음")
     })
     @DeleteMapping("/department/{educationId}")
     public ResponseEntity<ApiResponse<Void>> deleteDepartmentEduReport(
-        @Parameter(description = "삭제할 부서 교육 게시물 ID", example = "1") @PathVariable
-        Long educationId,
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @Parameter(description = "삭제할 부서 교육 게시물 ID", example = "1") @PathVariable
+                    Long educationId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         eduReportService.deleteDepartmentEduReport(educationId, userDetails.getId());
         return ResponseEntity.ok().body(ApiResponse.onNoContent());
     }
 
     @Operation(
-        tags = {"PSM"},
-        summary = "PSM 게시물 삭제",
-        description = "PSM 게시물을 삭제합니다. PSM 관리 권한(`MANAGE_PSM`)이 필요합니다.")
+            tags = {"PSM"},
+            summary = "PSM 게시물 삭제",
+            description = "PSM 게시물을 삭제합니다. PSM 관리 권한(`MANAGE_PSM`)이 필요합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200",
-            description = "삭제 성공"),
+                responseCode = "200",
+                description = "삭제 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "403",
-            description = "권한 없음"),
+                responseCode = "403",
+                description = "권한 없음"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "404",
-            description = "리소스 없음")
+                responseCode = "404",
+                description = "리소스 없음")
     })
     @DeleteMapping("/psm/{educationId}")
     public ResponseEntity<ApiResponse<Void>> deletePsmEduReport(
-        @Parameter(description = "삭제할 PSM 게시물 ID", example = "1") @PathVariable
-        Long educationId,
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @Parameter(description = "삭제할 PSM 게시물 ID", example = "1") @PathVariable
+                    Long educationId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         eduReportService.deletePsmEduReport(educationId, userDetails.getId());
         return ResponseEntity.ok().body(ApiResponse.onNoContent());
     }
 
     @Operation(
-        tags = {"안전보건"},
-        summary = "안전 보건 게시물 삭제",
-        description = "안전 보건 게시물을 삭제합니다. 안전 보건 관리 권한(`MANAGE_SAFETY`)이 필요합니다.")
+            tags = {"안전보건"},
+            summary = "안전 보건 게시물 삭제",
+            description = "안전 보건 게시물을 삭제합니다. 안전 보건 관리 권한(`MANAGE_SAFETY`)이 필요합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200",
-            description = "삭제 성공"),
+                responseCode = "200",
+                description = "삭제 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "403",
-            description = "권한 없음"),
+                responseCode = "403",
+                description = "권한 없음"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "404",
-            description = "리소스 없음")
+                responseCode = "404",
+                description = "리소스 없음")
     })
     @DeleteMapping("/safety/{educationId}")
     public ResponseEntity<ApiResponse<Void>> deleteSafetyEduReport(
-        @Parameter(description = "삭제할 안전 보건 게시물 ID", example = "1") @PathVariable
-        Long educationId,
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @Parameter(description = "삭제할 안전 보건 게시물 ID", example = "1") @PathVariable
+                    Long educationId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         eduReportService.deleteSafetyEduReport(educationId, userDetails.getId());
         return ResponseEntity.ok().body(ApiResponse.onNoContent());
     }
 
     @Operation(
-        tags = {"부서교육"},
-        summary = "부서 교육 게시물 출석(서명) 처리",
-        description =
-            """
+            tags = {"부서교육"},
+            summary = "부서 교육 게시물 출석(서명) 처리",
+            description =
+                    """
                 부서 교육 게시물 출석을 처리합니다.
 
                 - `signatureRequired=true` 게시물은 PNG 서명 파일(`signature`)이 필수입니다.
                 - `signatureRequired=false` 게시물은 파일 없이도 출석 처리됩니다.
                 - 동일 사용자 중복 출석은 허용되지 않습니다.
                 """,
-        requestBody =
-        @io.swagger.v3.oas.annotations.parameters.RequestBody(
-            required = false,
-            content =
-            @Content(
-                mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-                schema =
-                @Schema(
-                    implementation =
-                        EduReportAttendanceMultipartRequestDoc
-                            .class),
-                encoding =
-                @Encoding(
-                    name = "signature",
-                    contentType = "image/png"))))
+            requestBody =
+                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            required = false,
+                            content =
+                                    @Content(
+                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                                            schema =
+                                                    @Schema(
+                                                            implementation =
+                                                                    EduReportAttendanceMultipartRequestDoc
+                                                                            .class),
+                                            encoding =
+                                                    @Encoding(
+                                                            name = "signature",
+                                                            contentType = "image/png"))))
     @ApiResponses(
-        value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "출석 처리 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "400",
-                description = "잘못된 요청"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음")
-        })
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "출석 처리 성공"),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "400",
+                        description = "잘못된 요청"),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "404",
+                        description = "리소스 없음")
+            })
     @PostMapping(
-        value = "/department/{educationId}/attendance",
-        consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+            value = "/department/{educationId}/attendance",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Void>> markDepartmentAttendance(
-        @Parameter(description = "부서 교육 게시물 ID", example = "1") @PathVariable Long educationId,
-        @Parameter(description = "서명 PNG 파일(signatureRequired=true인 경우 필수)")
-        @RequestPart(value = "signature", required = false)
-        MultipartFile signature,
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
-        throws IOException {
+            @Parameter(description = "부서 교육 게시물 ID", example = "1") @PathVariable Long educationId,
+            @Parameter(description = "서명 PNG 파일(signatureRequired=true인 경우 필수)")
+                    @RequestPart(value = "signature", required = false)
+                    MultipartFile signature,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
+            throws IOException {
         eduReportService.markDepartmentAttendance(educationId, signature, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onNoContent());
     }
 
     @Operation(
-        tags = {"부서교육", "PSM", "안전보건"},
-        summary = "서명 현황 목록 조회",
-        description =
-            """
+            tags = {"부서교육", "PSM", "안전보건"},
+            summary = "서명 현황 목록 조회",
+            description =
+                    """
                 교육 보고서의 대상 직원별 서명 현황을 조회합니다.
 
                 - 교육 유형에 따라 권한 검증이 이루어집니다.
@@ -1316,24 +1321,24 @@ public class EduReportController {
                 """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200",
-            description = "조회 성공"),
+                responseCode = "200",
+                description = "조회 성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "403",
-            description = "권한 없음"),
+                responseCode = "403",
+                description = "권한 없음"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "404",
-            description = "리소스 없음")
+                responseCode = "404",
+                description = "리소스 없음")
     })
     @GetMapping("/{educationId}/signatures")
     public ResponseEntity<ApiResponse<List<EduReportSignatureStatusDto>>> getSignatureStatuses(
-        @Parameter(description = "교육 보고서 ID", example = "1") @PathVariable Long educationId,
-        @Parameter(description = "직원명 검색 필터 (한글명/영문명 부분 일치)", example = "홍")
-        @RequestParam(required = false)
-        String name,
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @Parameter(description = "교육 보고서 ID", example = "1") @PathVariable Long educationId,
+            @Parameter(description = "직원명 검색 필터 (한글명/영문명 부분 일치)", example = "홍")
+                    @RequestParam(required = false)
+                    String name,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         List<EduReportSignatureStatusDto> result =
-            eduReportService.getSignatureStatuses(educationId, name, userDetails.getId());
+                eduReportService.getSignatureStatuses(educationId, name, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
 
@@ -1341,9 +1346,9 @@ public class EduReportController {
     static class EduReportAttendanceMultipartRequestDoc {
 
         @Schema(
-            description = "서명 PNG 파일(signatureRequired=true인 경우 필수)",
-            type = "string",
-            format = "binary")
+                description = "서명 PNG 파일(signatureRequired=true인 경우 필수)",
+                type = "string",
+                format = "binary")
         public String signature;
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportSignatureStatusDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportSignatureStatusDto.java
@@ -23,7 +23,9 @@ public class EduReportSignatureStatusDto {
     @Schema(description = "직급", example = "사원")
     private String position;
 
-    @Schema(description = "서명 이미지 Presigned URL (서명 없으면 null)", example = "https://s3.amazonaws.com/...")
+    @Schema(
+            description = "서명 이미지 Presigned URL (서명 없으면 null)",
+            example = "https://s3.amazonaws.com/...")
     private String signatureUrl;
 
     @Schema(description = "서명 여부", example = "true")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportSignatureStatusDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportSignatureStatusDto.java
@@ -1,0 +1,31 @@
+package kr.co.awesomelead.groupware_backend.domain.education.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "교육 보고서 서명 현황 응답 DTO")
+public class EduReportSignatureStatusDto {
+
+    @Schema(description = "직원 이름", example = "홍길동")
+    private String displayName;
+
+    @Schema(description = "부서명", example = "경영지원부")
+    private String departmentName;
+
+    @Schema(description = "직급", example = "사원")
+    private String position;
+
+    @Schema(description = "서명 이미지 Presigned URL (서명 없으면 null)", example = "https://s3.amazonaws.com/...")
+    private String signatureUrl;
+
+    @Schema(description = "서명 여부", example = "true")
+    private boolean isSigned;
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
@@ -9,7 +9,7 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.List;
+
 import kr.co.awesomelead.groupware_backend.domain.department.entity.Department;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
@@ -20,9 +20,13 @@ import kr.co.awesomelead.groupware_backend.domain.education.enums.EduType;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.QUser;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -33,164 +37,162 @@ public class EduReportQueryRepository {
     /**
      * 교육 보고서 목록 조회
      *
-     * @param type      교육 유형 필터 (null 이면 전체)
-     * @param dept      부서 필터 엔티티
-     * @param userId    출석 여부 서브쿼리에 사용할 현재 사용자 ID
+     * @param type 교육 유형 필터 (null 이면 전체)
+     * @param dept 부서 필터 엔티티
+     * @param userId 출석 여부 서브쿼리에 사용할 현재 사용자 ID
      * @param hasAccess MANAGE_DEPARTMENT_EDUCATION 권한 보유 여부
      */
     public List<EduReportSummaryDto> findEduReports(
-        EduType type, Department dept, Long categoryId, Long userId, boolean hasAccess) {
+            EduType type, Department dept, Long categoryId, Long userId, boolean hasAccess) {
         return findEduReports(type, dept, categoryId, userId, hasAccess, null, true);
     }
 
     public List<EduReportSummaryDto> findEduReports(
-        EduType type,
-        Department dept,
-        Long categoryId,
-        Long userId,
-        boolean hasAccess,
-        Company psmCompany,
-        boolean canReadAllPsmCompanies) {
+            EduType type,
+            Department dept,
+            Long categoryId,
+            Long userId,
+            boolean hasAccess,
+            Company psmCompany,
+            boolean canReadAllPsmCompanies) {
 
         return queryFactory
-            .select(
-                Projections.constructor(
-                    EduReportSummaryDto.class,
-                    eduReport.id,
-                    eduReport.title,
-                    eduReport.eduType,
-                    eduReport.eduDate,
-                    eduReport.content,
-                    JPAExpressions.selectOne()
-                        .from(eduAttendance)
-                        .where(
-                            eduAttendance.eduReport.eq(eduReport),
-                            eduAttendance.user.id.eq(userId))
-                        .exists(),
-                    eduReport.pinned,
-                    eduReport.signatureRequired,
-                    eduReport.status,
-                    educationCategory.id,
-                    educationCategory.name))
-            .from(eduReport)
-            .leftJoin(eduReport.category, educationCategory)
-            .where(
-                eqEduType(type),
-                eqCategoryId(categoryId),
-                deptFilter(type, hasAccess, dept),
-                psmFilter(psmCompany, canReadAllPsmCompanies))
-            // 같은 eduDate(일자) 내에서는 최신 생성건이 위로 오도록 id DESC를 타이브레이커로 사용
-            .orderBy(eduReport.pinned.desc(), eduReport.eduDate.desc(), eduReport.id.desc())
-            .fetch();
+                .select(
+                        Projections.constructor(
+                                EduReportSummaryDto.class,
+                                eduReport.id,
+                                eduReport.title,
+                                eduReport.eduType,
+                                eduReport.eduDate,
+                                eduReport.content,
+                                JPAExpressions.selectOne()
+                                        .from(eduAttendance)
+                                        .where(
+                                                eduAttendance.eduReport.eq(eduReport),
+                                                eduAttendance.user.id.eq(userId))
+                                        .exists(),
+                                eduReport.pinned,
+                                eduReport.signatureRequired,
+                                eduReport.status,
+                                educationCategory.id,
+                                educationCategory.name))
+                .from(eduReport)
+                .leftJoin(eduReport.category, educationCategory)
+                .where(
+                        eqEduType(type),
+                        eqCategoryId(categoryId),
+                        deptFilter(type, hasAccess, dept),
+                        psmFilter(psmCompany, canReadAllPsmCompanies))
+                // 같은 eduDate(일자) 내에서는 최신 생성건이 위로 오도록 id DESC를 타이브레이커로 사용
+                .orderBy(eduReport.pinned.desc(), eduReport.eduDate.desc(), eduReport.id.desc())
+                .fetch();
     }
 
     public List<EduReportSummaryDto> findPsmEduReports(
-        Long categoryId, Long userId, Company company, boolean canReadAllCompanies) {
+            Long categoryId, Long userId, Company company, boolean canReadAllCompanies) {
 
         return queryFactory
-            .select(
-                Projections.constructor(
-                    EduReportSummaryDto.class,
-                    eduReport.id,
-                    eduReport.title,
-                    eduReport.eduType,
-                    eduReport.eduDate,
-                    eduReport.content,
-                    JPAExpressions.selectOne()
-                        .from(eduAttendance)
-                        .where(
-                            eduAttendance.eduReport.eq(eduReport),
-                            eduAttendance.user.id.eq(userId))
-                        .exists(),
-                    eduReport.pinned,
-                    eduReport.signatureRequired,
-                    eduReport.status,
-                    educationCategory.id,
-                    educationCategory.name))
-            .from(eduReport)
-            .leftJoin(eduReport.category, educationCategory)
-            .where(
-                eduReport.eduType.eq(EduType.PSM),
-                eqCategoryId(categoryId),
-                psmCompanyFilter(company, canReadAllCompanies))
-            .orderBy(eduReport.pinned.desc(), eduReport.eduDate.desc(), eduReport.id.desc())
-            .fetch();
+                .select(
+                        Projections.constructor(
+                                EduReportSummaryDto.class,
+                                eduReport.id,
+                                eduReport.title,
+                                eduReport.eduType,
+                                eduReport.eduDate,
+                                eduReport.content,
+                                JPAExpressions.selectOne()
+                                        .from(eduAttendance)
+                                        .where(
+                                                eduAttendance.eduReport.eq(eduReport),
+                                                eduAttendance.user.id.eq(userId))
+                                        .exists(),
+                                eduReport.pinned,
+                                eduReport.signatureRequired,
+                                eduReport.status,
+                                educationCategory.id,
+                                educationCategory.name))
+                .from(eduReport)
+                .leftJoin(eduReport.category, educationCategory)
+                .where(
+                        eduReport.eduType.eq(EduType.PSM),
+                        eqCategoryId(categoryId),
+                        psmCompanyFilter(company, canReadAllCompanies))
+                .orderBy(eduReport.pinned.desc(), eduReport.eduDate.desc(), eduReport.id.desc())
+                .fetch();
     }
 
     public List<EduReportSummaryDto> findSafetyEduReports(
-        Long categoryId, Long userId, Company company, boolean canReadAllCompanies) {
+            Long categoryId, Long userId, Company company, boolean canReadAllCompanies) {
 
         return queryFactory
-            .select(
-                Projections.constructor(
-                    EduReportSummaryDto.class,
-                    eduReport.id,
-                    eduReport.title,
-                    eduReport.eduType,
-                    eduReport.eduDate,
-                    eduReport.content,
-                    JPAExpressions.selectOne()
-                        .from(eduAttendance)
-                        .where(
-                            eduAttendance.eduReport.eq(eduReport),
-                            eduAttendance.user.id.eq(userId))
-                        .exists(),
-                    eduReport.pinned,
-                    eduReport.signatureRequired,
-                    eduReport.status,
-                    educationCategory.id,
-                    educationCategory.name))
-            .from(eduReport)
-            .leftJoin(eduReport.category, educationCategory)
-            .where(
-                eduReport.eduType.eq(EduType.SAFETY),
-                eqCategoryId(categoryId),
-                psmCompanyFilter(company, canReadAllCompanies))
-            .orderBy(eduReport.pinned.desc(), eduReport.eduDate.desc(), eduReport.id.desc())
-            .fetch();
+                .select(
+                        Projections.constructor(
+                                EduReportSummaryDto.class,
+                                eduReport.id,
+                                eduReport.title,
+                                eduReport.eduType,
+                                eduReport.eduDate,
+                                eduReport.content,
+                                JPAExpressions.selectOne()
+                                        .from(eduAttendance)
+                                        .where(
+                                                eduAttendance.eduReport.eq(eduReport),
+                                                eduAttendance.user.id.eq(userId))
+                                        .exists(),
+                                eduReport.pinned,
+                                eduReport.signatureRequired,
+                                eduReport.status,
+                                educationCategory.id,
+                                educationCategory.name))
+                .from(eduReport)
+                .leftJoin(eduReport.category, educationCategory)
+                .where(
+                        eduReport.eduType.eq(EduType.SAFETY),
+                        eqCategoryId(categoryId),
+                        psmCompanyFilter(company, canReadAllCompanies))
+                .orderBy(eduReport.pinned.desc(), eduReport.eduDate.desc(), eduReport.id.desc())
+                .fetch();
     }
 
     public record SignatureStatusRow(
-        String nameKor,
-        String nameEng,
-        DepartmentName departmentName,
-        Position position,
-        String signatureKey) {
-
-    }
+            String nameKor,
+            String nameEng,
+            DepartmentName departmentName,
+            Position position,
+            String signatureKey) {}
 
     public List<SignatureStatusRow> findSignatureStatuses(EduReport report, String name) {
         QUser user = QUser.user;
         QEduAttendance att = new QEduAttendance("signatureAtt");
 
         List<Tuple> tuples =
-            queryFactory
-                .select(
-                    user.nameKor,
-                    user.nameEng,
-                    user.department.name,
-                    user.position,
-                    att.signatureKey)
-                .from(user)
-                .leftJoin(att)
-                .on(att.eduReport.id.eq(report.getId()).and(att.user.eq(user)))
-                .where(
-                    user.status.eq(Status.AVAILABLE),
-                    signatureMembershipFilter(report, user),
-                    signatureNameFilter(name, user))
-                .orderBy(user.nameKor.asc().nullsLast(), user.nameEng.asc().nullsLast())
-                .fetch();
+                queryFactory
+                        .select(
+                                user.nameKor,
+                                user.nameEng,
+                                user.department.name,
+                                user.position,
+                                att.signatureKey)
+                        .from(user)
+                        .leftJoin(att)
+                        .on(att.eduReport.id.eq(report.getId()).and(att.user.eq(user)))
+                        .where(
+                                user.status.eq(Status.AVAILABLE),
+                                signatureMembershipFilter(report, user),
+                                signatureNameFilter(name, user))
+                        .orderBy(user.nameKor.asc().nullsLast(), user.nameEng.asc().nullsLast())
+                        .fetch();
 
         return tuples.stream()
-            .map(
-                t ->
-                    new SignatureStatusRow(
-                        t.get(user.nameKor),
-                        t.get(user.nameEng),
-                        t.get(user.department.name),
-                        t.get(user.position),
-                        t.get(att.signatureKey)))
-            .toList();
+                .map(
+                        t ->
+                                new SignatureStatusRow(
+                                        t.get(user.nameKor),
+                                        t.get(user.nameEng),
+                                        t.get(user.department.name),
+                                        t.get(user.position),
+                                        t.get(att.signatureKey)))
+                .toList();
     }
 
     private BooleanExpression signatureMembershipFilter(EduReport report, QUser user) {
@@ -212,15 +214,13 @@ public class EduReportQueryRepository {
             return null;
         }
         return user.nameKor
-            .containsIgnoreCase(name)
-            .or(user.nameEng.isNotNull().and(user.nameEng.containsIgnoreCase(name)));
+                .containsIgnoreCase(name)
+                .or(user.nameEng.isNotNull().and(user.nameEng.containsIgnoreCase(name)));
     }
 
     // ── BooleanExpression 모듈 ──────────────────────────────────────
 
-    /**
-     * 교육 유형 필터 — null 이면 조건 없음 (전체)
-     */
+    /** 교육 유형 필터 — null 이면 조건 없음 (전체) */
     private BooleanExpression eqEduType(EduType type) {
         return type != null ? eduReport.eduType.eq(type) : null;
     }
@@ -276,9 +276,9 @@ public class EduReportQueryRepository {
         }
 
         return eduReport
-            .eduType
-            .ne(EduType.PSM)
-            .or(eduReport.company.eq(psmCompany))
-            .or(eduReport.company.isNull());
+                .eduType
+                .ne(EduType.PSM)
+                .or(eduReport.company.eq(psmCompany))
+                .or(eduReport.company.isNull());
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
@@ -4,21 +4,25 @@ import static kr.co.awesomelead.groupware_backend.domain.education.entity.QEduAt
 import static kr.co.awesomelead.groupware_backend.domain.education.entity.QEduReport.eduReport;
 import static kr.co.awesomelead.groupware_backend.domain.education.entity.QEducationCategory.educationCategory;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-
+import java.util.List;
 import kr.co.awesomelead.groupware_backend.domain.department.entity.Department;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
+import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
 import kr.co.awesomelead.groupware_backend.domain.education.dto.response.EduReportSummaryDto;
+import kr.co.awesomelead.groupware_backend.domain.education.entity.EduReport;
+import kr.co.awesomelead.groupware_backend.domain.education.entity.QEduAttendance;
 import kr.co.awesomelead.groupware_backend.domain.education.enums.EduType;
-
+import kr.co.awesomelead.groupware_backend.domain.user.entity.QUser;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
+import org.springframework.util.StringUtils;
 
 @Repository
 @RequiredArgsConstructor
@@ -29,126 +33,194 @@ public class EduReportQueryRepository {
     /**
      * 교육 보고서 목록 조회
      *
-     * @param type 교육 유형 필터 (null 이면 전체)
-     * @param dept 부서 필터 엔티티
-     * @param userId 출석 여부 서브쿼리에 사용할 현재 사용자 ID
+     * @param type      교육 유형 필터 (null 이면 전체)
+     * @param dept      부서 필터 엔티티
+     * @param userId    출석 여부 서브쿼리에 사용할 현재 사용자 ID
      * @param hasAccess MANAGE_DEPARTMENT_EDUCATION 권한 보유 여부
      */
     public List<EduReportSummaryDto> findEduReports(
-            EduType type, Department dept, Long categoryId, Long userId, boolean hasAccess) {
+        EduType type, Department dept, Long categoryId, Long userId, boolean hasAccess) {
         return findEduReports(type, dept, categoryId, userId, hasAccess, null, true);
     }
 
     public List<EduReportSummaryDto> findEduReports(
-            EduType type,
-            Department dept,
-            Long categoryId,
-            Long userId,
-            boolean hasAccess,
-            Company psmCompany,
-            boolean canReadAllPsmCompanies) {
+        EduType type,
+        Department dept,
+        Long categoryId,
+        Long userId,
+        boolean hasAccess,
+        Company psmCompany,
+        boolean canReadAllPsmCompanies) {
 
         return queryFactory
-                .select(
-                        Projections.constructor(
-                                EduReportSummaryDto.class,
-                                eduReport.id,
-                                eduReport.title,
-                                eduReport.eduType,
-                                eduReport.eduDate,
-                                eduReport.content,
-                                JPAExpressions.selectOne()
-                                        .from(eduAttendance)
-                                        .where(
-                                                eduAttendance.eduReport.eq(eduReport),
-                                                eduAttendance.user.id.eq(userId))
-                                        .exists(),
-                                eduReport.pinned,
-                                eduReport.signatureRequired,
-                                eduReport.status,
-                                educationCategory.id,
-                                educationCategory.name))
-                .from(eduReport)
-                .leftJoin(eduReport.category, educationCategory)
-                .where(
-                        eqEduType(type),
-                        eqCategoryId(categoryId),
-                        deptFilter(type, hasAccess, dept),
-                        psmFilter(psmCompany, canReadAllPsmCompanies))
-                // 같은 eduDate(일자) 내에서는 최신 생성건이 위로 오도록 id DESC를 타이브레이커로 사용
-                .orderBy(eduReport.pinned.desc(), eduReport.eduDate.desc(), eduReport.id.desc())
-                .fetch();
+            .select(
+                Projections.constructor(
+                    EduReportSummaryDto.class,
+                    eduReport.id,
+                    eduReport.title,
+                    eduReport.eduType,
+                    eduReport.eduDate,
+                    eduReport.content,
+                    JPAExpressions.selectOne()
+                        .from(eduAttendance)
+                        .where(
+                            eduAttendance.eduReport.eq(eduReport),
+                            eduAttendance.user.id.eq(userId))
+                        .exists(),
+                    eduReport.pinned,
+                    eduReport.signatureRequired,
+                    eduReport.status,
+                    educationCategory.id,
+                    educationCategory.name))
+            .from(eduReport)
+            .leftJoin(eduReport.category, educationCategory)
+            .where(
+                eqEduType(type),
+                eqCategoryId(categoryId),
+                deptFilter(type, hasAccess, dept),
+                psmFilter(psmCompany, canReadAllPsmCompanies))
+            // 같은 eduDate(일자) 내에서는 최신 생성건이 위로 오도록 id DESC를 타이브레이커로 사용
+            .orderBy(eduReport.pinned.desc(), eduReport.eduDate.desc(), eduReport.id.desc())
+            .fetch();
     }
 
     public List<EduReportSummaryDto> findPsmEduReports(
-            Long categoryId, Long userId, Company company, boolean canReadAllCompanies) {
+        Long categoryId, Long userId, Company company, boolean canReadAllCompanies) {
 
         return queryFactory
-                .select(
-                        Projections.constructor(
-                                EduReportSummaryDto.class,
-                                eduReport.id,
-                                eduReport.title,
-                                eduReport.eduType,
-                                eduReport.eduDate,
-                                eduReport.content,
-                                JPAExpressions.selectOne()
-                                        .from(eduAttendance)
-                                        .where(
-                                                eduAttendance.eduReport.eq(eduReport),
-                                                eduAttendance.user.id.eq(userId))
-                                        .exists(),
-                                eduReport.pinned,
-                                eduReport.signatureRequired,
-                                eduReport.status,
-                                educationCategory.id,
-                                educationCategory.name))
-                .from(eduReport)
-                .leftJoin(eduReport.category, educationCategory)
-                .where(
-                        eduReport.eduType.eq(EduType.PSM),
-                        eqCategoryId(categoryId),
-                        psmCompanyFilter(company, canReadAllCompanies))
-                .orderBy(eduReport.pinned.desc(), eduReport.eduDate.desc(), eduReport.id.desc())
-                .fetch();
+            .select(
+                Projections.constructor(
+                    EduReportSummaryDto.class,
+                    eduReport.id,
+                    eduReport.title,
+                    eduReport.eduType,
+                    eduReport.eduDate,
+                    eduReport.content,
+                    JPAExpressions.selectOne()
+                        .from(eduAttendance)
+                        .where(
+                            eduAttendance.eduReport.eq(eduReport),
+                            eduAttendance.user.id.eq(userId))
+                        .exists(),
+                    eduReport.pinned,
+                    eduReport.signatureRequired,
+                    eduReport.status,
+                    educationCategory.id,
+                    educationCategory.name))
+            .from(eduReport)
+            .leftJoin(eduReport.category, educationCategory)
+            .where(
+                eduReport.eduType.eq(EduType.PSM),
+                eqCategoryId(categoryId),
+                psmCompanyFilter(company, canReadAllCompanies))
+            .orderBy(eduReport.pinned.desc(), eduReport.eduDate.desc(), eduReport.id.desc())
+            .fetch();
     }
 
     public List<EduReportSummaryDto> findSafetyEduReports(
-            Long categoryId, Long userId, Company company, boolean canReadAllCompanies) {
+        Long categoryId, Long userId, Company company, boolean canReadAllCompanies) {
 
         return queryFactory
+            .select(
+                Projections.constructor(
+                    EduReportSummaryDto.class,
+                    eduReport.id,
+                    eduReport.title,
+                    eduReport.eduType,
+                    eduReport.eduDate,
+                    eduReport.content,
+                    JPAExpressions.selectOne()
+                        .from(eduAttendance)
+                        .where(
+                            eduAttendance.eduReport.eq(eduReport),
+                            eduAttendance.user.id.eq(userId))
+                        .exists(),
+                    eduReport.pinned,
+                    eduReport.signatureRequired,
+                    eduReport.status,
+                    educationCategory.id,
+                    educationCategory.name))
+            .from(eduReport)
+            .leftJoin(eduReport.category, educationCategory)
+            .where(
+                eduReport.eduType.eq(EduType.SAFETY),
+                eqCategoryId(categoryId),
+                psmCompanyFilter(company, canReadAllCompanies))
+            .orderBy(eduReport.pinned.desc(), eduReport.eduDate.desc(), eduReport.id.desc())
+            .fetch();
+    }
+
+    public record SignatureStatusRow(
+        String nameKor,
+        String nameEng,
+        DepartmentName departmentName,
+        Position position,
+        String signatureKey) {
+
+    }
+
+    public List<SignatureStatusRow> findSignatureStatuses(EduReport report, String name) {
+        QUser user = QUser.user;
+        QEduAttendance att = new QEduAttendance("signatureAtt");
+
+        List<Tuple> tuples =
+            queryFactory
                 .select(
-                        Projections.constructor(
-                                EduReportSummaryDto.class,
-                                eduReport.id,
-                                eduReport.title,
-                                eduReport.eduType,
-                                eduReport.eduDate,
-                                eduReport.content,
-                                JPAExpressions.selectOne()
-                                        .from(eduAttendance)
-                                        .where(
-                                                eduAttendance.eduReport.eq(eduReport),
-                                                eduAttendance.user.id.eq(userId))
-                                        .exists(),
-                                eduReport.pinned,
-                                eduReport.signatureRequired,
-                                eduReport.status,
-                                educationCategory.id,
-                                educationCategory.name))
-                .from(eduReport)
-                .leftJoin(eduReport.category, educationCategory)
+                    user.nameKor,
+                    user.nameEng,
+                    user.department.name,
+                    user.position,
+                    att.signatureKey)
+                .from(user)
+                .leftJoin(att)
+                .on(att.eduReport.id.eq(report.getId()).and(att.user.eq(user)))
                 .where(
-                        eduReport.eduType.eq(EduType.SAFETY),
-                        eqCategoryId(categoryId),
-                        psmCompanyFilter(company, canReadAllCompanies))
-                .orderBy(eduReport.pinned.desc(), eduReport.eduDate.desc(), eduReport.id.desc())
+                    user.status.eq(Status.AVAILABLE),
+                    signatureMembershipFilter(report, user),
+                    signatureNameFilter(name, user))
+                .orderBy(user.nameKor.asc().nullsLast(), user.nameEng.asc().nullsLast())
                 .fetch();
+
+        return tuples.stream()
+            .map(
+                t ->
+                    new SignatureStatusRow(
+                        t.get(user.nameKor),
+                        t.get(user.nameEng),
+                        t.get(user.department.name),
+                        t.get(user.position),
+                        t.get(att.signatureKey)))
+            .toList();
+    }
+
+    private BooleanExpression signatureMembershipFilter(EduReport report, QUser user) {
+        if (report.getEduType() == EduType.DEPARTMENT) {
+            if (report.getDepartment() == null) {
+                return user.id.isNull(); // 결과 없음
+            }
+            return user.department.eq(report.getDepartment());
+        }
+        Company company = report.getCompany();
+        if (company == null) {
+            return null; // 전사 대상
+        }
+        return user.workLocation.eq(company);
+    }
+
+    private BooleanExpression signatureNameFilter(String name, QUser user) {
+        if (!StringUtils.hasText(name)) {
+            return null;
+        }
+        return user.nameKor
+            .containsIgnoreCase(name)
+            .or(user.nameEng.isNotNull().and(user.nameEng.containsIgnoreCase(name)));
     }
 
     // ── BooleanExpression 모듈 ──────────────────────────────────────
 
-    /** 교육 유형 필터 — null 이면 조건 없음 (전체) */
+    /**
+     * 교육 유형 필터 — null 이면 조건 없음 (전체)
+     */
     private BooleanExpression eqEduType(EduType type) {
         return type != null ? eduReport.eduType.eq(type) : null;
     }
@@ -204,9 +276,9 @@ public class EduReportQueryRepository {
         }
 
         return eduReport
-                .eduType
-                .ne(EduType.PSM)
-                .or(eduReport.company.eq(psmCompany))
-                .or(eduReport.company.isNull());
+            .eduType
+            .ne(EduType.PSM)
+            .or(eduReport.company.eq(psmCompany))
+            .or(eduReport.company.isNull());
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -945,8 +945,7 @@ public class EduReportService {
                 row.departmentName() != null ? row.departmentName().getDescription() : null;
         String positionStr = row.position() != null ? row.position().getDescription() : null;
         boolean isSigned = row.signatureKey() != null;
-        String signatureUrl =
-                isSigned ? s3Service.getPresignedViewUrl(row.signatureKey()) : null;
+        String signatureUrl = isSigned ? s3Service.getPresignedViewUrl(row.signatureKey()) : null;
 
         return EduReportSignatureStatusDto.builder()
                 .displayName(displayName)

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -11,6 +11,7 @@ import kr.co.awesomelead.groupware_backend.domain.education.dto.request.EduRepor
 import kr.co.awesomelead.groupware_backend.domain.education.dto.request.PsmEduReportCreateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.education.dto.request.SafetyEduReportCreateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.education.dto.response.EduReportDetailDto;
+import kr.co.awesomelead.groupware_backend.domain.education.dto.response.EduReportSignatureStatusDto;
 import kr.co.awesomelead.groupware_backend.domain.education.dto.response.EduReportSummaryDto;
 import kr.co.awesomelead.groupware_backend.domain.education.entity.EduAttachment;
 import kr.co.awesomelead.groupware_backend.domain.education.entity.EduAttendance;
@@ -913,6 +914,47 @@ public class EduReportService {
             throw new CustomException(ErrorCode.INVALID_ARGUMENT);
         }
         return category;
+    }
+
+    @Transactional(readOnly = true)
+    public List<EduReportSignatureStatusDto> getSignatureStatuses(
+            Long educationId, String name, Long userId) {
+
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        EduReport report =
+                eduReportRepository
+                        .findById(educationId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+
+        validateCreateAuthority(user, report.getEduType());
+
+        return eduReportQueryRepository.findSignatureStatuses(report, name).stream()
+                .map(row -> toSignatureStatusDto(row))
+                .toList();
+    }
+
+    private EduReportSignatureStatusDto toSignatureStatusDto(
+            EduReportQueryRepository.SignatureStatusRow row) {
+        String displayName =
+                (row.nameKor() != null && !row.nameKor().isBlank()) ? row.nameKor() : row.nameEng();
+        String deptName =
+                row.departmentName() != null ? row.departmentName().getDescription() : null;
+        String positionStr = row.position() != null ? row.position().getDescription() : null;
+        boolean isSigned = row.signatureKey() != null;
+        String signatureUrl =
+                isSigned ? s3Service.getPresignedViewUrl(row.signatureKey()) : null;
+
+        return EduReportSignatureStatusDto.builder()
+                .displayName(displayName)
+                .departmentName(deptName)
+                .position(positionStr)
+                .isSigned(isSigned)
+                .signatureUrl(signatureUrl)
+                .build();
     }
 
     private long calculateTargetPeopleCount(EduReport report) {

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
@@ -21,6 +21,7 @@ import kr.co.awesomelead.groupware_backend.domain.education.dto.request.EduRepor
 import kr.co.awesomelead.groupware_backend.domain.education.dto.request.PsmEduReportCreateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.education.dto.request.SafetyEduReportCreateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.education.dto.response.EduReportDetailDto;
+import kr.co.awesomelead.groupware_backend.domain.education.dto.response.EduReportSignatureStatusDto;
 import kr.co.awesomelead.groupware_backend.domain.education.dto.response.EduReportSummaryDto;
 import kr.co.awesomelead.groupware_backend.domain.education.entity.EduAttachment;
 import kr.co.awesomelead.groupware_backend.domain.education.entity.EduAttendance;
@@ -39,6 +40,7 @@ import kr.co.awesomelead.groupware_backend.domain.education.service.EduReportSer
 import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Authority;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
@@ -1785,6 +1787,105 @@ public class EduReportServiceTest {
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NO_AUTHORITY_FOR_PSM_MANAGE);
         verify(eduReportRepository, never()).findById(anyLong());
+    }
+
+    @Test
+    @DisplayName("서명 현황 조회 성공 - 부서 교육 MANAGE_DEPARTMENT_EDUCATION 권한으로 서명자 포함 목록 반환")
+    void getSignatureStatuses_DepartmentEdu_Success() {
+        // Given
+        Long reportId = 100L;
+        Long userId = 1L;
+        User user = createNormalUser();
+        user.addAuthority(Authority.MANAGE_DEPARTMENT_EDUCATION);
+
+        EduReport report =
+                EduReport.builder()
+                        .id(reportId)
+                        .eduType(EduType.DEPARTMENT)
+                        .department(defaultDept)
+                        .signatureRequired(true)
+                        .build();
+
+        EduReportQueryRepository.SignatureStatusRow signedRow =
+                new EduReportQueryRepository.SignatureStatusRow(
+                        "홍길동", null, DepartmentName.SALES_DEPT, Position.STAFF, "sig-key-123");
+        EduReportQueryRepository.SignatureStatusRow unsignedRow =
+                new EduReportQueryRepository.SignatureStatusRow(
+                        "김철수", null, DepartmentName.SALES_DEPT, Position.MANAGER, null);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(eduReportRepository.findById(reportId)).thenReturn(Optional.of(report));
+        when(eduReportQueryRepository.findSignatureStatuses(report, null))
+                .thenReturn(List.of(signedRow, unsignedRow));
+        when(s3Service.getPresignedViewUrl("sig-key-123")).thenReturn("https://s3/sig-key-123");
+
+        // When
+        List<EduReportSignatureStatusDto> result =
+                eduReportService.getSignatureStatuses(reportId, null, userId);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.size()).isEqualTo(2);
+        assertThat(result.get(0).getDisplayName()).isEqualTo("홍길동");
+        assertThat(result.get(0).isSigned()).isTrue();
+        assertThat(result.get(0).getSignatureUrl()).isEqualTo("https://s3/sig-key-123");
+        assertThat(result.get(1).isSigned()).isFalse();
+        assertThat(result.get(1).getSignatureUrl()).isNull();
+    }
+
+    @Test
+    @DisplayName("서명 현황 조회 실패 - 사용자 없음")
+    void getSignatureStatuses_Fail_UserNotFound() {
+        // Given
+        when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> eduReportService.getSignatureStatuses(100L, null, 1L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
+
+        verify(eduReportRepository, never()).findById(anyLong());
+    }
+
+    @Test
+    @DisplayName("서명 현황 조회 실패 - 게시물 없음")
+    void getSignatureStatuses_Fail_EduReportNotFound() {
+        // Given
+        User user = createNormalUser();
+        user.addAuthority(Authority.MANAGE_DEPARTMENT_EDUCATION);
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(eduReportRepository.findById(100L)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> eduReportService.getSignatureStatuses(100L, null, 1L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.EDU_REPORT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("서명 현황 조회 실패 - 부서 교육 권한 없음")
+    void getSignatureStatuses_Fail_NoAuthority() {
+        // Given
+        User user = createNormalUser(); // 권한 없음
+
+        EduReport report =
+                EduReport.builder()
+                        .id(100L)
+                        .eduType(EduType.DEPARTMENT)
+                        .department(defaultDept)
+                        .build();
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(eduReportRepository.findById(100L)).thenReturn(Optional.of(report));
+
+        // When & Then
+        assertThatThrownBy(() -> eduReportService.getSignatureStatuses(100L, null, 1L))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.NO_AUTHORITY_FOR_EDU_REPORT);
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #269

## 📝작업 내용
- EduReportSignatureStatusDto 신규 생성 (직원 기본 정보 + S3 Presigned URL 제공)
- EduReportQueryRepository에 findSignatureStatuses 메서드 추가
    - User 메인으로 EduAttendance Left Join → 미서명 인원도 목록에 포함
    - nameKor / nameEng OR 조건 부분 일치 검색 지원
- EduReportService에 EduType별 권한 검증 및 URL 생성 로직 추가
    - MANAGE_PSM, MANAGE_SAFETY, MANAGE_DEPARTMENT_EDUCATION 권한 체크
- GET /api/educations/{educationId}/signatures 엔드포인트 노출
- 로컬 DB user_authorities.authority 컬럼 ENUM → VARCHAR(50) 변경 (운영 환경 동기화)

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
- X