### PR TITLE
docs(272): createApproval Swagger 명세 개선 - 참조자 타입 설명 강화 및 DocumentType별 요청 예시 추가

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/controller/ApprovalController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/controller/ApprovalController.java
@@ -146,7 +146,190 @@ public class ApprovalController {
             })
     @PostMapping
     public ResponseEntity<ApiResponse<Long>> createApproval(
-            @Parameter(description = "상신할 결재 문서 정보 (타입별 상세 필드 포함)", required = true)
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "상신할 결재 문서 정보. documentType 값에 따라 필수 필드가 달라집니다.",
+                    required = true,
+                    content =
+                            @Content(
+                                    mediaType = "application/json",
+                                    schema =
+                                            @Schema(
+                                                    implementation =
+                                                            ApprovalCreateRequestDto.class),
+                                    examples = {
+                                        @ExampleObject(
+                                                name = "기본양식 (BASIC)",
+                                                summary = "기본 기안문 예시",
+                                                value =
+                                                        """
+                        {
+                          "title": "비품 구매 요청",
+                          "content": "<p>사무용 노트북 1대 구매를 요청합니다.</p>",
+                          "documentType": "기본양식",
+                          "approvalSteps": [
+                            { "approverId": 2, "sequence": 1 },
+                            { "approverId": 3, "sequence": 2 }
+                          ],
+                          "participants": [
+                            { "userId": 10, "participantType": "참조자" }
+                          ]
+                        }
+                        """),
+                                        @ExampleObject(
+                                                name = "근태신청서 (LEAVE)",
+                                                summary = "휴가 신청 예시",
+                                                value =
+                                                        """
+                        {
+                          "title": "2026년 하계 휴가 신청",
+                          "content": "<p>계획된 휴가 신청합니다.</p>",
+                          "documentType": "근태신청서",
+                          "approvalSteps": [
+                            { "approverId": 2, "sequence": 1 },
+                            { "approverId": 3, "sequence": 2 }
+                          ],
+                          "participants": [
+                            { "userId": 10, "participantType": "참조자" }
+                          ],
+                          "startDate": "2026-07-01T09:00:00",
+                          "endDate": "2026-07-05T18:00:00",
+                          "leaveType": "휴가",
+                          "leaveDetailType": "연차",
+                          "reason": "정기 휴가",
+                          "emergencyContact": "010-1234-5678"
+                        }
+                        """),
+                                        @ExampleObject(
+                                                name = "기안및지출결의 (EXPENSE_DRAFT)",
+                                                summary = "지출결의 예시",
+                                                value =
+                                                        """
+                        {
+                          "title": "2026년 3월 사무용품 구매",
+                          "content": "<p>사무용품 구매 지출 결의합니다.</p>",
+                          "documentType": "기안및지출결의",
+                          "approvalSteps": [
+                            { "approverId": 2, "sequence": 1 },
+                            { "approverId": 3, "sequence": 2 }
+                          ],
+                          "participants": [],
+                          "details": [
+                            {
+                              "evidenceDate": "2026-03-10",
+                              "clientName": "(주)오피스디포",
+                              "content": "A4 용지 5박스",
+                              "supplyAmount": 50000,
+                              "vatAmount": 5000,
+                              "totalAmount": 55000,
+                              "paymentRequestDate": "2026-03-31",
+                              "expenseType": "법인카드"
+                            }
+                          ]
+                        }
+                        """),
+                                        @ExampleObject(
+                                                name = "차량유류정산지출결의 (CAR_FUEL)",
+                                                summary = "차량 유류비 정산 예시",
+                                                value =
+                                                        """
+                        {
+                          "title": "2026년 3월 차량 유류비 정산",
+                          "content": "<p>3월 차량 운행 유류비 정산 요청합니다.</p>",
+                          "documentType": "차량유류정산지출결의",
+                          "approvalSteps": [
+                            { "approverId": 2, "sequence": 1 }
+                          ],
+                          "participants": [],
+                          "agreementDepartment": "관리본부",
+                          "carTypeNumber": "카니발 / 12가 3456",
+                          "fuelType": "휘발유",
+                          "totalDistanceKm": 150.5,
+                          "fuelClaimAmount": 25000,
+                          "totalAmount": 30000,
+                          "bankName": "국민은행",
+                          "accountNumber": "123-456-7890",
+                          "accountHolder": "홍길동",
+                          "details": [
+                            {
+                              "driveDate": "2026-03-02",
+                              "purpose": "A업체 기술 지원 외근",
+                              "route": "본사 → 화성 공장 → 본사",
+                              "distanceKm": 50.2,
+                              "tollParkingFee": 5000
+                            }
+                          ]
+                        }
+                        """),
+                                        @ExampleObject(
+                                                name = "국외출장여비정산서 (OVERSEAS_TRIP)",
+                                                summary = "국외 출장비 정산 예시",
+                                                value =
+                                                        """
+                        {
+                          "title": "2026년 3월 미국 출장 여비 정산",
+                          "content": "<p>샌프란시스코 기술 컨퍼런스 참가 여비 정산합니다.</p>",
+                          "documentType": "국외출장여비정산서",
+                          "approvalSteps": [
+                            { "approverId": 2, "sequence": 1 },
+                            { "approverId": 3, "sequence": 2 }
+                          ],
+                          "participants": [
+                            { "userId": 10, "participantType": "참조자" }
+                          ],
+                          "companion": "박지민 팀장",
+                          "destination": "미국 샌프란시스코 (Google 본사)",
+                          "tripPeriod": "2026-03-01 ~ 2026-03-10",
+                          "purpose": "글로벌 기술 컨퍼런스 참가 및 파트너사 미팅",
+                          "currencyUnit": "USD",
+                          "exchangeRate": 1350.5,
+                          "advanceCash": 500000,
+                          "advanceCard": 1000000,
+                          "advanceTotal": 1500000,
+                          "advanceReturn": 200000,
+                          "additionalClaim": 0,
+                          "details": [
+                            {
+                              "evidenceNumber": "REC-20260301-001",
+                              "evidenceDate": "2026-03-01",
+                              "usageType": "숙박비",
+                              "description": "샌프란시스코 힐튼 호텔 1박",
+                              "foreignCurrency": 250.0,
+                              "exchangeRate": 1348.0,
+                              "cashAmount": 337000,
+                              "cardAmount": 0,
+                              "totalAmount": 337000
+                            }
+                          ]
+                        }
+                        """),
+                                        @ExampleObject(
+                                                name = "기안및지출결의_복리후생 (WELFARE_EXPENSE)",
+                                                summary = "복리후생 지출결의 예시",
+                                                value =
+                                                        """
+                        {
+                          "title": "2026년 3월 임직원 경조사 지원",
+                          "content": "<p>임직원 경조사 지원금 지출 결의합니다.</p>",
+                          "documentType": "기안및지출결의_복리후생",
+                          "approvalSteps": [
+                            { "approverId": 2, "sequence": 1 }
+                          ],
+                          "participants": [],
+                          "details": [
+                            {
+                              "evidenceDate": "2026-03-15",
+                              "clientName": "홍길동",
+                              "content": "결혼 축하금",
+                              "supplyAmount": 100000,
+                              "vatAmount": 0,
+                              "totalAmount": 100000,
+                              "paymentRequestDate": "2026-03-20",
+                              "expenseType": "개인경비"
+                            }
+                          ]
+                        }
+                        """)
+                                    }))
                     @RequestBody
                     @Valid
                     ApprovalCreateRequestDto requestDto,

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/controller/ApprovalController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/controller/ApprovalController.java
@@ -147,21 +147,21 @@ public class ApprovalController {
     @PostMapping
     public ResponseEntity<ApiResponse<Long>> createApproval(
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                    description = "상신할 결재 문서 정보. documentType 값에 따라 필수 필드가 달라집니다.",
-                    required = true,
-                    content =
-                            @Content(
-                                    mediaType = "application/json",
-                                    schema =
-                                            @Schema(
-                                                    implementation =
-                                                            ApprovalCreateRequestDto.class),
-                                    examples = {
-                                        @ExampleObject(
-                                                name = "기본양식 (BASIC)",
-                                                summary = "기본 기안문 예시",
-                                                value =
-                                                        """
+                            description = "상신할 결재 문서 정보. documentType 값에 따라 필수 필드가 달라집니다.",
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = "application/json",
+                                            schema =
+                                                    @Schema(
+                                                            implementation =
+                                                                    ApprovalCreateRequestDto.class),
+                                            examples = {
+                                                @ExampleObject(
+                                                        name = "기본양식 (BASIC)",
+                                                        summary = "기본 기안문 예시",
+                                                        value =
+                                                                """
                         {
                           "title": "비품 구매 요청",
                           "content": "<p>사무용 노트북 1대 구매를 요청합니다.</p>",
@@ -175,11 +175,11 @@ public class ApprovalController {
                           ]
                         }
                         """),
-                                        @ExampleObject(
-                                                name = "근태신청서 (LEAVE)",
-                                                summary = "휴가 신청 예시",
-                                                value =
-                                                        """
+                                                @ExampleObject(
+                                                        name = "근태신청서 (LEAVE)",
+                                                        summary = "휴가 신청 예시",
+                                                        value =
+                                                                """
                         {
                           "title": "2026년 하계 휴가 신청",
                           "content": "<p>계획된 휴가 신청합니다.</p>",
@@ -199,11 +199,11 @@ public class ApprovalController {
                           "emergencyContact": "010-1234-5678"
                         }
                         """),
-                                        @ExampleObject(
-                                                name = "기안및지출결의 (EXPENSE_DRAFT)",
-                                                summary = "지출결의 예시",
-                                                value =
-                                                        """
+                                                @ExampleObject(
+                                                        name = "기안및지출결의 (EXPENSE_DRAFT)",
+                                                        summary = "지출결의 예시",
+                                                        value =
+                                                                """
                         {
                           "title": "2026년 3월 사무용품 구매",
                           "content": "<p>사무용품 구매 지출 결의합니다.</p>",
@@ -227,11 +227,11 @@ public class ApprovalController {
                           ]
                         }
                         """),
-                                        @ExampleObject(
-                                                name = "차량유류정산지출결의 (CAR_FUEL)",
-                                                summary = "차량 유류비 정산 예시",
-                                                value =
-                                                        """
+                                                @ExampleObject(
+                                                        name = "차량유류정산지출결의 (CAR_FUEL)",
+                                                        summary = "차량 유류비 정산 예시",
+                                                        value =
+                                                                """
                         {
                           "title": "2026년 3월 차량 유류비 정산",
                           "content": "<p>3월 차량 운행 유류비 정산 요청합니다.</p>",
@@ -260,11 +260,11 @@ public class ApprovalController {
                           ]
                         }
                         """),
-                                        @ExampleObject(
-                                                name = "국외출장여비정산서 (OVERSEAS_TRIP)",
-                                                summary = "국외 출장비 정산 예시",
-                                                value =
-                                                        """
+                                                @ExampleObject(
+                                                        name = "국외출장여비정산서 (OVERSEAS_TRIP)",
+                                                        summary = "국외 출장비 정산 예시",
+                                                        value =
+                                                                """
                         {
                           "title": "2026년 3월 미국 출장 여비 정산",
                           "content": "<p>샌프란시스코 기술 컨퍼런스 참가 여비 정산합니다.</p>",
@@ -302,11 +302,11 @@ public class ApprovalController {
                           ]
                         }
                         """),
-                                        @ExampleObject(
-                                                name = "기안및지출결의_복리후생 (WELFARE_EXPENSE)",
-                                                summary = "복리후생 지출결의 예시",
-                                                value =
-                                                        """
+                                                @ExampleObject(
+                                                        name = "기안및지출결의_복리후생 (WELFARE_EXPENSE)",
+                                                        summary = "복리후생 지출결의 예시",
+                                                        value =
+                                                                """
                         {
                           "title": "2026년 3월 임직원 경조사 지원",
                           "content": "<p>임직원 경조사 지원금 지출 결의합니다.</p>",
@@ -329,7 +329,7 @@ public class ApprovalController {
                           ]
                         }
                         """)
-                                    }))
+                                            }))
                     @RequestBody
                     @Valid
                     ApprovalCreateRequestDto requestDto,

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/request/ApprovalCreateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/request/ApprovalCreateRequestDto.java
@@ -55,7 +55,7 @@ public abstract class ApprovalCreateRequestDto {
     @Valid
     private List<StepRequestDto> approvalSteps;
 
-    @Schema(description = "참조 및 열람자 리스트")
+    @Schema(description = "참조/열람자 리스트. 참조자(참조자)는 기안 시점에 알림을 받으며, 열람권자(열람권자)는 결재 완료 후 문서 열람 권한을 가집니다. (선택 사항)")
     @Valid
     private List<ParticipantRequestDto> participants;
 
@@ -85,7 +85,9 @@ public abstract class ApprovalCreateRequestDto {
         @NotNull(message = "대상자 ID는 필수입니다.")
         private Long userId; // 대상자 User ID
 
-        @Schema(description = "참여 유형 (REFERRER: 참조자, VIEWER: 열람권자)", example = "REFERRER")
+        @Schema(
+                description = "참여 유형 (참조자: 기안 시 알림 수신, 열람권자: 결재 완료 후 열람 권한 부여)",
+                example = "참조자")
         @NotNull(message = "참여 유형을 선택해주세요.")
         private ParticipantType participantType; // REFERRER, VIEWER
     }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/request/ApprovalCreateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/request/ApprovalCreateRequestDto.java
@@ -55,7 +55,10 @@ public abstract class ApprovalCreateRequestDto {
     @Valid
     private List<StepRequestDto> approvalSteps;
 
-    @Schema(description = "참조/열람자 리스트. 참조자(참조자)는 기안 시점에 알림을 받으며, 열람권자(열람권자)는 결재 완료 후 문서 열람 권한을 가집니다. (선택 사항)")
+    @Schema(
+            description =
+                    "참조/열람자 리스트. 참조자(참조자)는 기안 시점에 알림을 받으며, 열람권자(열람권자)는 결재 완료 후 문서 열람 권한을 가집니다. (선택"
+                        + " 사항)")
     @Valid
     private List<ParticipantRequestDto> participants;
 
@@ -85,9 +88,7 @@ public abstract class ApprovalCreateRequestDto {
         @NotNull(message = "대상자 ID는 필수입니다.")
         private Long userId; // 대상자 User ID
 
-        @Schema(
-                description = "참여 유형 (참조자: 기안 시 알림 수신, 열람권자: 결재 완료 후 열람 권한 부여)",
-                example = "참조자")
+        @Schema(description = "참여 유형 (참조자: 기안 시 알림 수신, 열람권자: 결재 완료 후 열람 권한 부여)", example = "참조자")
         @NotNull(message = "참여 유형을 선택해주세요.")
         private ParticipantType participantType; // REFERRER, VIEWER
     }


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #272

## 📝작업 내용

- `ApprovalCreateRequestDto`: `participantType` 필드 설명을 실제 동작 기준으로 수정 (참조자: 기안 시 알림 수신, 열람권자: 결재 완료 후 열람 권한 부여)
- `ApprovalCreateRequestDto`: `participants` 리스트 필드 설명 보강
- `ApprovalController`: `createApproval`에 `@io.swagger.v3.oas.annotations.parameters.RequestBody` 적용, 6개 DocumentType별 예시 추가
    - 기본양식 (BASIC), 근태신청서 (LEAVE), 기안및지출결의 (EXPENSE_DRAFT), 차량유류정산지출결의 (CAR_FUEL), 국외출장여비정산서 (OVERSEAS_TRIP), 기안및지출결의_복리후생 (WELFARE_EXPENSE)

## 📸 스크린샷 (선택)

## 🧪 테스트 여부

- [ ] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)

- 모든 Enum이 `@JsonValue`로 한글 description을 직렬화하므로, 예시 데이터의 `documentType`, `participantType`, `leaveType`, `leaveDetailType` 값이 한글로 작성됐습니다. 의도와 다르다면 Enum 설계 변경이 필요합니다.
