### PR TITLE
feat(275): 교육/안전보건 상세 응답 확장 및 companyScope 리스트 규격화

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/request/ApprovalCreateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/request/ApprovalCreateRequestDto.java
@@ -58,7 +58,7 @@ public abstract class ApprovalCreateRequestDto {
     @Schema(
             description =
                     "참조/열람자 리스트. 참조자(참조자)는 기안 시점에 알림을 받으며, 열람권자(열람권자)는 결재 완료 후 문서 열람 권한을 가집니다. (선택"
-                        + " 사항)")
+                            + " 사항)")
     @Valid
     private List<ParticipantRequestDto> participants;
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
@@ -275,7 +275,9 @@ public class EduReportController {
                 - `requestDto`(JSON 파트)는 필수입니다.
                 - `files`(파일 파트)는 선택입니다.
                 - 안전 보건 관리 권한(`MANAGE_SAFETY`)이 있어야 생성할 수 있습니다.
-                - `companyScope`를 지정하면 해당 회사 게시물, `null`이면 모든 회사 공통 게시물로 생성됩니다.
+                - `companyScope`는 회사 목록 배열입니다.
+                - `[AWESOME]`처럼 1개를 보내면 해당 회사 게시물로 생성됩니다.
+                - `[AWESOME, MARUI]`, `null`, `[]`는 모든 회사 공통 게시물로 생성됩니다.
                 """,
             requestBody =
                     @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -726,7 +728,7 @@ public class EduReportController {
                 PSM 게시물 상세 정보를 조회합니다.
 
                 - `MANAGE_PSM` 권한 사용자는 모든 회사의 PSM 게시물을 조회할 수 있습니다.
-                - 권한이 없는 사용자는 본인 소속 회사 게시물과 공통 게시물(`companyScope=null`)만 조회할 수 있습니다.
+                - 권한이 없는 사용자는 본인 소속 회사 게시물과 공통 게시물(`company` 컬럼이 null인 게시물)만 조회할 수 있습니다.
                 - 권한이 없는 사용자가 타 회사 게시물을 조회하면 `EDU_REPORT_NOT_FOUND(404)`가 반환됩니다.
                 """)
     @ApiResponses({
@@ -793,8 +795,10 @@ public class EduReportController {
                 안전 보건 게시물 상세 정보를 조회합니다.
 
                 - `MANAGE_SAFETY` 권한 사용자는 모든 회사의 안전 보건 게시물을 조회할 수 있습니다.
-                - 권한이 없는 사용자는 본인 소속 회사 게시물과 공통 게시물(`companyScope=null`)만 조회할 수 있습니다.
+                - 권한이 없는 사용자는 본인 소속 회사 게시물과 공통 게시물(`company` 컬럼이 null인 게시물)만 조회할 수 있습니다.
                 - 권한이 없는 사용자가 타 회사 게시물을 조회하면 `EDU_REPORT_NOT_FOUND(404)`가 반환됩니다.
+                - 응답의 `companyScope`는 회사 목록 배열로 반환됩니다.
+                - 공통 게시물은 `companyScope: ["AWESOME", "MARUI"]`로 응답됩니다.
                 """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
@@ -660,6 +660,7 @@ public class EduReportController {
                 - 권한이 없는 사용자는 본인 소속 부서의 게시물만 조회할 수 있습니다.
                 - 권한이 없는 사용자가 타 부서 게시물을 조회하면 `EDU_REPORT_NOT_FOUND(404)`가 반환됩니다.
                 - `MANAGE_DEPARTMENT_EDUCATION` 권한 사용자는 `attendees`, `numberOfPeople`, `numberOfAttendees`를 조회할 수 있으며, 권한이 없는 사용자는 위 필드가 `null`로 반환됩니다.
+                - `targetCount`, `signedCount`, `unsignedCount`는 부서 교육 상세에서 공통으로 제공됩니다.
                 """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
@@ -170,7 +170,9 @@ public class EduReportController {
                 - `requestDto`(JSON 파트)는 필수입니다.
                 - `files`(파일 파트)는 선택입니다.
                 - PSM 관리 권한(`MANAGE_PSM`)이 있어야 생성할 수 있습니다.
-                - `companyScope`를 지정하면 해당 회사 게시물, `null`이면 모든 회사 공통 게시물로 생성됩니다.
+                - `companyScope`는 회사 목록 배열입니다.
+                - `[AWESOME]`처럼 1개를 보내면 해당 회사 게시물로 생성됩니다.
+                - `[AWESOME, MARUI]`, `null`, `[]`는 모든 회사 공통 게시물로 생성됩니다.
                 """,
             requestBody =
                     @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -730,6 +732,8 @@ public class EduReportController {
                 - `MANAGE_PSM` 권한 사용자는 모든 회사의 PSM 게시물을 조회할 수 있습니다.
                 - 권한이 없는 사용자는 본인 소속 회사 게시물과 공통 게시물(`company` 컬럼이 null인 게시물)만 조회할 수 있습니다.
                 - 권한이 없는 사용자가 타 회사 게시물을 조회하면 `EDU_REPORT_NOT_FOUND(404)`가 반환됩니다.
+                - 응답의 `companyScope`는 회사 목록 배열로 반환됩니다.
+                - 공통 게시물은 `companyScope: ["AWESOME", "MARUI"]`로 응답됩니다.
                 """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/PsmEduReportCreateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/PsmEduReportCreateRequestDto.java
@@ -1,5 +1,7 @@
 package kr.co.awesomelead.groupware_backend.domain.education.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import jakarta.validation.constraints.NotBlank;
@@ -11,6 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Getter
 @Builder
@@ -34,9 +38,9 @@ public class PsmEduReportCreateRequestDto {
     private Long categoryId;
 
     @Schema(
-            description = "대상 회사 (null이면 모든 회사 공통 게시물)",
-            example = "AWESOME",
-            nullable = true,
-            allowableValues = {"AWESOME", "MARUI"})
-    private Company companyScope;
+            description = "대상 회사 범위 (예: [AWESOME], [AWESOME, MARUI], null/빈 배열이면 모든 회사 공통 게시물)",
+            example = "[\"AWESOME\", \"MARUI\"]",
+            nullable = true)
+    @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+    private List<Company> companyScope;
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/SafetyEduReportCreateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/SafetyEduReportCreateRequestDto.java
@@ -1,5 +1,7 @@
 package kr.co.awesomelead.groupware_backend.domain.education.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import jakarta.validation.constraints.NotBlank;
@@ -11,6 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Getter
 @Builder
@@ -34,9 +38,9 @@ public class SafetyEduReportCreateRequestDto {
     private Long categoryId;
 
     @Schema(
-            description = "대상 회사 (null이면 모든 회사 공통 게시물)",
-            example = "AWESOME",
-            nullable = true,
-            allowableValues = {"AWESOME", "MARUI"})
-    private Company companyScope;
+            description = "대상 회사 범위 (예: [AWESOME], [AWESOME, MARUI], null/빈 배열이면 모든 회사 공통 게시물)",
+            example = "[\"AWESOME\", \"MARUI\"]",
+            nullable = true)
+    @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+    private List<Company> companyScope;
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportDetailDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportDetailDto.java
@@ -36,7 +36,9 @@ public class EduReportDetailDto {
     @Schema(description = "교육 카테고리명", example = "유해위험물질")
     private String categoryName;
 
-    @Schema(description = "회사 범위(안전보건/PSM 대상). 공통 게시물은 전체 회사 목록으로 응답", example = "[\"AWESOME\", \"MARUI\"]")
+    @Schema(
+            description = "회사 범위(안전보건/PSM 대상). 공통 게시물은 전체 회사 목록으로 응답",
+            example = "[\"AWESOME\", \"MARUI\"]")
     private List<String> companyScope;
 
     @Schema(description = "부서 교육 시 대상 부서명 (부서 교육이 아닌 경우 null)", example = "영업부")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportDetailDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportDetailDto.java
@@ -36,6 +36,9 @@ public class EduReportDetailDto {
     @Schema(description = "교육 카테고리명", example = "유해위험물질")
     private String categoryName;
 
+    @Schema(description = "회사 범위(안전보건/PSM 대상). 공통 게시물은 전체 회사 목록으로 응답", example = "[\"AWESOME\", \"MARUI\"]")
+    private List<String> companyScope;
+
     @Schema(description = "부서 교육 시 대상 부서명 (부서 교육이 아닌 경우 null)", example = "영업부")
     private String departmentName;
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportDetailDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportDetailDto.java
@@ -63,6 +63,15 @@ public class EduReportDetailDto {
     @Schema(description = "출석 인원 수 (MANAGE_DEPARTMENT_EDUCATION 권한 없으면 null)", example = "45")
     private Integer numberOfAttendees;
 
+    @Schema(description = "대상 인원 수(부서교육 상세 조회 기준)", example = "50")
+    private Integer targetCount;
+
+    @Schema(description = "서명 인원 수(부서교육 상세 조회 기준)", example = "45")
+    private Integer signedCount;
+
+    @Schema(description = "미서명 인원 수(부서교육 상세 조회 기준)", example = "5")
+    private Integer unsignedCount;
+
     @Schema(description = "출석자 목록 (MANAGE_DEPARTMENT_EDUCATION 권한 없으면 null)")
     private List<AttendeeInfo> attendees;
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/mapper/EduMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/mapper/EduMapper.java
@@ -44,6 +44,7 @@ public interface EduMapper {
             target = "categoryName",
             expression =
                     "java(report.getCategory() != null ? report.getCategory().getName() : null)")
+    @Mapping(target = "companyScope", ignore = true)
     @Mapping(
             target = "departmentName",
             expression =

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/mapper/EduMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/mapper/EduMapper.java
@@ -55,6 +55,9 @@ public interface EduMapper {
     @Mapping(
             target = "numberOfAttendees",
             expression = "java(attendances != null ? attendances.size() : null)")
+    @Mapping(target = "targetCount", ignore = true)
+    @Mapping(target = "signedCount", ignore = true)
+    @Mapping(target = "unsignedCount", ignore = true)
     @Mapping(target = "attendees", source = "attendances")
     EduReportDetailDto toDetailDto(
             EduReport report,

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -311,7 +311,7 @@ public class EduReportService {
                         .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
 
         boolean hasAccess = user.hasAuthority(Authority.MANAGE_DEPARTMENT_EDUCATION);
-        return buildEduReportDetailDto(user, report, hasAccess);
+        return buildEduReportDetailDto(user, report, hasAccess, false);
     }
 
     @Transactional(readOnly = true)
@@ -339,7 +339,7 @@ public class EduReportService {
             }
         }
 
-        return buildEduReportDetailDto(user, report, hasAccess);
+        return buildEduReportDetailDto(user, report, hasAccess, true);
     }
 
     @Transactional(readOnly = true)
@@ -370,7 +370,7 @@ public class EduReportService {
         }
 
         boolean hasAccess = user.hasAuthority(Authority.MANAGE_DEPARTMENT_EDUCATION);
-        return buildEduReportDetailDto(user, report, hasAccess);
+        return buildEduReportDetailDto(user, report, hasAccess, false);
     }
 
     @Transactional(readOnly = true)
@@ -401,11 +401,11 @@ public class EduReportService {
         }
 
         boolean hasAccess = user.hasAuthority(Authority.MANAGE_DEPARTMENT_EDUCATION);
-        return buildEduReportDetailDto(user, report, hasAccess);
+        return buildEduReportDetailDto(user, report, hasAccess, false);
     }
 
     private EduReportDetailDto buildEduReportDetailDto(
-            User user, EduReport report, boolean hasAccess) {
+            User user, EduReport report, boolean hasAccess, boolean includeSignatureCounts) {
         List<EduAttendance> attendances = null;
         long numberOfPeople = -1L;
 
@@ -417,6 +417,16 @@ public class EduReportService {
 
         EduReportDetailDto dto =
                 eduMapper.toDetailDto(report, attendances, numberOfPeople, s3Service);
+
+        if (includeSignatureCounts) {
+            long targetCount = calculateTargetPeopleCount(report);
+            long signedCount = eduAttendanceRepository.countByEduReportId(report.getId());
+            long unsignedCount = Math.max(targetCount - signedCount, 0L);
+
+            dto.setTargetCount(safeToInteger(targetCount));
+            dto.setSignedCount(safeToInteger(signedCount));
+            dto.setUnsignedCount(safeToInteger(unsignedCount));
+        }
 
         boolean isAttended = eduAttendanceRepository.existsByEduReportAndUser(report, user);
         dto.setAttendance(isAttended);
@@ -961,5 +971,15 @@ public class EduReportService {
             return userRepository.countByDepartment(report.getDepartment());
         }
         return userRepository.count();
+    }
+
+    private Integer safeToInteger(long value) {
+        if (value < 0L) {
+            return null;
+        }
+        if (value > Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        return (int) value;
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -84,7 +84,8 @@ public class EduReportService {
                         .signatureRequired(false)
                         .categoryId(requestDto.getCategoryId())
                         .build();
-        return createEduReportInternal(baseRequest, files, id, true, requestDto.getCompanyScope());
+        Company companyOverride = resolveCompanyScopeOverride(requestDto.getCompanyScope());
+        return createEduReportInternal(baseRequest, files, id, true, companyOverride);
     }
 
     @Transactional
@@ -371,7 +372,9 @@ public class EduReportService {
         }
 
         boolean hasAccess = user.hasAuthority(Authority.MANAGE_DEPARTMENT_EDUCATION);
-        return buildEduReportDetailDto(user, report, hasAccess, false);
+        EduReportDetailDto dto = buildEduReportDetailDto(user, report, hasAccess, false);
+        dto.setCompanyScope(toCompanyScopeList(report.getCompany()));
+        return dto;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -100,7 +100,8 @@ public class EduReportService {
                         .signatureRequired(false)
                         .categoryId(requestDto.getCategoryId())
                         .build();
-        return createEduReportInternal(baseRequest, files, id, true, requestDto.getCompanyScope());
+        Company companyOverride = resolveCompanyScopeOverride(requestDto.getCompanyScope());
+        return createEduReportInternal(baseRequest, files, id, true, companyOverride);
     }
 
     private Long createEduReportInternal(
@@ -401,7 +402,9 @@ public class EduReportService {
         }
 
         boolean hasAccess = user.hasAuthority(Authority.MANAGE_DEPARTMENT_EDUCATION);
-        return buildEduReportDetailDto(user, report, hasAccess, false);
+        EduReportDetailDto dto = buildEduReportDetailDto(user, report, hasAccess, false);
+        dto.setCompanyScope(toCompanyScopeList(report.getCompany()));
+        return dto;
     }
 
     private EduReportDetailDto buildEduReportDetailDto(
@@ -971,6 +974,34 @@ public class EduReportService {
             return userRepository.countByDepartment(report.getDepartment());
         }
         return userRepository.count();
+    }
+
+    private Company resolveCompanyScopeOverride(List<Company> companyScopes) {
+        if (companyScopes == null || companyScopes.isEmpty()) {
+            return null; // 모든 회사 공통
+        }
+
+        LinkedHashSet<Company> normalized = new LinkedHashSet<>(companyScopes);
+        if (normalized.contains(null)) {
+            throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+        }
+
+        if (normalized.size() == 1) {
+            return normalized.iterator().next();
+        }
+
+        if (normalized.size() == Company.values().length) {
+            return null; // 전체 회사 선택은 공통 게시물로 저장
+        }
+
+        throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+    }
+
+    private List<String> toCompanyScopeList(Company storedCompany) {
+        if (storedCompany == null) {
+            return List.of(Company.AWESOME.name(), Company.MARUI.name());
+        }
+        return List.of(storedCompany.name());
     }
 
     private Integer safeToInteger(long value) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingSessionDetailResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingSessionDetailResponseDto.java
@@ -82,8 +82,7 @@ public class SafetyTrainingSessionDetailResponseDto {
     private SafetyTrainingAttendeeStatus myAttendanceStatus;
 
     @Schema(
-            description =
-                    "내 수료 상태(대표이사/MASTER_ADMIN 또는 세션 회사와 내 회사가 다르면 null)",
+            description = "내 수료 상태(대표이사/MASTER_ADMIN 또는 세션 회사와 내 회사가 다르면 null)",
             example = "COMPLETED",
             nullable = true)
     private SafetyTrainingCompletionStatus myCompletionStatus;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingSessionDetailResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingSessionDetailResponseDto.java
@@ -81,7 +81,11 @@ public class SafetyTrainingSessionDetailResponseDto {
     @Schema(description = "내 참석 상태", example = "SIGNED")
     private SafetyTrainingAttendeeStatus myAttendanceStatus;
 
-    @Schema(description = "내 수료 상태", example = "COMPLETED")
+    @Schema(
+            description =
+                    "내 수료 상태(대표이사/MASTER_ADMIN 또는 세션 회사와 내 회사가 다르면 null)",
+            example = "COMPLETED",
+            nullable = true)
     private SafetyTrainingCompletionStatus myCompletionStatus;
 
     @Schema(description = "내 서명 시각", example = "2026-03-24T10:31:00")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
@@ -241,9 +241,7 @@ public class SafetyTrainingSessionService {
 
         SafetyTrainingAttendeeStatus myStatus = attendee.getStatus();
         SafetyTrainingCompletionStatus completionStatus =
-                myStatus == SafetyTrainingAttendeeStatus.SIGNED
-                        ? SafetyTrainingCompletionStatus.COMPLETED
-                        : SafetyTrainingCompletionStatus.INCOMPLETE;
+                resolveMyCompletionStatus(actor, session, myStatus);
 
         String reportFileUrl =
                 session.getReportFileKey() == null
@@ -837,6 +835,20 @@ public class SafetyTrainingSessionService {
             return null;
         }
         return signed;
+    }
+
+    private SafetyTrainingCompletionStatus resolveMyCompletionStatus(
+            User actor, SafetyTrainingSession session, SafetyTrainingAttendeeStatus myStatus) {
+        if (!canExposeMySigned(actor)) {
+            return null;
+        }
+        if (actor.getWorkLocation() == null
+                || actor.getWorkLocation() != session.getCompanyScope()) {
+            return null;
+        }
+        return myStatus == SafetyTrainingAttendeeStatus.SIGNED
+                ? SafetyTrainingCompletionStatus.COMPLETED
+                : SafetyTrainingCompletionStatus.INCOMPLETE;
     }
 
     private List<SafetyEducationMethod> toMethods(String educationMethodsJson) {

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
@@ -377,7 +377,7 @@ public class EduReportServiceTest {
                         .content("PSM 내용")
                         .pinned(false)
                         .categoryId(1L)
-                        .companyScope(Company.MARUI)
+                        .companyScope(List.of(Company.MARUI))
                         .build();
 
         EduReport report =
@@ -462,7 +462,7 @@ public class EduReportServiceTest {
                         .content("안전 보건 내용")
                         .pinned(false)
                         .categoryId(2L)
-                        .companyScope(Company.AWESOME)
+                        .companyScope(List.of(Company.AWESOME))
                         .build();
 
         EduReport report =


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #275 

## 📝작업 내용
- 부서교육 상세 조회 응답 확장
- `targetCount`, `signedCount`, `unsignedCount` 필드 추가
- Swagger 설명 반영

- 안전보건 게시물 생성/상세 `companyScope` 규격 변경
- 생성 요청: 리스트 입력(`[AWESOME]`, `[AWESOME, MARUI]`, `null`, `[]`)
- 상세 응답: 리스트 출력(공통 게시물은 `["AWESOME","MARUI"]`)
- Swagger 문서 동기화

- PSM 게시물 생성/상세 `companyScope` 규격 변경
- 생성 요청/상세 응답을 안전보건과 동일한 리스트 규격으로 통일
- Swagger 문서 동기화

- 안전보건 교육일지 상세 조회 보정
- 대표이사/MASTER_ADMIN/타회사 조회 시 `myCompletionStatus: null` 처리

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [ ] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X