### PR TITLE
refactor(283): 이메일 찾기 선검증 API 및 교육/결재 응답 개선

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/config/SecurityConfig.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/config/SecurityConfig.java
@@ -94,6 +94,7 @@ public class SecurityConfig {
                                         "/api/auth/verify-phone-code",
                                         "/api/auth/check-account/email",
                                         "/api/auth/check-account/phone",
+                                        "/api/auth/check-account/find-email",
                                         "/api/auth/verify-identity",
                                         "/api/auth/verify-email-code",
                                         "/api/auth/send-phone-code",

--- a/src/main/java/kr/co/awesomelead/groupware_backend/config/SwaggerConfig.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/config/SwaggerConfig.java
@@ -64,6 +64,7 @@ public class SwaggerConfig {
                     "/api/auth/verify-phone-code",
                     "/api/auth/check-account/email",
                     "/api/auth/check-account/phone",
+                    "/api/auth/check-account/find-email",
                     "/api/auth/verify-identity",
                     "/api/auth/verify-email-code",
                     "/api/auth/send-phone-code",

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/controller/ApprovalConfigController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/controller/ApprovalConfigController.java
@@ -39,7 +39,8 @@ public class ApprovalConfigController {
             summary = "결재선 설정 저장",
             description =
                     "문서 양식(DocumentType)별 기본 결재자/참조자 ID 목록을 저장합니다. 기존 설정이 있으면 덮어씁니다."
-                            + " `MANAGE_APPROVAL_LINE` 권한이 필요합니다.")
+                            + " 응답에는 `documentType`(영문 enum), `documentTypeLabel`(한글) 및 결재자/참조자 상세"
+                            + " 정보가 포함됩니다. `MANAGE_APPROVAL_LINE` 권한이 필요합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",
@@ -57,7 +58,11 @@ public class ApprovalConfigController {
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
-    @Operation(summary = "전체 결재선 설정 조회", description = "모든 문서 양식에 대한 기본 결재선 설정을 목록으로 조회합니다.")
+    @Operation(
+            summary = "전체 결재선 설정 조회",
+            description =
+                    "모든 문서 양식에 대한 기본 결재선 설정을 목록으로 조회합니다. `documentType`은 영문 enum,"
+                            + " `documentTypeLabel`은 한글 라벨로 반환됩니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",
@@ -72,7 +77,8 @@ public class ApprovalConfigController {
             summary = "결재선 설정 조회",
             description =
                     "문서 양식(DocumentType)에 해당하는 기본 결재선 설정을 조회합니다."
-                            + " 설정이 없는 경우 빈 목록을 반환합니다. 인증된 사용자라면 누구나 조회할 수 있습니다.")
+                            + " 설정이 없는 경우 빈 목록을 반환합니다. 인증된 사용자라면 누구나 조회할 수 있습니다."
+                            + " 응답에는 결재자/참조자 상세 정보가 제공됩니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/response/ApprovalConfigResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/response/ApprovalConfigResponseDto.java
@@ -3,14 +3,17 @@ package kr.co.awesomelead.groupware_backend.domain.approval.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalLineConfig;
-import kr.co.awesomelead.groupware_backend.domain.approval.enums.DocumentType;
+import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 @Getter
 @Builder
@@ -19,20 +22,74 @@ import java.util.List;
 @Schema(description = "결재선 설정 응답 DTO")
 public class ApprovalConfigResponseDto {
 
-    @Schema(description = "문서 양식 타입", example = "BASIC")
-    private DocumentType documentType;
+    @Schema(description = "문서 양식 타입(영문 enum)", example = "BASIC")
+    private String documentType;
 
-    @Schema(description = "결재자 ID 목록 (순서 보장)", example = "[1, 2, 3]")
-    private List<Long> approverIds;
+    @Schema(description = "문서 양식 한글 라벨", example = "기본양식")
+    private String documentTypeLabel;
 
-    @Schema(description = "참조자 ID 목록", example = "[4, 5]")
-    private List<Long> referrerIds;
+    @Schema(description = "결재자 상세 정보 목록 (순서 보장)")
+    private List<ApprovalLineUserDto> approvers;
 
-    public static ApprovalConfigResponseDto from(ApprovalLineConfig config) {
+    @Schema(description = "참조자 상세 정보 목록")
+    private List<ApprovalLineUserDto> referrers;
+
+    public static ApprovalConfigResponseDto from(
+            ApprovalLineConfig config, Map<Long, User> usersById) {
+        List<Long> approverIds =
+                config.getApproverIds() == null ? Collections.emptyList() : config.getApproverIds();
+        List<Long> referrerIds =
+                config.getReferrerIds() == null ? Collections.emptyList() : config.getReferrerIds();
+
         return ApprovalConfigResponseDto.builder()
-                .documentType(config.getDocumentType())
-                .approverIds(config.getApproverIds())
-                .referrerIds(config.getReferrerIds())
+                .documentType(config.getDocumentType().name())
+                .documentTypeLabel(config.getDocumentType().getDescription())
+                .approvers(toUserDtos(approverIds, usersById))
+                .referrers(toUserDtos(referrerIds, usersById))
                 .build();
+    }
+
+    private static List<ApprovalLineUserDto> toUserDtos(List<Long> ids, Map<Long, User> usersById) {
+        return ids.stream()
+                .map(usersById::get)
+                .filter(Objects::nonNull)
+                .map(
+                        user ->
+                                ApprovalLineUserDto.builder()
+                                        .id(user.getId())
+                                        .name(user.getDisplayName())
+                                        .position(
+                                                user.getPosition() == null
+                                                        ? null
+                                                        : user.getPosition().getDescription())
+                                        .departmentName(
+                                                user.getDepartment() == null
+                                                                || user.getDepartment().getName()
+                                                                        == null
+                                                        ? null
+                                                        : user.getDepartment()
+                                                                .getName()
+                                                                .getDescription())
+                                        .build())
+                .toList();
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "결재선 유저 상세 정보")
+    public static class ApprovalLineUserDto {
+        @Schema(description = "사용자 ID", example = "14")
+        private Long id;
+
+        @Schema(description = "이름", example = "고영민")
+        private String name;
+
+        @Schema(description = "직급", example = "사원")
+        private String position;
+
+        @Schema(description = "부서명", example = "경영지원부")
+        private String departmentName;
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/enums/DocumentType.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/enums/DocumentType.java
@@ -12,7 +12,7 @@ public enum DocumentType {
     LEAVE("근태신청서", RetentionPeriod.PERMANENT),
     OVERSEAS_TRIP("국외출장여비정산서", RetentionPeriod.PERMANENT),
     EXPENSE_DRAFT("기안및지출결의", RetentionPeriod.PERMANENT),
-    WELFARE_EXPENSE("기안및지출결의_복리후생", RetentionPeriod.PERMANENT),
+    WELFARE_EXPENSE("기안및지출결의복리후생", RetentionPeriod.PERMANENT),
     CAR_FUEL("차량유류정산지출결의", RetentionPeriod.PERMANENT);
 
     private final String description;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalConfigService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalConfigService.java
@@ -18,9 +18,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -58,7 +60,7 @@ public class ApprovalConfigService {
             approvalLineConfigRepository.save(config);
         }
 
-        return ApprovalConfigResponseDto.from(config);
+        return ApprovalConfigResponseDto.from(config, loadUsersByIds(config));
     }
 
     @Transactional(readOnly = true)
@@ -70,19 +72,23 @@ public class ApprovalConfigService {
                                 Collectors.toMap(
                                         ApprovalLineConfig::getDocumentType, Function.identity()));
 
-        return Arrays.stream(DocumentType.values())
-                .map(
-                        type -> {
-                            ApprovalLineConfig config =
-                                    configMap.getOrDefault(
-                                            type,
-                                            ApprovalLineConfig.of(
-                                                    type,
-                                                    Collections.emptyList(),
-                                                    Collections.emptyList()));
-                            return ApprovalConfigResponseDto.from(config);
-                        })
-                .collect(Collectors.toList());
+        List<ApprovalLineConfig> resolvedConfigs =
+                Arrays.stream(DocumentType.values())
+                        .map(
+                                type ->
+                                        configMap.getOrDefault(
+                                                type,
+                                                ApprovalLineConfig.of(
+                                                        type,
+                                                        Collections.emptyList(),
+                                                        Collections.emptyList())))
+                        .toList();
+
+        Map<Long, User> usersById = loadUsersByIds(resolvedConfigs);
+
+        return resolvedConfigs.stream()
+                .map(config -> ApprovalConfigResponseDto.from(config, usersById))
+                .toList();
     }
 
     @Transactional(readOnly = true)
@@ -97,6 +103,34 @@ public class ApprovalConfigService {
                                                 java.util.Collections.emptyList(),
                                                 java.util.Collections.emptyList()));
 
-        return ApprovalConfigResponseDto.from(config);
+        return ApprovalConfigResponseDto.from(config, loadUsersByIds(config));
+    }
+
+    private Map<Long, User> loadUsersByIds(ApprovalLineConfig config) {
+        Set<Long> userIds = new HashSet<>();
+        userIds.addAll(config.getApproverIds());
+        userIds.addAll(config.getReferrerIds());
+
+        return loadUsersByIds(userIds);
+    }
+
+    private Map<Long, User> loadUsersByIds(List<ApprovalLineConfig> configs) {
+        Set<Long> userIds = new HashSet<>();
+        for (ApprovalLineConfig config : configs) {
+            userIds.addAll(config.getApproverIds());
+            userIds.addAll(config.getReferrerIds());
+        }
+
+        return loadUsersByIds(userIds);
+    }
+
+    private Map<Long, User> loadUsersByIds(Set<Long> userIds) {
+
+        if (userIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        return userRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/controller/AuthController.java
@@ -790,6 +790,72 @@ public class AuthController {
     }
 
     @Operation(
+            summary = "이메일 찾기 인증 요청 전 계정 존재 검증",
+            description = "이메일 찾기(이름+전화번호)에서 휴대폰 인증번호 발송 전에 계정 존재 여부를 검증합니다.")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "계정 확인 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
+                                        {
+                                          "isSuccess": true,
+                                          "code": "COMMON204",
+                                          "message": "계정 확인이 완료되었습니다.",
+                                          "result": null
+                                        }
+                                        """))),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "400",
+                        description = "입력값 검증 실패",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
+                                                        {
+                                                          "isSuccess": false,
+                                                          "code": "COMMON400",
+                                                          "message": "입력값이 유효하지 않습니다.",
+                                                          "result": {
+                                                            "phoneNumber": "전화번호는 '-' 없이 10~11자리 숫자로 입력해주세요."
+                                                          }
+                                                        }
+                                                        """))),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "404",
+                        description = "사용자를 찾을 수 없음",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
+                                        {
+                                          "isSuccess": false,
+                                          "code": "USER_NOT_FOUND",
+                                          "message": "해당 사용자를 찾을 수 없습니다.",
+                                          "result": null
+                                        }
+                                        """)))
+            })
+    @PostMapping("/check-account/find-email")
+    public ResponseEntity<ApiResponse<Void>> checkAccountForFindEmail(
+            @Valid @RequestBody FindEmailRequestDto requestDto) {
+        authService.checkAccountForFindEmail(requestDto.getName(), requestDto.getPhoneNumber());
+        return ResponseEntity.ok(ApiResponse.onNoContent("계정 확인이 완료되었습니다."));
+    }
+
+    @Operation(
             summary = "이메일 인증 요청 전 계정 존재 검증",
             description = "이메일 인증번호 발송 전, 입력한 이메일 계정 존재 여부를 검증합니다.")
     @ApiResponses(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
@@ -251,26 +251,35 @@ public class AuthService {
             throw new CustomException(ErrorCode.PHONE_NOT_VERIFIED);
         }
 
-        // 2. 해시로 사용자 찾기
+        // 2. 이름+전화번호 계정 검증
+        User user = findUserByNameAndPhone(name, phoneNumber);
+
+        long endTime = System.currentTimeMillis();
+        log.info("해시 검색 방식 소요 시간: {}ms", endTime - startTime);
+
+        // 3. 인증 플래그 삭제
+        phoneAuthService.clearVerification(phoneNumber);
+
+        // 4. 응답 생성
+        return new FindEmailResponseDto(maskEmail(user.getEmail()));
+    }
+
+    public void checkAccountForFindEmail(String name, String phoneNumber) {
+        findUserByNameAndPhone(name, phoneNumber);
+    }
+
+    private User findUserByNameAndPhone(String name, String phoneNumber) {
         String phoneNumberHash = User.hashValue(phoneNumber);
         User user =
                 userRepository
                         .findByPhoneNumberHash(phoneNumberHash)
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        // 3. 이름 검증
         if (!user.getNameKor().equals(name)) {
             throw new CustomException(ErrorCode.USER_NOT_FOUND);
         }
 
-        long endTime = System.currentTimeMillis();
-        log.info("해시 검색 방식 소요 시간: {}ms", endTime - startTime);
-
-        // 4. 인증 플래그 삭제
-        phoneAuthService.clearVerification(phoneNumber);
-
-        // 5. 응답 생성
-        return new FindEmailResponseDto(maskEmail(user.getEmail()));
+        return user;
     }
 
     private String maskEmail(String email) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
@@ -665,6 +665,7 @@ public class EduReportController {
                 - 권한이 없는 사용자가 타 부서 게시물을 조회하면 `EDU_REPORT_NOT_FOUND(404)`가 반환됩니다.
                 - `MANAGE_DEPARTMENT_EDUCATION` 권한 사용자는 `attendees`, `numberOfPeople`, `numberOfAttendees`를 조회할 수 있으며, 권한이 없는 사용자는 위 필드가 `null`로 반환됩니다.
                 - `targetCount`, `signedCount`, `unsignedCount`는 부서 교육 상세에서 공통으로 제공됩니다.
+                - `canSign`은 현재 사용자의 서명 가능 여부를 의미하며, `OPEN` 상태이면서 미서명인 경우 `true`입니다.
                 """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportDetailDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportDetailDto.java
@@ -77,6 +77,9 @@ public class EduReportDetailDto {
     @Schema(description = "미서명 인원 수(부서교육 상세 조회 기준)", example = "5")
     private Integer unsignedCount;
 
+    @Schema(description = "현재 사용자의 서명 가능 여부(부서교육 상세 조회 기준)", example = "true")
+    private boolean canSign;
+
     @Schema(description = "출석자 목록 (MANAGE_DEPARTMENT_EDUCATION 권한 없으면 null)")
     private List<AttendeeInfo> attendees;
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/mapper/EduMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/mapper/EduMapper.java
@@ -59,6 +59,7 @@ public interface EduMapper {
     @Mapping(target = "targetCount", ignore = true)
     @Mapping(target = "signedCount", ignore = true)
     @Mapping(target = "unsignedCount", ignore = true)
+    @Mapping(target = "canSign", ignore = true)
     @Mapping(target = "attendees", source = "attendances")
     EduReportDetailDto toDetailDto(
             EduReport report,

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -436,7 +436,18 @@ public class EduReportService {
 
         boolean isAttended = eduAttendanceRepository.existsByEduReportAndUser(report, user);
         dto.setAttendance(isAttended);
+        dto.setCanSign(canSignDepartmentEduReport(report, isAttended));
         return dto;
+    }
+
+    private boolean canSignDepartmentEduReport(EduReport report, boolean isAttended) {
+        if (report.getEduType() != EduType.DEPARTMENT) {
+            return false;
+        }
+        if (report.getStatus() != EduReportStatus.OPEN) {
+            return false;
+        }
+        return !isAttended;
     }
 
     @Transactional

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/approval/ApprovalConfigServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/approval/ApprovalConfigServiceTest.java
@@ -54,7 +54,8 @@ class ApprovalConfigServiceTest {
 
         normalUser = User.builder().id(2L).build();
 
-        lenient().when(userRepository.findAllById(org.mockito.ArgumentMatchers.anyIterable()))
+        lenient()
+                .when(userRepository.findAllById(org.mockito.ArgumentMatchers.anyIterable()))
                 .thenReturn(List.of());
     }
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/approval/ApprovalConfigServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/approval/ApprovalConfigServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -52,6 +53,9 @@ class ApprovalConfigServiceTest {
         adminUser.addAuthority(Authority.MANAGE_APPROVAL_LINE);
 
         normalUser = User.builder().id(2L).build();
+
+        lenient().when(userRepository.findAllById(org.mockito.ArgumentMatchers.anyIterable()))
+                .thenReturn(List.of());
     }
 
     @Nested
@@ -78,9 +82,9 @@ class ApprovalConfigServiceTest {
                         approvalConfigService.saveConfig(request, ADMIN_ID);
 
                 verify(approvalLineConfigRepository).save(any(ApprovalLineConfig.class));
-                assertThat(response.getDocumentType()).isEqualTo(DocumentType.BASIC);
-                assertThat(response.getApproverIds()).containsExactly(10L, 20L, 30L);
-                assertThat(response.getReferrerIds()).containsExactly(40L);
+                assertThat(response.getDocumentType()).isEqualTo(DocumentType.BASIC.name());
+                assertThat(response.getApprovers()).isEmpty();
+                assertThat(response.getReferrers()).isEmpty();
             }
 
             @Test
@@ -102,8 +106,8 @@ class ApprovalConfigServiceTest {
                         approvalConfigService.saveConfig(request, ADMIN_ID);
 
                 verify(approvalLineConfigRepository, never()).save(any());
-                assertThat(response.getApproverIds()).containsExactly(10L, 20L);
-                assertThat(response.getReferrerIds()).containsExactly(99L);
+                assertThat(response.getApprovers()).isEmpty();
+                assertThat(response.getReferrers()).isEmpty();
             }
 
             @Test
@@ -117,11 +121,22 @@ class ApprovalConfigServiceTest {
                 given(userRepository.findById(ADMIN_ID)).willReturn(Optional.of(adminUser));
                 given(approvalLineConfigRepository.findById(DocumentType.LEAVE))
                         .willReturn(Optional.empty());
+                given(userRepository.findAllById(org.mockito.ArgumentMatchers.anyIterable()))
+                        .willAnswer(
+                                invocation -> {
+                                    User u5 = User.builder().id(5L).nameKor("u5").build();
+                                    User u3 = User.builder().id(3L).nameKor("u3").build();
+                                    User u7 = User.builder().id(7L).nameKor("u7").build();
+                                    User u1 = User.builder().id(1L).nameKor("u1").build();
+                                    return List.of(u5, u3, u7, u1);
+                                });
 
                 ApprovalConfigResponseDto response =
                         approvalConfigService.saveConfig(request, ADMIN_ID);
 
-                assertThat(response.getApproverIds()).containsExactly(5L, 3L, 7L, 1L);
+                assertThat(response.getApprovers())
+                        .extracting(ApprovalConfigResponseDto.ApprovalLineUserDto::getId)
+                        .containsExactly(5L, 3L, 7L, 1L);
             }
         }
 
@@ -162,24 +177,36 @@ class ApprovalConfigServiceTest {
                     ApprovalLineConfig.of(DocumentType.BASIC, List.of(10L, 20L), List.of(30L));
 
             given(approvalLineConfigRepository.findAll()).willReturn(List.of(basicConfig));
+            given(userRepository.findAllById(org.mockito.ArgumentMatchers.anyIterable()))
+                    .willAnswer(
+                            invocation -> {
+                                User u10 = User.builder().id(10L).nameKor("u10").build();
+                                User u20 = User.builder().id(20L).nameKor("u20").build();
+                                User u30 = User.builder().id(30L).nameKor("u30").build();
+                                return List.of(u10, u20, u30);
+                            });
 
             List<ApprovalConfigResponseDto> result = approvalConfigService.getAllConfigs();
 
             assertThat(result).hasSize(DocumentType.values().length);
             ApprovalConfigResponseDto basicResult =
                     result.stream()
-                            .filter(r -> r.getDocumentType() == DocumentType.BASIC)
+                            .filter(r -> DocumentType.BASIC.name().equals(r.getDocumentType()))
                             .findFirst()
                             .orElseThrow();
-            assertThat(basicResult.getApproverIds()).containsExactly(10L, 20L);
-            assertThat(basicResult.getReferrerIds()).containsExactly(30L);
+            assertThat(basicResult.getApprovers())
+                    .extracting(ApprovalConfigResponseDto.ApprovalLineUserDto::getId)
+                    .containsExactly(10L, 20L);
+            assertThat(basicResult.getReferrers())
+                    .extracting(ApprovalConfigResponseDto.ApprovalLineUserDto::getId)
+                    .containsExactly(30L);
 
             result.stream()
-                    .filter(r -> r.getDocumentType() != DocumentType.BASIC)
+                    .filter(r -> !DocumentType.BASIC.name().equals(r.getDocumentType()))
                     .forEach(
                             r -> {
-                                assertThat(r.getApproverIds()).isEmpty();
-                                assertThat(r.getReferrerIds()).isEmpty();
+                                assertThat(r.getApprovers()).isEmpty();
+                                assertThat(r.getReferrers()).isEmpty();
                             });
         }
     }
@@ -197,13 +224,25 @@ class ApprovalConfigServiceTest {
 
             given(approvalLineConfigRepository.findById(DocumentType.EXPENSE_DRAFT))
                     .willReturn(Optional.of(config));
+            given(userRepository.findAllById(org.mockito.ArgumentMatchers.anyIterable()))
+                    .willAnswer(
+                            invocation -> {
+                                User u10 = User.builder().id(10L).nameKor("u10").build();
+                                User u20 = User.builder().id(20L).nameKor("u20").build();
+                                User u30 = User.builder().id(30L).nameKor("u30").build();
+                                return List.of(u10, u20, u30);
+                            });
 
             ApprovalConfigResponseDto response =
                     approvalConfigService.getConfig(DocumentType.EXPENSE_DRAFT);
 
-            assertThat(response.getDocumentType()).isEqualTo(DocumentType.EXPENSE_DRAFT);
-            assertThat(response.getApproverIds()).containsExactly(10L, 20L);
-            assertThat(response.getReferrerIds()).containsExactly(30L);
+            assertThat(response.getDocumentType()).isEqualTo(DocumentType.EXPENSE_DRAFT.name());
+            assertThat(response.getApprovers())
+                    .extracting(ApprovalConfigResponseDto.ApprovalLineUserDto::getId)
+                    .containsExactly(10L, 20L);
+            assertThat(response.getReferrers())
+                    .extracting(ApprovalConfigResponseDto.ApprovalLineUserDto::getId)
+                    .containsExactly(30L);
         }
 
         @Test
@@ -215,9 +254,9 @@ class ApprovalConfigServiceTest {
             ApprovalConfigResponseDto response =
                     approvalConfigService.getConfig(DocumentType.CAR_FUEL);
 
-            assertThat(response.getDocumentType()).isEqualTo(DocumentType.CAR_FUEL);
-            assertThat(response.getApproverIds()).isEmpty();
-            assertThat(response.getReferrerIds()).isEmpty();
+            assertThat(response.getDocumentType()).isEqualTo(DocumentType.CAR_FUEL.name());
+            assertThat(response.getApprovers()).isEmpty();
+            assertThat(response.getReferrers()).isEmpty();
         }
     }
 }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
@@ -586,6 +586,59 @@ class AuthServiceTest {
     }
 
     @Nested
+    @DisplayName("이메일 찾기 인증요청 전 계정 선검증")
+    class CheckAccountForFindEmailTest {
+
+        @Test
+        @DisplayName("성공: 이름과 전화번호가 일치하면 통과")
+        void checkAccountForFindEmail_Success() {
+            // given
+            testUser.setNameKor("홍길동");
+            testUser.setPhoneNumberHash(User.hashValue(TEST_PHONE));
+            given(userRepository.findByPhoneNumberHash(User.hashValue(TEST_PHONE)))
+                    .willReturn(Optional.of(testUser));
+
+            // when
+            authService.checkAccountForFindEmail("홍길동", TEST_PHONE);
+
+            // then
+            verify(userRepository).findByPhoneNumberHash(User.hashValue(TEST_PHONE));
+        }
+
+        @Test
+        @DisplayName("실패: 전화번호로 사용자를 찾을 수 없으면 USER_NOT_FOUND")
+        void checkAccountForFindEmail_UserNotFound() {
+            // given
+            given(userRepository.findByPhoneNumberHash(User.hashValue(TEST_PHONE)))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> authService.checkAccountForFindEmail("홍길동", TEST_PHONE))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+
+            verify(userRepository).findByPhoneNumberHash(User.hashValue(TEST_PHONE));
+        }
+
+        @Test
+        @DisplayName("실패: 이름이 일치하지 않으면 USER_NOT_FOUND")
+        void checkAccountForFindEmail_NameMismatch() {
+            // given
+            testUser.setNameKor("김철수");
+            testUser.setPhoneNumberHash(User.hashValue(TEST_PHONE));
+            given(userRepository.findByPhoneNumberHash(User.hashValue(TEST_PHONE)))
+                    .willReturn(Optional.of(testUser));
+
+            // when & then
+            assertThatThrownBy(() -> authService.checkAccountForFindEmail("홍길동", TEST_PHONE))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+
+            verify(userRepository).findByPhoneNumberHash(User.hashValue(TEST_PHONE));
+        }
+    }
+
+    @Nested
     @DisplayName("휴대폰 비밀번호 찾기 계정 검증")
     class VerifyAccountByPhoneTest {
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
@@ -934,6 +934,7 @@ public class EduReportServiceTest {
         // then
         assertThat(result).isNotNull();
         assertThat(result.getEduType()).isEqualTo(EduType.DEPARTMENT);
+        assertThat(result.isCanSign()).isTrue();
         verify(eduAttendanceRepository, never()).findAllByEduReportIdWithUser(anyLong());
     }
 
@@ -992,6 +993,7 @@ public class EduReportServiceTest {
         // then
         assertThat(result).isNotNull();
         assertThat(result.getEduType()).isEqualTo(EduType.PSM);
+        assertThat(result.isCanSign()).isFalse();
     }
 
     @Test
@@ -1024,6 +1026,7 @@ public class EduReportServiceTest {
         // then
         assertThat(result).isNotNull();
         assertThat(result.getEduType()).isEqualTo(EduType.PSM);
+        assertThat(result.isCanSign()).isFalse();
     }
 
     @Test
@@ -1081,6 +1084,7 @@ public class EduReportServiceTest {
         // then
         assertThat(result).isNotNull();
         assertThat(result.getEduType()).isEqualTo(EduType.SAFETY);
+        assertThat(result.isCanSign()).isFalse();
     }
 
     @Test
@@ -1113,6 +1117,7 @@ public class EduReportServiceTest {
         // then
         assertThat(result).isNotNull();
         assertThat(result.getEduType()).isEqualTo(EduType.SAFETY);
+        assertThat(result.isCanSign()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #283 

## 📝작업 내용
- 이메일 찾기 선검증 API 추가
  - `POST /api/auth/check-account/find-email`
  - 이름+전화번호 기반 계정 존재 여부 검증
  - 인증요청 전 사전 검증 용도
- 부서교육 상세 조회 응답 개선
  - `canSign` 필드 추가
  - 서명 가능 여부 계산 로직 반영
- 결재선 목록 응답 개선
  - 사용자 상세정보(이름, 직급, 부서) 포함
  - `documentType`(영문 코드) / `documentTypeLabel`(한글 라벨) 분리

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X