### PR TITLE
refactor: 부서교육 상세 canSign 조건을 본인 부서 + signatureRequired=true로 제한

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
@@ -665,7 +665,7 @@ public class EduReportController {
                 - 권한이 없는 사용자가 타 부서 게시물을 조회하면 `EDU_REPORT_NOT_FOUND(404)`가 반환됩니다.
                 - `MANAGE_DEPARTMENT_EDUCATION` 권한 사용자는 `attendees`, `numberOfPeople`, `numberOfAttendees`를 조회할 수 있으며, 권한이 없는 사용자는 위 필드가 `null`로 반환됩니다.
                 - `targetCount`, `signedCount`, `unsignedCount`는 부서 교육 상세에서 공통으로 제공됩니다.
-                - `canSign`은 현재 사용자의 서명 가능 여부를 의미하며, `OPEN` 상태이면서 미서명인 경우 `true`입니다.
+                - `canSign`은 현재 사용자의 서명 가능 여부를 의미하며, `signatureRequired=true` + `OPEN` 상태 + 미서명 + 본인 소속 부서 게시물인 경우 `true`입니다.
                 """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -436,15 +436,23 @@ public class EduReportService {
 
         boolean isAttended = eduAttendanceRepository.existsByEduReportAndUser(report, user);
         dto.setAttendance(isAttended);
-        dto.setCanSign(canSignDepartmentEduReport(report, isAttended));
+        dto.setCanSign(canSignDepartmentEduReport(report, user, isAttended));
         return dto;
     }
 
-    private boolean canSignDepartmentEduReport(EduReport report, boolean isAttended) {
+    private boolean canSignDepartmentEduReport(EduReport report, User user, boolean isAttended) {
         if (report.getEduType() != EduType.DEPARTMENT) {
             return false;
         }
+        if (!report.isSignatureRequired()) {
+            return false;
+        }
         if (report.getStatus() != EduReportStatus.OPEN) {
+            return false;
+        }
+        if (user.getDepartment() == null
+                || report.getDepartment() == null
+                || !report.getDepartment().getId().equals(user.getDepartment().getId())) {
             return false;
         }
         return !isAttended;

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
@@ -913,6 +913,7 @@ public class EduReportServiceTest {
                         .id(reportId)
                         .eduType(EduType.DEPARTMENT)
                         .department(defaultDept)
+                        .signatureRequired(true)
                         .title("본인 부서 교육")
                         .build();
 
@@ -936,6 +937,87 @@ public class EduReportServiceTest {
         assertThat(result.getEduType()).isEqualTo(EduType.DEPARTMENT);
         assertThat(result.isCanSign()).isTrue();
         verify(eduAttendanceRepository, never()).findAllByEduReportIdWithUser(anyLong());
+    }
+
+    @Test
+    @DisplayName("부서 교육 상세 조회 - 본인 부서라도 signatureRequired=false면 canSign=false")
+    void getDepartmentEduReport_OwnDepartment_SignatureNotRequired_CanSignFalse() {
+        // given
+        Long reportId = 3L;
+        Long userId = 1L;
+        User user = createNormalUser();
+
+        EduReport report =
+                EduReport.builder()
+                        .id(reportId)
+                        .eduType(EduType.DEPARTMENT)
+                        .department(defaultDept)
+                        .signatureRequired(false)
+                        .status(EduReportStatus.OPEN)
+                        .title("서명 불필요 부서 교육")
+                        .build();
+
+        EduReportDetailDto mockDto =
+                EduReportDetailDto.builder()
+                        .id(reportId)
+                        .title("서명 불필요 부서 교육")
+                        .eduType(EduType.DEPARTMENT)
+                        .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(eduReportRepository.findById(reportId)).thenReturn(Optional.of(report));
+        when(eduMapper.toDetailDto(report, null, -1L, s3Service)).thenReturn(mockDto);
+        when(eduAttendanceRepository.existsByEduReportAndUser(report, user)).thenReturn(false);
+
+        // when
+        EduReportDetailDto result = eduReportService.getDepartmentEduReport(reportId, userId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.isCanSign()).isFalse();
+    }
+
+    @Test
+    @DisplayName("부서 교육 상세 조회 - 권한이 있어도 타 부서 게시물은 canSign=false")
+    void getDepartmentEduReport_WithAuthority_OtherDepartment_CanSignFalse() {
+        // given
+        Long reportId = 2L;
+        Long userId = 1L;
+        User user = createNormalUser();
+        user.addAuthority(Authority.MANAGE_DEPARTMENT_EDUCATION);
+
+        Department otherDepartment =
+                Department.builder().id(2L).name(DepartmentName.MANAGEMENT_SUPPORT).build();
+
+        EduReport report =
+                EduReport.builder()
+                        .id(reportId)
+                        .eduType(EduType.DEPARTMENT)
+                        .department(otherDepartment)
+                        .status(EduReportStatus.OPEN)
+                        .title("타 부서 교육")
+                        .build();
+
+        EduReportDetailDto mockDto =
+                EduReportDetailDto.builder()
+                        .id(reportId)
+                        .title("타 부서 교육")
+                        .eduType(EduType.DEPARTMENT)
+                        .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(eduReportRepository.findById(reportId)).thenReturn(Optional.of(report));
+        when(eduAttendanceRepository.findAllByEduReportIdWithUser(reportId))
+                .thenReturn(new ArrayList<>());
+        when(eduMapper.toDetailDto(report, new ArrayList<>(), 0L, s3Service)).thenReturn(mockDto);
+        when(eduAttendanceRepository.existsByEduReportAndUser(report, user)).thenReturn(false);
+
+        // when
+        EduReportDetailDto result = eduReportService.getDepartmentEduReport(reportId, userId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.isCanSign()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #283 

## 📝작업 내용
- 부서교육 상세 조회의 `canSign` 계산 로직 수정
  - 본인 소속 부서 게시물인 경우에만 `canSign=true` 가능
  - `signatureRequired=true`인 게시물에서만 `canSign=true` 가능
  - 그 외(`signatureRequired=false`, 타 부서, CLOSED, 기서명)는 `canSign=false`
- Swagger 설명 문구를 실제 조건과 일치하도록 수정
- 테스트 코드 보강
  - 본인 부서 + 서명필수(true) 케이스
  - 본인 부서 + 서명비필수(false) 케이스
  - 권한 보유자라도 타 부서인 경우 케이스

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X