### PR TITLE
fix(288): 제증명 신청 내역 페이징 정렬 500 오류 수정

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/repository/RequestHistoryQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/repository/RequestHistoryQueryRepository.java
@@ -1,0 +1,88 @@
+package kr.co.awesomelead.groupware_backend.domain.requesthistory.repository;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import kr.co.awesomelead.groupware_backend.domain.requesthistory.entity.QRequestHistory;
+import kr.co.awesomelead.groupware_backend.domain.requesthistory.entity.RequestHistory;
+import kr.co.awesomelead.groupware_backend.domain.requesthistory.enums.RequestHistoryStatus;
+import kr.co.awesomelead.groupware_backend.domain.user.entity.QUser;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class RequestHistoryQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Page<RequestHistory> findAllWithUserAndDepartmentByStatus(
+            RequestHistoryStatus status, Pageable pageable) {
+
+        QRequestHistory rh = QRequestHistory.requestHistory;
+        QUser user = QUser.user;
+
+        List<RequestHistory> content =
+                queryFactory
+                        .selectFrom(rh)
+                        .innerJoin(rh.user, user)
+                        .fetchJoin()
+                        .leftJoin(user.department)
+                        .fetchJoin()
+                        .where(status != null ? rh.approvalStatus.eq(status) : null)
+                        .orderBy(orderSpecifiers(rh, pageable))
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize())
+                        .fetch();
+
+        return PageableExecutionUtils.getPage(
+                content,
+                pageable,
+                () -> {
+                    Long count =
+                            queryFactory
+                                    .select(rh.count())
+                                    .from(rh)
+                                    .where(status != null ? rh.approvalStatus.eq(status) : null)
+                                    .fetchOne();
+                    return count != null ? count : 0L;
+                });
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private OrderSpecifier<?>[] orderSpecifiers(QRequestHistory rh, Pageable pageable) {
+        List<OrderSpecifier<?>> orders = new ArrayList<>();
+
+        for (Sort.Order order : pageable.getSort()) {
+            Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+            String property = order.getProperty();
+
+            // createdAt은 엔티티 필드명 requestDate에 매핑
+            if ("createdAt".equals(property)) {
+                property = "requestDate";
+            }
+
+            PathBuilder<RequestHistory> path =
+                    new PathBuilder<>(RequestHistory.class, "requestHistory");
+            orders.add(new OrderSpecifier(direction, path.get(property)));
+        }
+
+        if (orders.isEmpty()) {
+            orders.add(rh.requestDate.desc());
+            orders.add(rh.id.desc());
+        }
+
+        return orders.toArray(new OrderSpecifier[0]);
+    }
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/repository/RequestHistoryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/repository/RequestHistoryRepository.java
@@ -1,10 +1,7 @@
 package kr.co.awesomelead.groupware_backend.domain.requesthistory.repository;
 
 import kr.co.awesomelead.groupware_backend.domain.requesthistory.entity.RequestHistory;
-import kr.co.awesomelead.groupware_backend.domain.requesthistory.enums.RequestHistoryStatus;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -24,16 +21,4 @@ public interface RequestHistoryRepository extends JpaRepository<RequestHistory, 
                     + "left join fetch u.department d "
                     + "where rh.id = :id")
     Optional<RequestHistory> findByIdWithUserAndDepartment(@Param("id") Long id);
-
-    @Query(
-            value =
-                    "select rh from RequestHistory rh "
-                            + "join fetch rh.user u "
-                            + "left join fetch u.department d "
-                            + "where (:status is null or rh.approvalStatus = :status)",
-            countQuery =
-                    "select count(rh) from RequestHistory rh "
-                            + "where (:status is null or rh.approvalStatus = :status)")
-    Page<RequestHistory> findAllWithUserAndDepartmentByStatus(
-            @Param("status") RequestHistoryStatus status, Pageable pageable);
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/service/RequestHistoryService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/service/RequestHistoryService.java
@@ -11,6 +11,7 @@ import kr.co.awesomelead.groupware_backend.domain.requesthistory.dto.response.Re
 import kr.co.awesomelead.groupware_backend.domain.requesthistory.dto.response.RequestHistorySummaryResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.requesthistory.entity.RequestHistory;
 import kr.co.awesomelead.groupware_backend.domain.requesthistory.enums.RequestHistoryStatus;
+import kr.co.awesomelead.groupware_backend.domain.requesthistory.repository.RequestHistoryQueryRepository;
 import kr.co.awesomelead.groupware_backend.domain.requesthistory.repository.RequestHistoryRepository;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Authority;
@@ -34,6 +35,7 @@ import java.util.List;
 public class RequestHistoryService {
 
     private final RequestHistoryRepository requestHistoryRepository;
+    private final RequestHistoryQueryRepository requestHistoryQueryRepository;
     private final UserRepository userRepository;
     private final NotificationService notificationService;
     private final NotificationRepository notificationRepository;
@@ -127,7 +129,7 @@ public class RequestHistoryService {
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         validateAdminAuthority(admin);
 
-        return requestHistoryRepository
+        return requestHistoryQueryRepository
                 .findAllWithUserAndDepartmentByStatus(status, pageable)
                 .map(AdminRequestHistorySummaryResponseDto::from);
     }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/RequestHistoryServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/RequestHistoryServiceTest.java
@@ -18,6 +18,7 @@ import kr.co.awesomelead.groupware_backend.domain.requesthistory.dto.response.Re
 import kr.co.awesomelead.groupware_backend.domain.requesthistory.entity.RequestHistory;
 import kr.co.awesomelead.groupware_backend.domain.requesthistory.enums.RequestHistoryStatus;
 import kr.co.awesomelead.groupware_backend.domain.requesthistory.enums.RequestType;
+import kr.co.awesomelead.groupware_backend.domain.requesthistory.repository.RequestHistoryQueryRepository;
 import kr.co.awesomelead.groupware_backend.domain.requesthistory.repository.RequestHistoryRepository;
 import kr.co.awesomelead.groupware_backend.domain.requesthistory.service.RequestHistoryService;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
@@ -37,6 +38,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
@@ -49,6 +51,7 @@ class RequestHistoryServiceTest {
 
     @InjectMocks private RequestHistoryService requestHistoryService;
     @Mock private RequestHistoryRepository requestHistoryRepository;
+    @Mock private RequestHistoryQueryRepository requestHistoryQueryRepository;
     @Mock private UserRepository userRepository;
     @Mock private NotificationService notificationService;
     @Mock private NotificationRepository notificationRepository;
@@ -231,12 +234,13 @@ class RequestHistoryServiceTest {
             ReflectionTestUtils.setField(requestHistory, "id", 10L);
             ReflectionTestUtils.setField(requestHistory, "name", "홍길동");
 
-            PageRequest pageable = PageRequest.of(0, 20);
+            PageRequest pageable =
+                    PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdAt"));
             Page<RequestHistory> page = new PageImpl<>(List.of(requestHistory), pageable, 1);
 
             given(userRepository.findById(100L)).willReturn(Optional.of(admin));
             given(
-                            requestHistoryRepository.findAllWithUserAndDepartmentByStatus(
+                            requestHistoryQueryRepository.findAllWithUserAndDepartmentByStatus(
                                     RequestHistoryStatus.PENDING, pageable))
                     .willReturn(page);
 
@@ -244,6 +248,7 @@ class RequestHistoryServiceTest {
             Page<AdminRequestHistorySummaryResponseDto> result =
                     requestHistoryService.getAllRequestsForAdmin(
                             100L, RequestHistoryStatus.PENDING, pageable);
+
 
             // then
             assertThat(result.getTotalElements()).isEqualTo(1);

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/RequestHistoryServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/RequestHistoryServiceTest.java
@@ -234,8 +234,7 @@ class RequestHistoryServiceTest {
             ReflectionTestUtils.setField(requestHistory, "id", 10L);
             ReflectionTestUtils.setField(requestHistory, "name", "홍길동");
 
-            PageRequest pageable =
-                    PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdAt"));
+            PageRequest pageable = PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "createdAt"));
             Page<RequestHistory> page = new PageImpl<>(List.of(requestHistory), pageable, 1);
 
             given(userRepository.findById(100L)).willReturn(Optional.of(admin));
@@ -248,7 +247,6 @@ class RequestHistoryServiceTest {
             Page<AdminRequestHistorySummaryResponseDto> result =
                     requestHistoryService.getAllRequestsForAdmin(
                             100L, RequestHistoryStatus.PENDING, pageable);
-
 
             // then
             assertThat(result.getTotalElements()).isEqualTo(1);


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #288

## 📝작업 내용

- `RequestHistoryQueryRepository` 신규 생성 (QueryDSL)
  - `sort=createdAt,desc` 등 Pageable 정렬 파라미터를 동적으로 처리
  - `createdAt` 요청 → 엔티티 필드 `requestDate` 자동 매핑
  - `innerJoin/fetchJoin`으로 user·department 단건 로드, in-memory paging 없음
  - `PageableExecutionUtils.getPage()`로 count 쿼리 최적화
- `RequestHistoryRepository` — 500 오류를 유발하던 JPQL `@Query` 기반 `findAllWithUserAndDepartmentByStatus` 제거
- `RequestHistoryService` — `RequestHistoryQueryRepository`로 호출 변경
- `RequestHistoryServiceTest` — Mock 대상 교체, `sort=createdAt,desc` Pageable 포함 테스트 보완

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬 리뷰 요구사항
- X