### PR TITLE
fix(291): RequestHistory 정렬 조건 빈 property 스킵 및 status→approvalStatus 매핑 추가

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/repository/RequestHistoryQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/repository/RequestHistoryQueryRepository.java
@@ -65,12 +65,21 @@ public class RequestHistoryQueryRepository {
         List<OrderSpecifier<?>> orders = new ArrayList<>();
 
         for (Sort.Order order : pageable.getSort()) {
-            Order direction = order.isAscending() ? Order.ASC : Order.DESC;
             String property = order.getProperty();
+
+            if (property == null || property.isBlank()) {
+                continue;
+            }
+
+            Order direction = order.isAscending() ? Order.ASC : Order.DESC;
 
             // createdAt은 엔티티 필드명 requestDate에 매핑
             if ("createdAt".equals(property)) {
                 property = "requestDate";
+            }
+            // status는 엔티티 필드명 approvalStatus에 매핑
+            if ("status".equals(property)) {
+                property = "approvalStatus";
             }
 
             PathBuilder<RequestHistory> path =


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #291

## 📝작업 내용

- `RequestHistoryQueryRepository.orderSpecifiers()` 정렬 방어 로직 추가
    - property가 `null` 또는 빈 문자열("")인 경우 해당 정렬 조건 skip → 500 에러 방지
- `status` 파라미터를 엔티티 실제 필드명 `approvalStatus`로 매핑 추가
    - 기존 `createdAt` → `requestDate` 매핑 패턴 동일하게 적용

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
- 프로젝트 내 다른 QueryDSL 목록 조회에서도 유사한 문제 가능성이 있어, 공통 정렬 유틸리티 도입을 향후 고려