### PR TITLE
fix(294): 공지사항 이전글/다음글 방향 반전 및 NoticeType 필터링 추가

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/respository/NoticeQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/respository/NoticeQueryRepository.java
@@ -107,32 +107,7 @@ public class NoticeQueryRepository {
     }
 
     public NoticeDetailDto.NoticeInfo findPrevNotice(
-            Long noticeId, LocalDateTime createdDate, Long userId, boolean hasAccessNotice) {
-        QNotice notice = QNotice.notice;
-        QUser author = QUser.user;
-
-        return queryFactory
-                .select(
-                        Projections.constructor(
-                                NoticeDetailDto.NoticeInfo.class,
-                                notice.id,
-                                notice.title,
-                                displayNameExpr(author),
-                                notice.createdDate))
-                .from(notice)
-                .innerJoin(notice.author, author)
-                .where(
-                        notice.createdDate
-                                .lt(createdDate)
-                                .or(notice.createdDate.eq(createdDate).and(notice.id.lt(noticeId))),
-                        noticeAccessible(hasAccessNotice, userId))
-                .orderBy(notice.createdDate.desc(), notice.id.desc())
-                .limit(1)
-                .fetchOne();
-    }
-
-    public NoticeDetailDto.NoticeInfo findNextNotice(
-            Long noticeId, LocalDateTime createdDate, Long userId, boolean hasAccessNotice) {
+            Long noticeId, LocalDateTime createdDate, NoticeType type, Long userId, boolean hasAccessNotice) {
         QNotice notice = QNotice.notice;
         QUser author = QUser.user;
 
@@ -150,8 +125,35 @@ public class NoticeQueryRepository {
                         notice.createdDate
                                 .gt(createdDate)
                                 .or(notice.createdDate.eq(createdDate).and(notice.id.gt(noticeId))),
+                        notice.type.eq(type),
                         noticeAccessible(hasAccessNotice, userId))
                 .orderBy(notice.createdDate.asc(), notice.id.asc())
+                .limit(1)
+                .fetchOne();
+    }
+
+    public NoticeDetailDto.NoticeInfo findNextNotice(
+            Long noticeId, LocalDateTime createdDate, NoticeType type, Long userId, boolean hasAccessNotice) {
+        QNotice notice = QNotice.notice;
+        QUser author = QUser.user;
+
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                NoticeDetailDto.NoticeInfo.class,
+                                notice.id,
+                                notice.title,
+                                displayNameExpr(author),
+                                notice.createdDate))
+                .from(notice)
+                .innerJoin(notice.author, author)
+                .where(
+                        notice.createdDate
+                                .lt(createdDate)
+                                .or(notice.createdDate.eq(createdDate).and(notice.id.lt(noticeId))),
+                        notice.type.eq(type),
+                        noticeAccessible(hasAccessNotice, userId))
+                .orderBy(notice.createdDate.desc(), notice.id.desc())
                 .limit(1)
                 .fetchOne();
     }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/respository/NoticeQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/respository/NoticeQueryRepository.java
@@ -107,7 +107,11 @@ public class NoticeQueryRepository {
     }
 
     public NoticeDetailDto.NoticeInfo findPrevNotice(
-            Long noticeId, LocalDateTime createdDate, NoticeType type, Long userId, boolean hasAccessNotice) {
+            Long noticeId,
+            LocalDateTime createdDate,
+            NoticeType type,
+            Long userId,
+            boolean hasAccessNotice) {
         QNotice notice = QNotice.notice;
         QUser author = QUser.user;
 
@@ -133,7 +137,11 @@ public class NoticeQueryRepository {
     }
 
     public NoticeDetailDto.NoticeInfo findNextNotice(
-            Long noticeId, LocalDateTime createdDate, NoticeType type, Long userId, boolean hasAccessNotice) {
+            Long noticeId,
+            LocalDateTime createdDate,
+            NoticeType type,
+            Long userId,
+            boolean hasAccessNotice) {
         QNotice notice = QNotice.notice;
         QUser author = QUser.user;
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/service/NoticeService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/service/NoticeService.java
@@ -149,10 +149,18 @@ public class NoticeService {
         NoticeDetailDto dto = noticeMapper.toNoticeDetailDto(notice, s3Service);
         dto.setPrevNotice(
                 noticeQueryRepository.findPrevNotice(
-                        noticeId, notice.getCreatedDate(), notice.getType(), userId, hasAccessNotice));
+                        noticeId,
+                        notice.getCreatedDate(),
+                        notice.getType(),
+                        userId,
+                        hasAccessNotice));
         dto.setNextNotice(
                 noticeQueryRepository.findNextNotice(
-                        noticeId, notice.getCreatedDate(), notice.getType(), userId, hasAccessNotice));
+                        noticeId,
+                        notice.getCreatedDate(),
+                        notice.getType(),
+                        userId,
+                        hasAccessNotice));
 
         return dto;
     }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/service/NoticeService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/service/NoticeService.java
@@ -149,10 +149,10 @@ public class NoticeService {
         NoticeDetailDto dto = noticeMapper.toNoticeDetailDto(notice, s3Service);
         dto.setPrevNotice(
                 noticeQueryRepository.findPrevNotice(
-                        noticeId, notice.getCreatedDate(), userId, hasAccessNotice));
+                        noticeId, notice.getCreatedDate(), notice.getType(), userId, hasAccessNotice));
         dto.setNextNotice(
                 noticeQueryRepository.findNextNotice(
-                        noticeId, notice.getCreatedDate(), userId, hasAccessNotice));
+                        noticeId, notice.getCreatedDate(), notice.getType(), userId, hasAccessNotice));
 
         return dto;
     }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/notice/NoticeServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/notice/NoticeServiceTest.java
@@ -245,9 +245,9 @@ class NoticeServiceTest {
             given(userRepository.findById(1L)).willReturn(Optional.of(adminUser));
             given(noticeMapper.toNoticeDetailDto(any(), any()))
                     .willReturn(NoticeDetailDto.builder().title("상세조회").build());
-            given(noticeQueryRepository.findPrevNotice(any(), any(), any(), anyBoolean()))
+            given(noticeQueryRepository.findPrevNotice(any(), any(), any(), any(), anyBoolean()))
                     .willReturn(null);
-            given(noticeQueryRepository.findNextNotice(any(), any(), any(), anyBoolean()))
+            given(noticeQueryRepository.findNextNotice(any(), any(), any(), any(), anyBoolean()))
                     .willReturn(null);
 
             // when
@@ -276,9 +276,9 @@ class NoticeServiceTest {
                                     .targetDepartmentIds(List.of(10L, 20L))
                                     .targetUserIds(List.of(99L))
                                     .build());
-            given(noticeQueryRepository.findPrevNotice(any(), any(), any(), anyBoolean()))
+            given(noticeQueryRepository.findPrevNotice(any(), any(), any(), any(), anyBoolean()))
                     .willReturn(null);
-            given(noticeQueryRepository.findNextNotice(any(), any(), any(), anyBoolean()))
+            given(noticeQueryRepository.findNextNotice(any(), any(), any(), any(), anyBoolean()))
                     .willReturn(null);
 
             // when
@@ -304,9 +304,9 @@ class NoticeServiceTest {
                                     .title("타입조회")
                                     .type(NoticeType.REGULAR.name())
                                     .build());
-            given(noticeQueryRepository.findPrevNotice(any(), any(), any(), anyBoolean()))
+            given(noticeQueryRepository.findPrevNotice(any(), any(), any(), any(), anyBoolean()))
                     .willReturn(null);
-            given(noticeQueryRepository.findNextNotice(any(), any(), any(), anyBoolean()))
+            given(noticeQueryRepository.findNextNotice(any(), any(), any(), any(), anyBoolean()))
                     .willReturn(null);
 
             // when
@@ -342,9 +342,9 @@ class NoticeServiceTest {
             given(userRepository.findById(1L)).willReturn(Optional.of(adminUser));
             given(noticeMapper.toNoticeDetailDto(any(), any()))
                     .willReturn(NoticeDetailDto.builder().title("이전다음조회").build());
-            given(noticeQueryRepository.findPrevNotice(any(), any(), any(), anyBoolean()))
+            given(noticeQueryRepository.findPrevNotice(any(), any(), any(), any(), anyBoolean()))
                     .willReturn(prevInfo);
-            given(noticeQueryRepository.findNextNotice(any(), any(), any(), anyBoolean()))
+            given(noticeQueryRepository.findNextNotice(any(), any(), any(), any(), anyBoolean()))
                     .willReturn(nextInfo);
 
             // when


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #294

## 📝작업 내용

- NoticeQueryRepository 수정: findPrevNotice / findNextNotice 쿼리 로직 스왑
    - prevNotice → 리스트 기준 이전글(최신 글, gt/asc)
    - nextNotice → 리스트 기준 다음글(과거 글, lt/desc)
- notice.type.eq(type) 조건 추가로 NoticeType 기준 필터링 적용
- NoticeService 수정: getNotice 메서드에서 notice.getType()을 쿼리 메서드에 전달
- NoticeServiceTest 수정: 변경된 파라미터 시그니처에 맞춰 Mock 호출 갱신

## 📸 스크린샷 (선택)

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
- X