### PR TITLE
feat(297): 직원 관리 목록 조회 응답에 입퇴사일 필드 추가

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/dto/response/AdminUserSummaryResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/dto/response/AdminUserSummaryResponseDto.java
@@ -2,6 +2,8 @@ package kr.co.awesomelead.groupware_backend.domain.admin.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.LocalDate;
+
 import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.JobType;
@@ -37,6 +39,12 @@ public class AdminUserSummaryResponseDto {
     @Schema(description = "개인정보 수정 요청 대기 여부", example = "false")
     private boolean hasPendingMyInfoRequest;
 
+    @Schema(description = "입사일", example = "2025-09-22")
+    private LocalDate hireDate;
+
+    @Schema(description = "퇴사일", example = "2025-09-22")
+    private LocalDate resignationDate;
+
     public static AdminUserSummaryResponseDto from(User user, boolean hasPendingMyInfoRequest) {
         return AdminUserSummaryResponseDto.builder()
                 .userId(user.getId())
@@ -47,6 +55,8 @@ public class AdminUserSummaryResponseDto {
                         user.getDepartment() != null ? user.getDepartment().getName() : null)
                 .signupStatus(user.getStatus())
                 .hasPendingMyInfoRequest(hasPendingMyInfoRequest)
+                .hireDate(user.getHireDate())
+                .resignationDate(user.getResignationDate())
                 .build();
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/dto/response/AdminUserSummaryResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/dto/response/AdminUserSummaryResponseDto.java
@@ -2,8 +2,6 @@ package kr.co.awesomelead.groupware_backend.domain.admin.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import java.time.LocalDate;
-
 import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.JobType;
@@ -12,6 +10,8 @@ import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
 
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDate;
 
 @Getter
 @Builder

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
@@ -269,7 +269,14 @@ class AdminServiceTest {
             // given
             Department department =
                     Department.builder().id(1L).name(DepartmentName.MANAGEMENT_SUPPORT).build();
-            User user = User.builder().id(17L).nameKor("고영민").department(department).build();
+            User user =
+                    User.builder()
+                            .id(17L)
+                            .nameKor("고영민")
+                            .department(department)
+                            .hireDate(LocalDate.of(2025, 9, 22))
+                            .resignationDate(LocalDate.of(2026, 3, 31))
+                            .build();
             user.setStatus(Status.AVAILABLE);
 
             Pageable pageable = PageRequest.of(0, 20);
@@ -297,6 +304,10 @@ class AdminServiceTest {
             assertThat(result.getContent().get(0).getUserId()).isEqualTo(17L);
             assertThat(result.getContent().get(0).isHasPendingMyInfoRequest()).isEqualTo(true);
             assertThat(result.getContent().get(0).getSignupStatus()).isEqualTo(Status.AVAILABLE);
+            assertThat(result.getContent().get(0).getHireDate())
+                    .isEqualTo(LocalDate.of(2025, 9, 22));
+            assertThat(result.getContent().get(0).getResignationDate())
+                    .isEqualTo(LocalDate.of(2026, 3, 31));
         }
 
         @Test


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #297

## 📝작업 내용

- `AdminUserSummaryResponseDto`에 `hireDate`, `resignationDate` (LocalDate) 필드 추가
    - `@Schema(description = "입사일"/"퇴사일", example = "2025-09-22")` 적용
- `AdminUserSummaryResponseDto.from()`에서 `User` 엔티티의 입퇴사일 매핑 추가
- `AdminServiceTest` `Describe_getUsers` 픽스처에 입퇴사일 값 설정 및 assertThat 검증 추가

## 📸 스크린샷 (선택)

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)

- X
