### PR TITLE
refactor(300): 결재선 설정 역할별 사용자/부서 타겟 구조 개편 및 부서교육 목록 canSign 반영

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/controller/ApprovalConfigController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/controller/ApprovalConfigController.java
@@ -38,9 +38,10 @@ public class ApprovalConfigController {
     @Operation(
             summary = "결재선 설정 저장",
             description =
-                    "문서 양식(DocumentType)별 기본 결재자/참조자 ID 목록을 저장합니다. 기존 설정이 있으면 덮어씁니다."
-                            + " 응답에는 `documentType`(영문 enum), `documentTypeLabel`(한글) 및 결재자/참조자 상세"
-                            + " 정보가 포함됩니다. `MANAGE_APPROVAL_LINE` 권한이 필요합니다.")
+                    "문서 양식(DocumentType)별 기본 승인자/열람권자/참조자 타겟을 저장합니다."
+                            + " 각 역할은 `targetDepartmentIds`, `targetUserIds`로 구성됩니다."
+                            + " 기존 설정이 있으면 덮어씁니다. 응답에는 타입 코드/라벨 및 타겟 상세 정보가 포함됩니다."
+                            + " `MANAGE_APPROVAL_LINE` 권한이 필요합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",
@@ -61,8 +62,8 @@ public class ApprovalConfigController {
     @Operation(
             summary = "전체 결재선 설정 조회",
             description =
-                    "모든 문서 양식에 대한 기본 결재선 설정을 목록으로 조회합니다. `documentType`은 영문 enum,"
-                            + " `documentTypeLabel`은 한글 라벨로 반환됩니다.")
+                    "모든 문서 양식의 기본 결재선 설정을 목록으로 조회합니다."
+                            + " `documentType`은 영문 enum, `documentTypeLabel`은 한글 라벨로 반환됩니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",
@@ -78,7 +79,7 @@ public class ApprovalConfigController {
             description =
                     "문서 양식(DocumentType)에 해당하는 기본 결재선 설정을 조회합니다."
                             + " 설정이 없는 경우 빈 목록을 반환합니다. 인증된 사용자라면 누구나 조회할 수 있습니다."
-                            + " 응답에는 결재자/참조자 상세 정보가 제공됩니다.")
+                            + " 응답에는 승인자/열람권자/참조자 타겟 상세 정보가 제공됩니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/request/ApprovalConfigSaveRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/request/ApprovalConfigSaveRequestDto.java
@@ -23,9 +23,24 @@ public class ApprovalConfigSaveRequestDto {
     @Schema(description = "문서 양식 타입", example = "BASIC")
     private DocumentType documentType;
 
-    @Schema(description = "결재자 ID 목록 (순서 보장)", example = "[1, 2, 3]")
-    private List<Long> approverIds = new ArrayList<>();
+    @Schema(description = "승인자 타겟(부서/사용자). targetUserIds는 순서를 보장합니다.")
+    private ApprovalTargetRequestDto approvers = new ApprovalTargetRequestDto();
 
-    @Schema(description = "참조자 ID 목록", example = "[4, 5]")
-    private List<Long> referrerIds = new ArrayList<>();
+    @Schema(description = "열람권자 타겟(부서/사용자). 결재 완료 후 열람 가능합니다.")
+    private ApprovalTargetRequestDto viewers = new ApprovalTargetRequestDto();
+
+    @Schema(description = "참조자 타겟(부서/사용자). 결재 진행 전 과정에서 열람 가능합니다.")
+    private ApprovalTargetRequestDto referrers = new ApprovalTargetRequestDto();
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @Schema(description = "결재선 역할별 타겟 요청 DTO")
+    public static class ApprovalTargetRequestDto {
+        @Schema(description = "대상 부서 ID 목록", example = "[1, 2]")
+        private List<Long> targetDepartmentIds = new ArrayList<>();
+
+        @Schema(description = "대상 사용자 ID 목록", example = "[14, 15]")
+        private List<Long> targetUserIds = new ArrayList<>();
+    }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/response/ApprovalConfigResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/response/ApprovalConfigResponseDto.java
@@ -3,6 +3,7 @@ package kr.co.awesomelead.groupware_backend.domain.approval.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalLineConfig;
+import kr.co.awesomelead.groupware_backend.domain.department.entity.Department;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 
 import lombok.AllArgsConstructor;
@@ -28,57 +29,117 @@ public class ApprovalConfigResponseDto {
     @Schema(description = "문서 양식 한글 라벨", example = "기본양식")
     private String documentTypeLabel;
 
-    @Schema(description = "결재자 상세 정보 목록 (순서 보장)")
-    private List<ApprovalLineUserDto> approvers;
+    @Schema(description = "승인자 타겟 설정")
+    private ApprovalTargetResponseDto approvers;
 
-    @Schema(description = "참조자 상세 정보 목록")
-    private List<ApprovalLineUserDto> referrers;
+    @Schema(description = "열람권자 타겟 설정(결재 완료 후 열람 가능)")
+    private ApprovalTargetResponseDto viewers;
+
+    @Schema(description = "참조자 타겟 설정(결재 진행 전 과정에서 열람 가능)")
+    private ApprovalTargetResponseDto referrers;
 
     public static ApprovalConfigResponseDto from(
-            ApprovalLineConfig config, Map<Long, User> usersById) {
-        List<Long> approverIds =
-                config.getApproverIds() == null ? Collections.emptyList() : config.getApproverIds();
-        List<Long> referrerIds =
-                config.getReferrerIds() == null ? Collections.emptyList() : config.getReferrerIds();
-
+            ApprovalLineConfig config, Map<Long, User> usersById, Map<Long, Department> departmentsById) {
         return ApprovalConfigResponseDto.builder()
                 .documentType(config.getDocumentType().name())
                 .documentTypeLabel(config.getDocumentType().getDescription())
-                .approvers(toUserDtos(approverIds, usersById))
-                .referrers(toUserDtos(referrerIds, usersById))
+                .approvers(
+                        toTargetDto(
+                                config.getApproverTargetDepartmentIds(),
+                                config.getApproverTargetUserIds(),
+                                usersById,
+                                departmentsById))
+                .viewers(
+                        toTargetDto(
+                                config.getViewerTargetDepartmentIds(),
+                                config.getViewerTargetUserIds(),
+                                usersById,
+                                departmentsById))
+                .referrers(
+                        toTargetDto(
+                                config.getReferrerTargetDepartmentIds(),
+                                config.getReferrerTargetUserIds(),
+                                usersById,
+                                departmentsById))
                 .build();
     }
 
-    private static List<ApprovalLineUserDto> toUserDtos(List<Long> ids, Map<Long, User> usersById) {
-        return ids.stream()
-                .map(usersById::get)
-                .filter(Objects::nonNull)
-                .map(
-                        user ->
-                                ApprovalLineUserDto.builder()
-                                        .id(user.getId())
-                                        .name(user.getDisplayName())
-                                        .position(
-                                                user.getPosition() == null
-                                                        ? null
-                                                        : user.getPosition().getDescription())
-                                        .departmentName(
-                                                user.getDepartment() == null
-                                                                || user.getDepartment().getName()
-                                                                        == null
-                                                        ? null
-                                                        : user.getDepartment()
-                                                                .getName()
-                                                                .getDescription())
-                                        .build())
-                .toList();
+    private static ApprovalTargetResponseDto toTargetDto(
+            List<Long> departmentIds,
+            List<Long> userIds,
+            Map<Long, User> usersById,
+            Map<Long, Department> departmentsById) {
+        List<Long> safeDepartmentIds =
+                departmentIds == null ? Collections.emptyList() : departmentIds;
+        List<Long> safeUserIds = userIds == null ? Collections.emptyList() : userIds;
+
+        List<ApprovalLineDepartmentDto> departments =
+                safeDepartmentIds.stream()
+                        .map(departmentsById::get)
+                        .filter(Objects::nonNull)
+                        .map(
+                                department ->
+                                        ApprovalLineDepartmentDto.builder()
+                                                .id(department.getId())
+                                                .name(
+                                                        department.getName() == null
+                                                                ? null
+                                                                : department.getName().getDescription())
+                                                .company(
+                                                        department.getCompany() == null
+                                                                ? null
+                                                                : department.getCompany().getDescription())
+                                                .build())
+                        .toList();
+
+        List<ApprovalLineUserDto> users =
+                safeUserIds.stream()
+                        .map(usersById::get)
+                        .filter(Objects::nonNull)
+                        .map(
+                                user ->
+                                        ApprovalLineUserDto.builder()
+                                                .id(user.getId())
+                                                .name(user.getDisplayName())
+                                                .position(
+                                                        user.getPosition() == null
+                                                                ? null
+                                                                : user.getPosition().getDescription())
+                                                .departmentName(
+                                                        user.getDepartment() == null
+                                                                        || user.getDepartment().getName()
+                                                                                == null
+                                                                ? null
+                                                                : user.getDepartment()
+                                                                        .getName()
+                                                                        .getDescription())
+                                                .build())
+                        .toList();
+
+        return ApprovalTargetResponseDto.builder()
+                .targetDepartment(departments)
+                .targetUser(users)
+                .build();
     }
 
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(description = "결재선 유저 상세 정보")
+    @Schema(description = "결재선 역할별 타겟 응답")
+    public static class ApprovalTargetResponseDto {
+        @Schema(description = "대상 부서 상세 목록")
+        private List<ApprovalLineDepartmentDto> targetDepartment;
+
+        @Schema(description = "대상 사용자 상세 목록")
+        private List<ApprovalLineUserDto> targetUser;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "결재선 사용자 상세 정보")
     public static class ApprovalLineUserDto {
         @Schema(description = "사용자 ID", example = "14")
         private Long id;
@@ -91,5 +152,21 @@ public class ApprovalConfigResponseDto {
 
         @Schema(description = "부서명", example = "경영지원부")
         private String departmentName;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "결재선 부서 상세 정보")
+    public static class ApprovalLineDepartmentDto {
+        @Schema(description = "부서 ID", example = "1")
+        private Long id;
+
+        @Schema(description = "부서명", example = "경영지원부")
+        private String name;
+
+        @Schema(description = "회사명", example = "어썸리드")
+        private String company;
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/response/ApprovalConfigResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/response/ApprovalConfigResponseDto.java
@@ -39,7 +39,9 @@ public class ApprovalConfigResponseDto {
     private ApprovalTargetResponseDto referrers;
 
     public static ApprovalConfigResponseDto from(
-            ApprovalLineConfig config, Map<Long, User> usersById, Map<Long, Department> departmentsById) {
+            ApprovalLineConfig config,
+            Map<Long, User> usersById,
+            Map<Long, Department> departmentsById) {
         return ApprovalConfigResponseDto.builder()
                 .documentType(config.getDocumentType().name())
                 .documentTypeLabel(config.getDocumentType().getDescription())
@@ -84,11 +86,15 @@ public class ApprovalConfigResponseDto {
                                                 .name(
                                                         department.getName() == null
                                                                 ? null
-                                                                : department.getName().getDescription())
+                                                                : department
+                                                                        .getName()
+                                                                        .getDescription())
                                                 .company(
                                                         department.getCompany() == null
                                                                 ? null
-                                                                : department.getCompany().getDescription())
+                                                                : department
+                                                                        .getCompany()
+                                                                        .getDescription())
                                                 .build())
                         .toList();
 
@@ -104,10 +110,12 @@ public class ApprovalConfigResponseDto {
                                                 .position(
                                                         user.getPosition() == null
                                                                 ? null
-                                                                : user.getPosition().getDescription())
+                                                                : user.getPosition()
+                                                                        .getDescription())
                                                 .departmentName(
                                                         user.getDepartment() == null
-                                                                        || user.getDepartment().getName()
+                                                                        || user.getDepartment()
+                                                                                        .getName()
                                                                                 == null
                                                                 ? null
                                                                 : user.getDepartment()

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/entity/ApprovalLineConfig.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/entity/ApprovalLineConfig.java
@@ -37,28 +37,85 @@ public class ApprovalLineConfig {
             joinColumns = @JoinColumn(name = "document_type"))
     @OrderColumn(name = "sequence_order")
     @Column(name = "approver_ids")
-    private List<Long> approverIds = new ArrayList<>();
+    private List<Long> approverTargetUserIds = new ArrayList<>();
+
+    @ElementCollection
+    @CollectionTable(
+            name = "approval_config_approver_departments",
+            joinColumns = @JoinColumn(name = "document_type"))
+    @Column(name = "department_ids")
+    private List<Long> approverTargetDepartmentIds = new ArrayList<>();
+
+    @ElementCollection
+    @CollectionTable(
+            name = "approval_config_viewers",
+            joinColumns = @JoinColumn(name = "document_type"))
+    @Column(name = "viewer_ids")
+    private List<Long> viewerTargetUserIds = new ArrayList<>();
+
+    @ElementCollection
+    @CollectionTable(
+            name = "approval_config_viewer_departments",
+            joinColumns = @JoinColumn(name = "document_type"))
+    @Column(name = "department_ids")
+    private List<Long> viewerTargetDepartmentIds = new ArrayList<>();
 
     @ElementCollection
     @CollectionTable(
             name = "approval_config_referrers",
             joinColumns = @JoinColumn(name = "document_type"))
     @Column(name = "referrer_ids")
-    private List<Long> referrerIds = new ArrayList<>();
+    private List<Long> referrerTargetUserIds = new ArrayList<>();
+
+    @ElementCollection
+    @CollectionTable(
+            name = "approval_config_referrer_departments",
+            joinColumns = @JoinColumn(name = "document_type"))
+    @Column(name = "department_ids")
+    private List<Long> referrerTargetDepartmentIds = new ArrayList<>();
 
     public static ApprovalLineConfig of(
-            DocumentType documentType, List<Long> approverIds, List<Long> referrerIds) {
+            DocumentType documentType,
+            List<Long> approverTargetUserIds,
+            List<Long> approverTargetDepartmentIds,
+            List<Long> viewerTargetUserIds,
+            List<Long> viewerTargetDepartmentIds,
+            List<Long> referrerTargetUserIds,
+            List<Long> referrerTargetDepartmentIds) {
         ApprovalLineConfig config = new ApprovalLineConfig();
         config.documentType = documentType;
-        config.approverIds = new ArrayList<>(approverIds);
-        config.referrerIds = new ArrayList<>(referrerIds);
+        config.approverTargetUserIds = new ArrayList<>(approverTargetUserIds);
+        config.approverTargetDepartmentIds = new ArrayList<>(approverTargetDepartmentIds);
+        config.viewerTargetUserIds = new ArrayList<>(viewerTargetUserIds);
+        config.viewerTargetDepartmentIds = new ArrayList<>(viewerTargetDepartmentIds);
+        config.referrerTargetUserIds = new ArrayList<>(referrerTargetUserIds);
+        config.referrerTargetDepartmentIds = new ArrayList<>(referrerTargetDepartmentIds);
         return config;
     }
 
-    public void update(List<Long> approverIds, List<Long> referrerIds) {
-        this.approverIds.clear();
-        this.approverIds.addAll(approverIds);
-        this.referrerIds.clear();
-        this.referrerIds.addAll(referrerIds);
+    public void update(
+            List<Long> approverTargetUserIds,
+            List<Long> approverTargetDepartmentIds,
+            List<Long> viewerTargetUserIds,
+            List<Long> viewerTargetDepartmentIds,
+            List<Long> referrerTargetUserIds,
+            List<Long> referrerTargetDepartmentIds) {
+        this.approverTargetUserIds.clear();
+        this.approverTargetUserIds.addAll(approverTargetUserIds);
+
+        this.approverTargetDepartmentIds.clear();
+        this.approverTargetDepartmentIds.addAll(approverTargetDepartmentIds);
+
+        this.viewerTargetUserIds.clear();
+        this.viewerTargetUserIds.addAll(viewerTargetUserIds);
+
+        this.viewerTargetDepartmentIds.clear();
+        this.viewerTargetDepartmentIds.addAll(viewerTargetDepartmentIds);
+
+        this.referrerTargetUserIds.clear();
+        this.referrerTargetUserIds.addAll(referrerTargetUserIds);
+
+        this.referrerTargetDepartmentIds.clear();
+        this.referrerTargetDepartmentIds.addAll(referrerTargetDepartmentIds);
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalConfigService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalConfigService.java
@@ -93,13 +93,13 @@ public class ApprovalConfigService {
                                         configMap.getOrDefault(
                                                 type,
                                                 ApprovalLineConfig.of(
-                                                type,
-                                                Collections.emptyList(),
-                                                Collections.emptyList(),
-                                                Collections.emptyList(),
-                                                Collections.emptyList(),
-                                                Collections.emptyList(),
-                                                Collections.emptyList())))
+                                                        type,
+                                                        Collections.emptyList(),
+                                                        Collections.emptyList(),
+                                                        Collections.emptyList(),
+                                                        Collections.emptyList(),
+                                                        Collections.emptyList(),
+                                                        Collections.emptyList())))
                         .toList();
 
         Map<Long, User> usersById = loadUsersByIds(resolvedConfigs);

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalConfigService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalConfigService.java
@@ -5,6 +5,8 @@ import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.Approval
 import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalLineConfig;
 import kr.co.awesomelead.groupware_backend.domain.approval.enums.DocumentType;
 import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalLineConfigRepository;
+import kr.co.awesomelead.groupware_backend.domain.department.entity.Department;
+import kr.co.awesomelead.groupware_backend.domain.department.repository.DepartmentRepository;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Authority;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
@@ -32,6 +34,7 @@ public class ApprovalConfigService {
 
     private final ApprovalLineConfigRepository approvalLineConfigRepository;
     private final UserRepository userRepository;
+    private final DepartmentRepository departmentRepository;
 
     @Transactional
     public ApprovalConfigResponseDto saveConfig(ApprovalConfigSaveRequestDto request, Long userId) {
@@ -50,17 +53,28 @@ public class ApprovalConfigService {
         ApprovalLineConfig config;
         if (existing.isPresent()) {
             config = existing.get();
-            config.update(request.getApproverIds(), request.getReferrerIds());
+            config.update(
+                    safeTargetUserIds(request.getApprovers()),
+                    safeTargetDepartmentIds(request.getApprovers()),
+                    safeTargetUserIds(request.getViewers()),
+                    safeTargetDepartmentIds(request.getViewers()),
+                    safeTargetUserIds(request.getReferrers()),
+                    safeTargetDepartmentIds(request.getReferrers()));
         } else {
             config =
                     ApprovalLineConfig.of(
                             request.getDocumentType(),
-                            request.getApproverIds(),
-                            request.getReferrerIds());
+                            safeTargetUserIds(request.getApprovers()),
+                            safeTargetDepartmentIds(request.getApprovers()),
+                            safeTargetUserIds(request.getViewers()),
+                            safeTargetDepartmentIds(request.getViewers()),
+                            safeTargetUserIds(request.getReferrers()),
+                            safeTargetDepartmentIds(request.getReferrers()));
             approvalLineConfigRepository.save(config);
         }
 
-        return ApprovalConfigResponseDto.from(config, loadUsersByIds(config));
+        return ApprovalConfigResponseDto.from(
+                config, loadUsersByIds(config), loadDepartmentsByIds(config));
     }
 
     @Transactional(readOnly = true)
@@ -79,15 +93,20 @@ public class ApprovalConfigService {
                                         configMap.getOrDefault(
                                                 type,
                                                 ApprovalLineConfig.of(
-                                                        type,
-                                                        Collections.emptyList(),
-                                                        Collections.emptyList())))
+                                                type,
+                                                Collections.emptyList(),
+                                                Collections.emptyList(),
+                                                Collections.emptyList(),
+                                                Collections.emptyList(),
+                                                Collections.emptyList(),
+                                                Collections.emptyList())))
                         .toList();
 
         Map<Long, User> usersById = loadUsersByIds(resolvedConfigs);
+        Map<Long, Department> departmentsById = loadDepartmentsByIds(resolvedConfigs);
 
         return resolvedConfigs.stream()
-                .map(config -> ApprovalConfigResponseDto.from(config, usersById))
+                .map(config -> ApprovalConfigResponseDto.from(config, usersById, departmentsById))
                 .toList();
     }
 
@@ -101,15 +120,21 @@ public class ApprovalConfigService {
                                         ApprovalLineConfig.of(
                                                 documentType,
                                                 java.util.Collections.emptyList(),
+                                                java.util.Collections.emptyList(),
+                                                java.util.Collections.emptyList(),
+                                                java.util.Collections.emptyList(),
+                                                java.util.Collections.emptyList(),
                                                 java.util.Collections.emptyList()));
 
-        return ApprovalConfigResponseDto.from(config, loadUsersByIds(config));
+        return ApprovalConfigResponseDto.from(
+                config, loadUsersByIds(config), loadDepartmentsByIds(config));
     }
 
     private Map<Long, User> loadUsersByIds(ApprovalLineConfig config) {
         Set<Long> userIds = new HashSet<>();
-        userIds.addAll(config.getApproverIds());
-        userIds.addAll(config.getReferrerIds());
+        userIds.addAll(config.getApproverTargetUserIds());
+        userIds.addAll(config.getViewerTargetUserIds());
+        userIds.addAll(config.getReferrerTargetUserIds());
 
         return loadUsersByIds(userIds);
     }
@@ -117,8 +142,9 @@ public class ApprovalConfigService {
     private Map<Long, User> loadUsersByIds(List<ApprovalLineConfig> configs) {
         Set<Long> userIds = new HashSet<>();
         for (ApprovalLineConfig config : configs) {
-            userIds.addAll(config.getApproverIds());
-            userIds.addAll(config.getReferrerIds());
+            userIds.addAll(config.getApproverTargetUserIds());
+            userIds.addAll(config.getViewerTargetUserIds());
+            userIds.addAll(config.getReferrerTargetUserIds());
         }
 
         return loadUsersByIds(userIds);
@@ -132,5 +158,50 @@ public class ApprovalConfigService {
 
         return userRepository.findAllById(userIds).stream()
                 .collect(Collectors.toMap(User::getId, Function.identity()));
+    }
+
+    private Map<Long, Department> loadDepartmentsByIds(ApprovalLineConfig config) {
+        Set<Long> departmentIds = new HashSet<>();
+        departmentIds.addAll(config.getApproverTargetDepartmentIds());
+        departmentIds.addAll(config.getViewerTargetDepartmentIds());
+        departmentIds.addAll(config.getReferrerTargetDepartmentIds());
+
+        return loadDepartmentsByIds(departmentIds);
+    }
+
+    private Map<Long, Department> loadDepartmentsByIds(List<ApprovalLineConfig> configs) {
+        Set<Long> departmentIds = new HashSet<>();
+        for (ApprovalLineConfig config : configs) {
+            departmentIds.addAll(config.getApproverTargetDepartmentIds());
+            departmentIds.addAll(config.getViewerTargetDepartmentIds());
+            departmentIds.addAll(config.getReferrerTargetDepartmentIds());
+        }
+
+        return loadDepartmentsByIds(departmentIds);
+    }
+
+    private Map<Long, Department> loadDepartmentsByIds(Set<Long> departmentIds) {
+        if (departmentIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        return departmentRepository.findAllById(departmentIds).stream()
+                .collect(Collectors.toMap(Department::getId, Function.identity()));
+    }
+
+    private List<Long> safeTargetUserIds(
+            ApprovalConfigSaveRequestDto.ApprovalTargetRequestDto targetRequestDto) {
+        if (targetRequestDto == null || targetRequestDto.getTargetUserIds() == null) {
+            return Collections.emptyList();
+        }
+        return targetRequestDto.getTargetUserIds();
+    }
+
+    private List<Long> safeTargetDepartmentIds(
+            ApprovalConfigSaveRequestDto.ApprovalTargetRequestDto targetRequestDto) {
+        if (targetRequestDto == null || targetRequestDto.getTargetDepartmentIds() == null) {
+            return Collections.emptyList();
+        }
+        return targetRequestDto.getTargetDepartmentIds();
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
@@ -460,14 +460,29 @@ public class AuthService {
         // 2) 결재선 설정에서 해당 유저 ID 제거
         List<ApprovalLineConfig> configs = approvalLineConfigRepository.findAll();
         for (ApprovalLineConfig config : configs) {
-            boolean hasApprover = config.getApproverIds().contains(userId);
-            boolean hasReferrer = config.getReferrerIds().contains(userId);
-            if (hasApprover || hasReferrer) {
+            boolean hasApprover = config.getApproverTargetUserIds().contains(userId);
+            boolean hasViewer = config.getViewerTargetUserIds().contains(userId);
+            boolean hasReferrer = config.getReferrerTargetUserIds().contains(userId);
+            if (hasApprover || hasViewer || hasReferrer) {
                 List<Long> newApprovers =
-                        config.getApproverIds().stream().filter(id -> !id.equals(userId)).toList();
+                        config.getApproverTargetUserIds().stream()
+                                .filter(id -> !id.equals(userId))
+                                .toList();
+                List<Long> newViewers =
+                        config.getViewerTargetUserIds().stream()
+                                .filter(id -> !id.equals(userId))
+                                .toList();
                 List<Long> newReferrers =
-                        config.getReferrerIds().stream().filter(id -> !id.equals(userId)).toList();
-                config.update(newApprovers, newReferrers);
+                        config.getReferrerTargetUserIds().stream()
+                                .filter(id -> !id.equals(userId))
+                                .toList();
+                config.update(
+                        newApprovers,
+                        new java.util.ArrayList<>(config.getApproverTargetDepartmentIds()),
+                        newViewers,
+                        new java.util.ArrayList<>(config.getViewerTargetDepartmentIds()),
+                        newReferrers,
+                        new java.util.ArrayList<>(config.getReferrerTargetDepartmentIds()));
             }
         }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
@@ -432,6 +432,7 @@ public class EduReportController {
 
                 - `MANAGE_DEPARTMENT_EDUCATION` 권한 사용자는 `departmentName`으로 전체 부서 대상 필터 조회가 가능합니다.
                 - `MANAGE_DEPARTMENT_EDUCATION` 권한이 없는 사용자는 본인 소속 부서 게시물만 조회됩니다.
+                - `canSign`은 목록 기준 서명 가능 여부이며, `signatureRequired=true` + `OPEN` 상태 + 미서명 + 본인 소속 부서 게시물일 때 `true`입니다.
                 """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -456,6 +457,7 @@ public class EduReportController {
                                   "eduDate": "2026-03-16",
                                   "content": "부서교육 게시글입니다.",
                                   "attendance": false,
+                                  "canSign": true,
                                   "pinned": false,
                                   "signatureRequired": true,
                                   "status": "OPEN",
@@ -540,6 +542,7 @@ public class EduReportController {
                                   "eduDate": "2026-04-14",
                                   "content": "PSM 교육 게시글입니다.",
                                   "attendance": false,
+                                  "canSign": false,
                                   "pinned": false,
                                   "signatureRequired": false,
                                   "status": "OPEN",
@@ -613,6 +616,7 @@ public class EduReportController {
                                   "eduDate": "2026-04-14",
                                   "content": "안전 보건 교육 게시글입니다.",
                                   "attendance": false,
+                                  "canSign": false,
                                   "pinned": false,
                                   "signatureRequired": true,
                                   "status": "OPEN",

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportSummaryDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportSummaryDto.java
@@ -36,6 +36,9 @@ public class EduReportSummaryDto {
     @Schema(description = "출석 여부", example = "true")
     private boolean attendance;
 
+    @Schema(description = "현재 사용자의 서명 가능 여부(목록 기준)", example = "true")
+    private boolean canSign;
+
     @Schema(description = "상단 고정 여부", example = "false")
     private boolean pinned;
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
@@ -61,7 +61,9 @@ public class EduReportQueryRepository {
         BooleanExpression attendanceExists =
                 JPAExpressions.selectOne()
                         .from(eduAttendance)
-                        .where(eduAttendance.eduReport.eq(eduReport), eduAttendance.user.id.eq(userId))
+                        .where(
+                                eduAttendance.eduReport.eq(eduReport),
+                                eduAttendance.user.id.eq(userId))
                         .exists();
         BooleanExpression canSignDepartment =
                 eduReport
@@ -109,7 +111,9 @@ public class EduReportQueryRepository {
         BooleanExpression attendanceExists =
                 JPAExpressions.selectOne()
                         .from(eduAttendance)
-                        .where(eduAttendance.eduReport.eq(eduReport), eduAttendance.user.id.eq(userId))
+                        .where(
+                                eduAttendance.eduReport.eq(eduReport),
+                                eduAttendance.user.id.eq(userId))
                         .exists();
 
         return queryFactory
@@ -143,7 +147,9 @@ public class EduReportQueryRepository {
         BooleanExpression attendanceExists =
                 JPAExpressions.selectOne()
                         .from(eduAttendance)
-                        .where(eduAttendance.eduReport.eq(eduReport), eduAttendance.user.id.eq(userId))
+                        .where(
+                                eduAttendance.eduReport.eq(eduReport),
+                                eduAttendance.user.id.eq(userId))
                         .exists();
 
         return queryFactory

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
@@ -7,6 +7,7 @@ import static kr.co.awesomelead.groupware_backend.domain.education.entity.QEduca
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -16,6 +17,7 @@ import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentNam
 import kr.co.awesomelead.groupware_backend.domain.education.dto.response.EduReportSummaryDto;
 import kr.co.awesomelead.groupware_backend.domain.education.entity.EduReport;
 import kr.co.awesomelead.groupware_backend.domain.education.entity.QEduAttendance;
+import kr.co.awesomelead.groupware_backend.domain.education.enums.EduReportStatus;
 import kr.co.awesomelead.groupware_backend.domain.education.enums.EduType;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.QUser;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
@@ -55,6 +57,24 @@ public class EduReportQueryRepository {
             boolean hasAccess,
             Company psmCompany,
             boolean canReadAllPsmCompanies) {
+        QUser currentUser = new QUser("currentUserForCanSign");
+        BooleanExpression attendanceExists =
+                JPAExpressions.selectOne()
+                        .from(eduAttendance)
+                        .where(eduAttendance.eduReport.eq(eduReport), eduAttendance.user.id.eq(userId))
+                        .exists();
+        BooleanExpression canSignDepartment =
+                eduReport
+                        .eduType
+                        .eq(EduType.DEPARTMENT)
+                        .and(eduReport.signatureRequired.isTrue())
+                        .and(eduReport.status.eq(EduReportStatus.OPEN))
+                        .and(attendanceExists.not())
+                        .and(
+                                eduReport.department.id.eq(
+                                        JPAExpressions.select(currentUser.department.id)
+                                                .from(currentUser)
+                                                .where(currentUser.id.eq(userId))));
 
         return queryFactory
                 .select(
@@ -65,12 +85,8 @@ public class EduReportQueryRepository {
                                 eduReport.eduType,
                                 eduReport.eduDate,
                                 eduReport.content,
-                                JPAExpressions.selectOne()
-                                        .from(eduAttendance)
-                                        .where(
-                                                eduAttendance.eduReport.eq(eduReport),
-                                                eduAttendance.user.id.eq(userId))
-                                        .exists(),
+                                attendanceExists,
+                                canSignDepartment,
                                 eduReport.pinned,
                                 eduReport.signatureRequired,
                                 eduReport.status,
@@ -90,6 +106,11 @@ public class EduReportQueryRepository {
 
     public List<EduReportSummaryDto> findPsmEduReports(
             Long categoryId, Long userId, Company company, boolean canReadAllCompanies) {
+        BooleanExpression attendanceExists =
+                JPAExpressions.selectOne()
+                        .from(eduAttendance)
+                        .where(eduAttendance.eduReport.eq(eduReport), eduAttendance.user.id.eq(userId))
+                        .exists();
 
         return queryFactory
                 .select(
@@ -100,12 +121,8 @@ public class EduReportQueryRepository {
                                 eduReport.eduType,
                                 eduReport.eduDate,
                                 eduReport.content,
-                                JPAExpressions.selectOne()
-                                        .from(eduAttendance)
-                                        .where(
-                                                eduAttendance.eduReport.eq(eduReport),
-                                                eduAttendance.user.id.eq(userId))
-                                        .exists(),
+                                attendanceExists,
+                                Expressions.constant(false),
                                 eduReport.pinned,
                                 eduReport.signatureRequired,
                                 eduReport.status,
@@ -123,6 +140,11 @@ public class EduReportQueryRepository {
 
     public List<EduReportSummaryDto> findSafetyEduReports(
             Long categoryId, Long userId, Company company, boolean canReadAllCompanies) {
+        BooleanExpression attendanceExists =
+                JPAExpressions.selectOne()
+                        .from(eduAttendance)
+                        .where(eduAttendance.eduReport.eq(eduReport), eduAttendance.user.id.eq(userId))
+                        .exists();
 
         return queryFactory
                 .select(
@@ -133,12 +155,8 @@ public class EduReportQueryRepository {
                                 eduReport.eduType,
                                 eduReport.eduDate,
                                 eduReport.content,
-                                JPAExpressions.selectOne()
-                                        .from(eduAttendance)
-                                        .where(
-                                                eduAttendance.eduReport.eq(eduReport),
-                                                eduAttendance.user.id.eq(userId))
-                                        .exists(),
+                                attendanceExists,
+                                Expressions.constant(false),
                                 eduReport.pinned,
                                 eduReport.signatureRequired,
                                 eduReport.status,

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/approval/ApprovalConfigServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/approval/ApprovalConfigServiceTest.java
@@ -14,6 +14,10 @@ import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalLineCo
 import kr.co.awesomelead.groupware_backend.domain.approval.enums.DocumentType;
 import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalLineConfigRepository;
 import kr.co.awesomelead.groupware_backend.domain.approval.service.ApprovalConfigService;
+import kr.co.awesomelead.groupware_backend.domain.department.entity.Department;
+import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
+import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
+import kr.co.awesomelead.groupware_backend.domain.department.repository.DepartmentRepository;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Authority;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
@@ -42,6 +46,8 @@ class ApprovalConfigServiceTest {
 
     @Mock private UserRepository userRepository;
 
+    @Mock private DepartmentRepository departmentRepository;
+
     private static final Long ADMIN_ID = 1L;
 
     private User adminUser;
@@ -56,6 +62,9 @@ class ApprovalConfigServiceTest {
 
         lenient()
                 .when(userRepository.findAllById(org.mockito.ArgumentMatchers.anyIterable()))
+                .thenReturn(List.of());
+        lenient()
+                .when(departmentRepository.findAllById(org.mockito.ArgumentMatchers.anyIterable()))
                 .thenReturn(List.of());
     }
 
@@ -72,52 +81,109 @@ class ApprovalConfigServiceTest {
             void saveConfig_newEntry_savesEntity() {
                 ApprovalConfigSaveRequestDto request = new ApprovalConfigSaveRequestDto();
                 request.setDocumentType(DocumentType.BASIC);
-                request.setApproverIds(List.of(10L, 20L, 30L));
-                request.setReferrerIds(List.of(40L));
+                request.setApprovers(target(List.of(1L), List.of(10L, 20L)));
+                request.setViewers(target(List.of(2L), List.of(30L)));
+                request.setReferrers(target(List.of(), List.of(40L)));
 
                 given(userRepository.findById(ADMIN_ID)).willReturn(Optional.of(adminUser));
                 given(approvalLineConfigRepository.findById(DocumentType.BASIC))
                         .willReturn(Optional.empty());
+
+                Department d1 =
+                        Department.builder()
+                                .id(1L)
+                                .name(DepartmentName.MANAGEMENT_SUPPORT)
+                                .company(Company.AWESOME)
+                                .build();
+                Department d2 =
+                        Department.builder()
+                                .id(2L)
+                                .name(DepartmentName.SALES_DEPT)
+                                .company(Company.MARUI)
+                                .build();
+                given(departmentRepository.findAllById(org.mockito.ArgumentMatchers.anyIterable()))
+                        .willReturn(List.of(d1, d2));
+
+                User u10 = User.builder().id(10L).nameKor("u10").build();
+                User u20 = User.builder().id(20L).nameKor("u20").build();
+                User u30 = User.builder().id(30L).nameKor("u30").build();
+                User u40 = User.builder().id(40L).nameKor("u40").build();
+                given(userRepository.findAllById(org.mockito.ArgumentMatchers.anyIterable()))
+                        .willReturn(List.of(u10, u20, u30, u40));
 
                 ApprovalConfigResponseDto response =
                         approvalConfigService.saveConfig(request, ADMIN_ID);
 
                 verify(approvalLineConfigRepository).save(any(ApprovalLineConfig.class));
                 assertThat(response.getDocumentType()).isEqualTo(DocumentType.BASIC.name());
-                assertThat(response.getApprovers()).isEmpty();
-                assertThat(response.getReferrers()).isEmpty();
+                assertThat(response.getApprovers().getTargetUser())
+                        .extracting(ApprovalConfigResponseDto.ApprovalLineUserDto::getId)
+                        .containsExactly(10L, 20L);
+                assertThat(response.getApprovers().getTargetDepartment())
+                        .extracting(ApprovalConfigResponseDto.ApprovalLineDepartmentDto::getId)
+                        .containsExactly(1L);
+                assertThat(response.getViewers().getTargetUser())
+                        .extracting(ApprovalConfigResponseDto.ApprovalLineUserDto::getId)
+                        .containsExactly(30L);
+                assertThat(response.getViewers().getTargetDepartment())
+                        .extracting(ApprovalConfigResponseDto.ApprovalLineDepartmentDto::getId)
+                        .containsExactly(2L);
+                assertThat(response.getReferrers().getTargetUser())
+                        .extracting(ApprovalConfigResponseDto.ApprovalLineUserDto::getId)
+                        .containsExactly(40L);
             }
 
             @Test
             @DisplayName("기존 설정이 있으면 덮어쓰고 save를 호출하지 않는다")
             void saveConfig_existingEntry_updatesInPlace() {
                 ApprovalLineConfig existing =
-                        ApprovalLineConfig.of(DocumentType.BASIC, List.of(1L, 2L), List.of(3L));
+                        ApprovalLineConfig.of(
+                                DocumentType.BASIC,
+                                List.of(1L, 2L),
+                                List.of(100L),
+                                List.of(3L),
+                                List.of(200L),
+                                List.of(4L),
+                                List.of(300L));
 
                 ApprovalConfigSaveRequestDto request = new ApprovalConfigSaveRequestDto();
                 request.setDocumentType(DocumentType.BASIC);
-                request.setApproverIds(List.of(10L, 20L));
-                request.setReferrerIds(List.of(99L));
+                request.setApprovers(target(List.of(10L), List.of(20L)));
+                request.setViewers(target(List.of(11L), List.of(21L)));
+                request.setReferrers(target(List.of(12L), List.of(22L)));
 
                 given(userRepository.findById(ADMIN_ID)).willReturn(Optional.of(adminUser));
                 given(approvalLineConfigRepository.findById(DocumentType.BASIC))
                         .willReturn(Optional.of(existing));
+                User u20 = User.builder().id(20L).nameKor("u20").build();
+                User u21 = User.builder().id(21L).nameKor("u21").build();
+                User u22 = User.builder().id(22L).nameKor("u22").build();
+                given(userRepository.findAllById(org.mockito.ArgumentMatchers.anyIterable()))
+                        .willReturn(List.of(u20, u21, u22));
 
                 ApprovalConfigResponseDto response =
                         approvalConfigService.saveConfig(request, ADMIN_ID);
 
                 verify(approvalLineConfigRepository, never()).save(any());
-                assertThat(response.getApprovers()).isEmpty();
-                assertThat(response.getReferrers()).isEmpty();
+                assertThat(response.getApprovers().getTargetUser())
+                        .extracting(ApprovalConfigResponseDto.ApprovalLineUserDto::getId)
+                        .containsExactly(20L);
+                assertThat(response.getViewers().getTargetUser())
+                        .extracting(ApprovalConfigResponseDto.ApprovalLineUserDto::getId)
+                        .containsExactly(21L);
+                assertThat(response.getReferrers().getTargetUser())
+                        .extracting(ApprovalConfigResponseDto.ApprovalLineUserDto::getId)
+                        .containsExactly(22L);
             }
 
             @Test
-            @DisplayName("결재자 순서가 정확히 유지된다")
+            @DisplayName("승인자 사용자 순서가 정확히 유지된다")
             void saveConfig_approverOrderIsPreserved() {
                 ApprovalConfigSaveRequestDto request = new ApprovalConfigSaveRequestDto();
                 request.setDocumentType(DocumentType.LEAVE);
-                request.setApproverIds(List.of(5L, 3L, 7L, 1L));
-                request.setReferrerIds(List.of());
+                request.setApprovers(target(List.of(), List.of(5L, 3L, 7L, 1L)));
+                request.setViewers(target(List.of(), List.of()));
+                request.setReferrers(target(List.of(), List.of()));
 
                 given(userRepository.findById(ADMIN_ID)).willReturn(Optional.of(adminUser));
                 given(approvalLineConfigRepository.findById(DocumentType.LEAVE))
@@ -135,7 +201,7 @@ class ApprovalConfigServiceTest {
                 ApprovalConfigResponseDto response =
                         approvalConfigService.saveConfig(request, ADMIN_ID);
 
-                assertThat(response.getApprovers())
+                assertThat(response.getApprovers().getTargetUser())
                         .extracting(ApprovalConfigResponseDto.ApprovalLineUserDto::getId)
                         .containsExactly(5L, 3L, 7L, 1L);
             }
@@ -150,8 +216,9 @@ class ApprovalConfigServiceTest {
             void saveConfig_withoutAuthority_throwsForbidden() {
                 ApprovalConfigSaveRequestDto request = new ApprovalConfigSaveRequestDto();
                 request.setDocumentType(DocumentType.BASIC);
-                request.setApproverIds(List.of(1L));
-                request.setReferrerIds(List.of());
+                request.setApprovers(target(List.of(), List.of(1L)));
+                request.setViewers(target(List.of(), List.of()));
+                request.setReferrers(target(List.of(), List.of()));
 
                 given(userRepository.findById(2L)).willReturn(Optional.of(normalUser));
 
@@ -172,10 +239,17 @@ class ApprovalConfigServiceTest {
     class GetAllConfigs {
 
         @Test
-        @DisplayName("DocumentType 전체 개수만큼 리스트가 반환되고, 설정 없는 타입은 빈 목록이다")
-        void getAllConfigs_성공() {
+        @DisplayName("DocumentType 전체 개수만큼 리스트가 반환되고, 설정 없는 타입은 빈 타겟이다")
+        void getAllConfigs_success() {
             ApprovalLineConfig basicConfig =
-                    ApprovalLineConfig.of(DocumentType.BASIC, List.of(10L, 20L), List.of(30L));
+                    ApprovalLineConfig.of(
+                            DocumentType.BASIC,
+                            List.of(10L, 20L),
+                            List.of(100L),
+                            List.of(30L),
+                            List.of(200L),
+                            List.of(40L),
+                            List.of(300L));
 
             given(approvalLineConfigRepository.findAll()).willReturn(List.of(basicConfig));
             given(userRepository.findAllById(org.mockito.ArgumentMatchers.anyIterable()))
@@ -184,7 +258,31 @@ class ApprovalConfigServiceTest {
                                 User u10 = User.builder().id(10L).nameKor("u10").build();
                                 User u20 = User.builder().id(20L).nameKor("u20").build();
                                 User u30 = User.builder().id(30L).nameKor("u30").build();
-                                return List.of(u10, u20, u30);
+                                User u40 = User.builder().id(40L).nameKor("u40").build();
+                                return List.of(u10, u20, u30, u40);
+                            });
+            given(departmentRepository.findAllById(org.mockito.ArgumentMatchers.anyIterable()))
+                    .willAnswer(
+                            invocation -> {
+                                Department d100 =
+                                        Department.builder()
+                                                .id(100L)
+                                                .name(DepartmentName.MANAGEMENT_SUPPORT)
+                                                .company(Company.AWESOME)
+                                                .build();
+                                Department d200 =
+                                        Department.builder()
+                                                .id(200L)
+                                                .name(DepartmentName.SALES_DEPT)
+                                                .company(Company.MARUI)
+                                                .build();
+                                Department d300 =
+                                        Department.builder()
+                                                .id(300L)
+                                                .name(DepartmentName.AWESOME_PROD_HQ)
+                                                .company(Company.AWESOME)
+                                                .build();
+                                return List.of(d100, d200, d300);
                             });
 
             List<ApprovalConfigResponseDto> result = approvalConfigService.getAllConfigs();
@@ -195,19 +293,32 @@ class ApprovalConfigServiceTest {
                             .filter(r -> DocumentType.BASIC.name().equals(r.getDocumentType()))
                             .findFirst()
                             .orElseThrow();
-            assertThat(basicResult.getApprovers())
+            assertThat(basicResult.getApprovers().getTargetUser())
                     .extracting(ApprovalConfigResponseDto.ApprovalLineUserDto::getId)
                     .containsExactly(10L, 20L);
-            assertThat(basicResult.getReferrers())
+            assertThat(basicResult.getViewers().getTargetUser())
                     .extracting(ApprovalConfigResponseDto.ApprovalLineUserDto::getId)
                     .containsExactly(30L);
+            assertThat(basicResult.getReferrers().getTargetUser())
+                    .extracting(ApprovalConfigResponseDto.ApprovalLineUserDto::getId)
+                    .containsExactly(40L);
+            assertThat(basicResult.getApprovers().getTargetDepartment())
+                    .extracting(ApprovalConfigResponseDto.ApprovalLineDepartmentDto::getId)
+                    .containsExactly(100L);
+            assertThat(basicResult.getViewers().getTargetDepartment())
+                    .extracting(ApprovalConfigResponseDto.ApprovalLineDepartmentDto::getId)
+                    .containsExactly(200L);
+            assertThat(basicResult.getReferrers().getTargetDepartment())
+                    .extracting(ApprovalConfigResponseDto.ApprovalLineDepartmentDto::getId)
+                    .containsExactly(300L);
 
             result.stream()
                     .filter(r -> !DocumentType.BASIC.name().equals(r.getDocumentType()))
                     .forEach(
                             r -> {
-                                assertThat(r.getApprovers()).isEmpty();
-                                assertThat(r.getReferrers()).isEmpty();
+                                assertThat(r.getApprovers().getTargetUser()).isEmpty();
+                                assertThat(r.getViewers().getTargetUser()).isEmpty();
+                                assertThat(r.getReferrers().getTargetUser()).isEmpty();
                             });
         }
     }
@@ -221,7 +332,13 @@ class ApprovalConfigServiceTest {
         void getConfig_existingConfig_returnsStoredValue() {
             ApprovalLineConfig config =
                     ApprovalLineConfig.of(
-                            DocumentType.EXPENSE_DRAFT, List.of(10L, 20L), List.of(30L));
+                            DocumentType.EXPENSE_DRAFT,
+                            List.of(10L, 20L),
+                            List.of(100L),
+                            List.of(30L),
+                            List.of(200L),
+                            List.of(40L),
+                            List.of(300L));
 
             given(approvalLineConfigRepository.findById(DocumentType.EXPENSE_DRAFT))
                     .willReturn(Optional.of(config));
@@ -231,33 +348,81 @@ class ApprovalConfigServiceTest {
                                 User u10 = User.builder().id(10L).nameKor("u10").build();
                                 User u20 = User.builder().id(20L).nameKor("u20").build();
                                 User u30 = User.builder().id(30L).nameKor("u30").build();
-                                return List.of(u10, u20, u30);
+                                User u40 = User.builder().id(40L).nameKor("u40").build();
+                                return List.of(u10, u20, u30, u40);
+                            });
+            given(departmentRepository.findAllById(org.mockito.ArgumentMatchers.anyIterable()))
+                    .willAnswer(
+                            invocation -> {
+                                Department d100 =
+                                        Department.builder()
+                                                .id(100L)
+                                                .name(DepartmentName.MANAGEMENT_SUPPORT)
+                                                .company(Company.AWESOME)
+                                                .build();
+                                Department d200 =
+                                        Department.builder()
+                                                .id(200L)
+                                                .name(DepartmentName.SALES_DEPT)
+                                                .company(Company.MARUI)
+                                                .build();
+                                Department d300 =
+                                        Department.builder()
+                                                .id(300L)
+                                                .name(DepartmentName.AWESOME_PROD_HQ)
+                                                .company(Company.AWESOME)
+                                                .build();
+                                return List.of(d100, d200, d300);
                             });
 
             ApprovalConfigResponseDto response =
                     approvalConfigService.getConfig(DocumentType.EXPENSE_DRAFT);
 
             assertThat(response.getDocumentType()).isEqualTo(DocumentType.EXPENSE_DRAFT.name());
-            assertThat(response.getApprovers())
+            assertThat(response.getApprovers().getTargetUser())
                     .extracting(ApprovalConfigResponseDto.ApprovalLineUserDto::getId)
                     .containsExactly(10L, 20L);
-            assertThat(response.getReferrers())
+            assertThat(response.getViewers().getTargetUser())
                     .extracting(ApprovalConfigResponseDto.ApprovalLineUserDto::getId)
                     .containsExactly(30L);
+            assertThat(response.getReferrers().getTargetUser())
+                    .extracting(ApprovalConfigResponseDto.ApprovalLineUserDto::getId)
+                    .containsExactly(40L);
+            assertThat(response.getApprovers().getTargetDepartment())
+                    .extracting(ApprovalConfigResponseDto.ApprovalLineDepartmentDto::getId)
+                    .containsExactly(100L);
+            assertThat(response.getViewers().getTargetDepartment())
+                    .extracting(ApprovalConfigResponseDto.ApprovalLineDepartmentDto::getId)
+                    .containsExactly(200L);
+            assertThat(response.getReferrers().getTargetDepartment())
+                    .extracting(ApprovalConfigResponseDto.ApprovalLineDepartmentDto::getId)
+                    .containsExactly(300L);
         }
 
         @Test
-        @DisplayName("설정이 없으면 빈 목록을 반환한다")
-        void getConfig_noConfig_returnsEmptyLists() {
+        @DisplayName("설정이 없으면 빈 타겟 목록을 반환한다")
+        void getConfig_noConfig_returnsEmptyTargets() {
             given(approvalLineConfigRepository.findById(DocumentType.CAR_FUEL))
                     .willReturn(Optional.empty());
 
-            ApprovalConfigResponseDto response =
-                    approvalConfigService.getConfig(DocumentType.CAR_FUEL);
+            ApprovalConfigResponseDto response = approvalConfigService.getConfig(DocumentType.CAR_FUEL);
 
             assertThat(response.getDocumentType()).isEqualTo(DocumentType.CAR_FUEL.name());
-            assertThat(response.getApprovers()).isEmpty();
-            assertThat(response.getReferrers()).isEmpty();
+            assertThat(response.getApprovers().getTargetUser()).isEmpty();
+            assertThat(response.getViewers().getTargetUser()).isEmpty();
+            assertThat(response.getReferrers().getTargetUser()).isEmpty();
+            assertThat(response.getApprovers().getTargetDepartment()).isEmpty();
+            assertThat(response.getViewers().getTargetDepartment()).isEmpty();
+            assertThat(response.getReferrers().getTargetDepartment()).isEmpty();
         }
+    }
+
+    private ApprovalConfigSaveRequestDto.ApprovalTargetRequestDto target(
+            List<Long> departmentIds, List<Long> userIds) {
+        ApprovalConfigSaveRequestDto.ApprovalTargetRequestDto dto =
+                new ApprovalConfigSaveRequestDto.ApprovalTargetRequestDto();
+        dto.setTargetDepartmentIds(departmentIds);
+        dto.setTargetUserIds(userIds);
+        return dto;
     }
 }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/approval/ApprovalConfigServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/approval/ApprovalConfigServiceTest.java
@@ -405,7 +405,8 @@ class ApprovalConfigServiceTest {
             given(approvalLineConfigRepository.findById(DocumentType.CAR_FUEL))
                     .willReturn(Optional.empty());
 
-            ApprovalConfigResponseDto response = approvalConfigService.getConfig(DocumentType.CAR_FUEL);
+            ApprovalConfigResponseDto response =
+                    approvalConfigService.getConfig(DocumentType.CAR_FUEL);
 
             assertThat(response.getDocumentType()).isEqualTo(DocumentType.CAR_FUEL.name());
             assertThat(response.getApprovers().getTargetUser()).isEmpty();


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #300 

## 📝작업 내용
- 결재선 설정에 열람권자(viewer) 역할을 추가했습니다.
- 승인자/열람권자/참조자 각각에 대해 사용자/부서 타겟 저장/조회 구조로 개편했습니다.
- ApprovalConfig 요청/응답 DTO 및 서비스/컨트롤러/테스트를 함께 수정했습니다.
- 계정 삭제 시 ApprovalConfig 내 사용자 참조 정리 로직을 보강했습니다.
- 부서교육 목록 조회 응답에 `canSign` 필드를 추가했습니다.
- 교육 타입별 서명 가능 여부 계산 로직을 반영했습니다.

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X