### PR TITLE
fix(303): CORS 허용 목록에 루트 도메인 추가

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/config/CorsConfig.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/config/CorsConfig.java
@@ -18,6 +18,7 @@ public class CorsConfig implements WebMvcConfigurer {
             List.of(
                     "http://localhost:*",
                     "http://127.0.0.1:*",
+                    "https://awesomelead.co.kr",
                     "https://api.awesomelead.co.kr",
                     "https://*.awesomelead.co.kr");
 


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #303

## 📝작업 내용
- `https://*.awesomelead.co.kr` 와일드카드 패턴은 서브도메인만 매칭되며, 루트 도메인 `https://awesomelead.co.kr`은 포함되지 않음
- `CorsConfig`의 `ALLOWED_ORIGIN_PATTERNS`에 `https://awesomelead.co.kr` 명시적으로 추가

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [ ] 테스트를 수행함

## 💬리뷰 요구사항(선택)