### PR TITLE
feat(309): Visit 도메인 페이징 및 복합 인덱스 적용

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/controller/VisitController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/controller/VisitController.java
@@ -27,6 +27,10 @@ import kr.co.awesomelead.groupware_backend.global.common.response.ApiResponse;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -208,9 +212,47 @@ public class VisitController {
 
     @Operation(
             summary = "직원용 내방객 목록 조회",
-            description = "관리 직군이 전체 내방객 목록을 조회합니다. 부서 및 상태별 필터링이 가능합니다.")
+            description = "관리 직군이 전체 내방객 목록을 조회합니다. 부서 및 상태별 필터링과 페이징이 가능합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "조회 성공",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
+                    {
+                      "isSuccess": true,
+                      "code": "COMMON200",
+                      "message": "요청에 성공했습니다.",
+                      "result": {
+                        "content": [
+                          {
+                            "id": 1,
+                            "visitorCompany": "어썸테크",
+                            "visitorName": "홍길동",
+                            "hostDepartmentName": "경영지원부",
+                            "startDate": "2026-07-01",
+                            "endDate": "2026-07-01",
+                            "status": "방문 중"
+                          }
+                        ],
+                        "totalPages": 1,
+                        "totalElements": 1,
+                        "size": 20,
+                        "number": 0
+                      }
+                    }
+                    """))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "권한 없음")
+    })
     @GetMapping("/admin/list")
-    public ResponseEntity<ApiResponse<List<VisitListResponseDto>>> getAdminVisitList(
+    public ResponseEntity<ApiResponse<Page<VisitListResponseDto>>> getAdminVisitList(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "필터링할 부서 ID", example = "10")
                     @RequestParam(name = "departmentId", required = false)
@@ -223,10 +265,11 @@ public class VisitController {
                     LocalDate startDate,
             @Parameter(description = "조회 종료일 (이 날짜 이전 시작되는 방문 포함)", example = "2024-07-05")
                     @RequestParam(name = "endDate", required = false)
-                    LocalDate endDate) {
-        List<VisitListResponseDto> response =
+                    LocalDate endDate,
+            @ParameterObject @PageableDefault(page = 0, size = 20) Pageable pageable) {
+        Page<VisitListResponseDto> response =
                 visitService.getVisitsForAdmin(
-                        userDetails.getId(), departmentId, status, startDate, endDate);
+                        userDetails.getId(), departmentId, status, startDate, endDate, pageable);
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/entity/Visit.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/entity/Visit.java
@@ -13,11 +13,13 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
 
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
@@ -46,6 +48,11 @@ import java.util.List;
 @Setter
 @Getter
 @Entity
+@Table(
+        indexes = {
+            @Index(name = "idx_visit_status_dates", columnList = "status, start_date, end_date"),
+            @Index(name = "idx_visit_phone_hash", columnList = "visitor_name, phone_number_hash")
+        })
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/repository/VisitRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/repository/VisitRepository.java
@@ -5,28 +5,11 @@ import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitCategory;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitStatus;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
 
 public interface VisitRepository extends JpaRepository<Visit, Long> {
-
-    @Query(
-            "SELECT v FROM Visit v "
-                    + "JOIN FETCH v.user u "
-                    + "JOIN FETCH u.department d "
-                    + "WHERE (:departmentId IS NULL OR d.id = :departmentId) "
-                    + "AND (:status IS NULL OR v.status = :status) "
-                    + "AND (:startDate IS NULL OR v.endDate >= :startDate) "
-                    + "AND (:endDate IS NULL OR v.startDate <= :endDate) "
-                    + "ORDER BY v.id DESC")
-    List<Visit> findAllByFilters(
-            @Param("departmentId") Long departmentId,
-            @Param("status") VisitStatus status,
-            @Param("startDate") LocalDate startDate,
-            @Param("endDate") LocalDate endDate);
 
     List<Visit> findByVisitorNameAndPhoneNumberHash(String name, String inputPhoneHash);
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/repository/querydsl/VisitQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/repository/querydsl/VisitQueryRepository.java
@@ -35,8 +35,10 @@ public class VisitQueryRepository {
         List<Visit> content =
                 queryFactory
                         .selectFrom(visit)
-                        .join(visit.user).fetchJoin()
-                        .join(visit.user.department).fetchJoin()
+                        .join(visit.user)
+                        .fetchJoin()
+                        .join(visit.user.department)
+                        .fetchJoin()
                         .where(
                                 departmentIdEq(departmentId),
                                 statusEq(status),

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/repository/querydsl/VisitQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/repository/querydsl/VisitQueryRepository.java
@@ -1,0 +1,83 @@
+package kr.co.awesomelead.groupware_backend.domain.visit.repository.querydsl;
+
+import static kr.co.awesomelead.groupware_backend.domain.visit.entity.QVisit.visit;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import kr.co.awesomelead.groupware_backend.domain.visit.entity.Visit;
+import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitStatus;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class VisitQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Page<Visit> findVisitsForAdmin(
+            Long departmentId,
+            VisitStatus status,
+            LocalDate startDate,
+            LocalDate endDate,
+            Pageable pageable) {
+
+        List<Visit> content =
+                queryFactory
+                        .selectFrom(visit)
+                        .join(visit.user).fetchJoin()
+                        .join(visit.user.department).fetchJoin()
+                        .where(
+                                departmentIdEq(departmentId),
+                                statusEq(status),
+                                endDateGoe(startDate),
+                                startDateLoe(endDate))
+                        .orderBy(visit.id.desc())
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize())
+                        .fetch();
+
+        long total =
+                Optional.ofNullable(
+                                queryFactory
+                                        .select(visit.count())
+                                        .from(visit)
+                                        .join(visit.user)
+                                        .join(visit.user.department)
+                                        .where(
+                                                departmentIdEq(departmentId),
+                                                statusEq(status),
+                                                endDateGoe(startDate),
+                                                startDateLoe(endDate))
+                                        .fetchOne())
+                        .orElse(0L);
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    private BooleanExpression departmentIdEq(Long departmentId) {
+        return departmentId != null ? visit.user.department.id.eq(departmentId) : null;
+    }
+
+    private BooleanExpression statusEq(VisitStatus status) {
+        return status != null ? visit.status.eq(status) : null;
+    }
+
+    private BooleanExpression endDateGoe(LocalDate startDate) {
+        return startDate != null ? visit.endDate.goe(startDate) : null;
+    }
+
+    private BooleanExpression startDateLoe(LocalDate endDate) {
+        return endDate != null ? visit.startDate.loe(endDate) : null;
+    }
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
@@ -22,6 +22,9 @@ import kr.co.awesomelead.groupware_backend.domain.visit.dto.request.VisitSearchR
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.response.MyVisitDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.response.MyVisitListResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.response.VisitListResponseDto;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import kr.co.awesomelead.groupware_backend.domain.visit.entity.Visit;
 import kr.co.awesomelead.groupware_backend.domain.visit.entity.VisitRecord;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.AdditionalPermissionType;
@@ -30,6 +33,7 @@ import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitPurpose;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitStatus;
 import kr.co.awesomelead.groupware_backend.domain.visit.mapper.VisitMapper;
 import kr.co.awesomelead.groupware_backend.domain.visit.repository.VisitRepository;
+import kr.co.awesomelead.groupware_backend.domain.visit.repository.querydsl.VisitQueryRepository;
 import kr.co.awesomelead.groupware_backend.global.error.CustomException;
 import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
 import kr.co.awesomelead.groupware_backend.global.infra.s3.service.S3Service;
@@ -54,6 +58,7 @@ import java.util.Map;
 public class VisitService {
 
     private final VisitRepository visitRepository;
+    private final VisitQueryRepository visitQueryRepository;
     private final UserRepository userRepository;
     private final DepartmentRepository departmentRepository;
     private final VisitMapper visitMapper;
@@ -414,19 +419,18 @@ public class VisitService {
 
     // 직용원 방문 목록 조회
     @Transactional(readOnly = true)
-    public List<VisitListResponseDto> getVisitsForAdmin(
+    public Page<VisitListResponseDto> getVisitsForAdmin(
             Long userId,
             Long departmentId,
             VisitStatus status,
             LocalDate startDate,
-            LocalDate endDate) {
-        // 관리 권한 확인
+            LocalDate endDate,
+            Pageable pageable) {
         validateAdminAuthority(userId);
 
-        List<Visit> visits =
-                visitRepository.findAllByFilters(departmentId, status, startDate, endDate);
-
-        return visitMapper.toVisitListResponseDtos(visits);
+        return visitQueryRepository
+                .findVisitsForAdmin(departmentId, status, startDate, endDate, pageable)
+                .map(visitMapper::toVisitListResponseDto);
     }
 
     // 직원용 방문 상세 조회

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
@@ -22,9 +22,6 @@ import kr.co.awesomelead.groupware_backend.domain.visit.dto.request.VisitSearchR
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.response.MyVisitDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.response.MyVisitListResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.response.VisitListResponseDto;
-
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import kr.co.awesomelead.groupware_backend.domain.visit.entity.Visit;
 import kr.co.awesomelead.groupware_backend.domain.visit.entity.VisitRecord;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.AdditionalPermissionType;
@@ -41,6 +38,8 @@ import kr.co.awesomelead.groupware_backend.global.infra.s3.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
@@ -832,10 +832,12 @@ public class VisitServiceTest {
 
             // when
             Page<VisitListResponseDto> result =
-                    visitService.getVisitsForAdmin(ADMIN_ID, null, null, startDate, endDate, pageable);
+                    visitService.getVisitsForAdmin(
+                            ADMIN_ID, null, null, startDate, endDate, pageable);
 
             // then
-            verify(visitQueryRepository).findVisitsForAdmin(null, null, startDate, endDate, pageable);
+            verify(visitQueryRepository)
+                    .findVisitsForAdmin(null, null, startDate, endDate, pageable);
             assertThat(result.getContent()).isEmpty();
         }
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
@@ -22,6 +22,7 @@ import kr.co.awesomelead.groupware_backend.domain.visit.dto.request.MyVisitUpdat
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.request.OnSiteVisitRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.request.OneDayVisitRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.request.VisitProcessRequestDto;
+import kr.co.awesomelead.groupware_backend.domain.visit.dto.response.VisitListResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.entity.Visit;
 import kr.co.awesomelead.groupware_backend.domain.visit.entity.VisitRecord;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.AdditionalPermissionType;
@@ -30,6 +31,7 @@ import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitPurpose;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitStatus;
 import kr.co.awesomelead.groupware_backend.domain.visit.mapper.VisitMapper;
 import kr.co.awesomelead.groupware_backend.domain.visit.repository.VisitRepository;
+import kr.co.awesomelead.groupware_backend.domain.visit.repository.querydsl.VisitQueryRepository;
 import kr.co.awesomelead.groupware_backend.domain.visit.service.VisitService;
 import kr.co.awesomelead.groupware_backend.global.error.CustomException;
 import kr.co.awesomelead.groupware_backend.global.infra.s3.service.S3Service;
@@ -43,6 +45,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
@@ -52,6 +58,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
@@ -64,6 +71,7 @@ public class VisitServiceTest {
     @InjectMocks private VisitService visitService;
 
     @Mock private VisitRepository visitRepository;
+    @Mock private VisitQueryRepository visitQueryRepository;
     @Mock private UserRepository userRepository;
     @Mock private S3Service s3Service;
     @Mock private PasswordEncoder passwordEncoder;
@@ -804,6 +812,7 @@ public class VisitServiceTest {
     class Describe_getVisitsForAdmin {
 
         private final Long ADMIN_ID = 1L;
+        private final Pageable pageable = PageRequest.of(0, 20);
 
         @BeforeEach
         void setUpAdmin() {
@@ -818,28 +827,30 @@ public class VisitServiceTest {
             // given
             LocalDate startDate = LocalDate.of(2024, 7, 1);
             LocalDate endDate = LocalDate.of(2024, 7, 5);
-            given(visitRepository.findAllByFilters(null, null, startDate, endDate))
-                    .willReturn(new ArrayList<>());
+            given(visitQueryRepository.findVisitsForAdmin(null, null, startDate, endDate, pageable))
+                    .willReturn(new PageImpl<>(List.of()));
 
             // when
-            visitService.getVisitsForAdmin(ADMIN_ID, null, null, startDate, endDate);
+            Page<VisitListResponseDto> result =
+                    visitService.getVisitsForAdmin(ADMIN_ID, null, null, startDate, endDate, pageable);
 
             // then
-            verify(visitRepository).findAllByFilters(null, null, startDate, endDate);
+            verify(visitQueryRepository).findVisitsForAdmin(null, null, startDate, endDate, pageable);
+            assertThat(result.getContent()).isEmpty();
         }
 
         @Test
         @DisplayName("날짜 범위 없이 호출하면 null로 저장소를 호출한다.")
         void it_calls_repository_with_null_dates_when_not_provided() {
             // given
-            given(visitRepository.findAllByFilters(null, null, null, null))
-                    .willReturn(new ArrayList<>());
+            given(visitQueryRepository.findVisitsForAdmin(null, null, null, null, pageable))
+                    .willReturn(new PageImpl<>(List.of()));
 
             // when
-            visitService.getVisitsForAdmin(ADMIN_ID, null, null, null, null);
+            visitService.getVisitsForAdmin(ADMIN_ID, null, null, null, null, pageable);
 
             // then
-            verify(visitRepository).findAllByFilters(null, null, null, null);
+            verify(visitQueryRepository).findVisitsForAdmin(null, null, null, null, pageable);
         }
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #309

## 📝작업 내용

- Visit 엔티티에 복합 인덱스 2개 추가
  - `idx_visit_status_dates` (status, start_date, end_date) — 직원용 목록 조회 최적화
  - `idx_visit_phone_hash` (visitor_name, phone_number_hash) — 내 방문 목록 조회 최적화
- `repository/querydsl/VisitQueryRepository` 신규 생성 (ApprovalQueryRepository 패턴 통일)
  - JPAQueryFactory 기반 데이터·카운트 쿼리 분리, PageImpl 반환
  - 기존 `@Query findAllByFilters` 제거
- `VisitService.getVisitsForAdmin` 반환타입 `List` → `Page`, Pageable 파라미터 추가
- `VisitController.getAdminVisitList`에 `@ParameterObject @PageableDefault(page=0, size=20)` 추가, 반환타입 `Page` 변경
- `@ApiResponses` 페이징 응답 예시 추가 (AdminRequestHistoryController 패턴으로 통일)
- `VisitServiceTest` — getVisitsForAdmin 테스트를 VisitQueryRepository Mock 기반으로 업데이트

## 📸 스크린샷 (선택)

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)

- X
