### PR TITLE
refactor(312): 부서교육/PSM/안전보건 API 응답 확장 및 companyScope 수정 반영

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/EduReportUpdateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/EduReportUpdateRequestDto.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import jakarta.validation.constraints.NotBlank;
 
+import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -37,6 +39,13 @@ public class EduReportUpdateRequestDto {
 
     @Schema(description = "카테고리 ID (PSM/안전보건 수정 시 선택)", example = "2")
     private Long categoryId;
+
+    @Schema(
+            description =
+                    "회사 범위(PSM/안전보건 수정 시 선택)."
+                            + " [AWESOME, MARUI]를 함께 넣으면 공통 게시물로 저장됩니다.",
+            example = "[\"AWESOME\"]")
+    private List<Company> companyScope;
 
     @Schema(description = "삭제할 첨부파일 ID 목록(선택)", example = "[10, 11]")
     private List<Long> deleteAttachmentIds;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/EduReportUpdateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/EduReportUpdateRequestDto.java
@@ -41,9 +41,7 @@ public class EduReportUpdateRequestDto {
     private Long categoryId;
 
     @Schema(
-            description =
-                    "회사 범위(PSM/안전보건 수정 시 선택)."
-                            + " [AWESOME, MARUI]를 함께 넣으면 공통 게시물로 저장됩니다.",
+            description = "회사 범위(PSM/안전보건 수정 시 선택)." + " [AWESOME, MARUI]를 함께 넣으면 공통 게시물로 저장됩니다.",
             example = "[\"AWESOME\"]")
     private List<Company> companyScope;
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportDetailDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportDetailDto.java
@@ -28,6 +28,12 @@ public class EduReportDetailDto {
     @Schema(description = "교육 제목", example = "안전 교육")
     private String title;
 
+    @Schema(description = "작성자 이름", example = "홍길동")
+    private String authorName;
+
+    @Schema(description = "작성일시", example = "2026-04-06T10:15:00")
+    private LocalDateTime createdAt;
+
     @Schema(description = "교육 유형", example = "안전 보건")
     private EduType eduType;
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportDetailDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportDetailDto.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -83,6 +84,12 @@ public class EduReportDetailDto {
     @Schema(description = "출석자 목록 (MANAGE_DEPARTMENT_EDUCATION 권한 없으면 null)")
     private List<AttendeeInfo> attendees;
 
+    @Schema(description = "이전 교육 정보 (없으면 null)")
+    private ReportInfo prevReport;
+
+    @Schema(description = "다음 교육 정보 (없으면 null)")
+    private ReportInfo nextReport;
+
     @Getter
     @Setter
     @Builder
@@ -115,5 +122,26 @@ public class EduReportDetailDto {
                 description = "서명 이미지 URL",
                 example = "https://s3.amazonaws.com/bucket/signature.png")
         private String signatureUrl;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "이전/다음 교육 요약 정보")
+    public static class ReportInfo {
+
+        @Schema(description = "교육 게시물 ID", example = "100")
+        private Long id;
+
+        @Schema(description = "교육 제목", example = "안전 교육")
+        private String title;
+
+        @Schema(description = "작성자 이름", example = "홍길동")
+        private String authorName;
+
+        @Schema(description = "작성일시", example = "2026-04-06T10:15:00")
+        private LocalDateTime createdAt;
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportSummaryDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportSummaryDto.java
@@ -1,14 +1,17 @@
 package kr.co.awesomelead.groupware_backend.domain.education.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+
 import kr.co.awesomelead.groupware_backend.domain.education.enums.EduReportStatus;
 import kr.co.awesomelead.groupware_backend.domain.education.enums.EduType;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 @Setter

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportSummaryDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportSummaryDto.java
@@ -1,16 +1,14 @@
 package kr.co.awesomelead.groupware_backend.domain.education.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import kr.co.awesomelead.groupware_backend.domain.education.enums.EduReportStatus;
 import kr.co.awesomelead.groupware_backend.domain.education.enums.EduType;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-
-import java.time.LocalDate;
 
 @Getter
 @Setter
@@ -53,4 +51,10 @@ public class EduReportSummaryDto {
 
     @Schema(description = "교육 카테고리명", example = "유해위험물질")
     private String categoryName;
+
+    @Schema(description = "작성자", example = "홍길동")
+    private String authorName;
+
+    @Schema(description = "작성일", example = "2026-04-06T10:15:00")
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/entity/EduReport.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/entity/EduReport.java
@@ -20,6 +20,7 @@ import kr.co.awesomelead.groupware_backend.domain.department.entity.Department;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.education.enums.EduReportStatus;
 import kr.co.awesomelead.groupware_backend.domain.education.enums.EduType;
+import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,6 +29,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -89,6 +91,13 @@ public class EduReport {
     @Column(name = "company", length = 20)
     private Company company;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by")
+    private User createdBy;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
     @PrePersist
     protected void prePersist() {
         if (this.eduDate == null) {
@@ -96,6 +105,9 @@ public class EduReport {
         }
         if (this.status == null) {
             this.status = EduReportStatus.OPEN;
+        }
+        if (this.createdAt == null) {
+            this.createdAt = LocalDateTime.now();
         }
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/mapper/EduMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/mapper/EduMapper.java
@@ -23,6 +23,8 @@ public interface EduMapper {
     @Mapping(target = "eduDate", ignore = true)
     @Mapping(target = "status", ignore = true)
     @Mapping(target = "attachments", ignore = true)
+    @Mapping(target = "createdBy", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "department", source = "department")
     @Mapping(target = "category", source = "category")
     EduReport toEduReportEntity(
@@ -60,6 +62,8 @@ public interface EduMapper {
     @Mapping(target = "signedCount", ignore = true)
     @Mapping(target = "unsignedCount", ignore = true)
     @Mapping(target = "canSign", ignore = true)
+    @Mapping(target = "prevReport", ignore = true)
+    @Mapping(target = "nextReport", ignore = true)
     @Mapping(target = "attendees", source = "attendances")
     EduReportDetailDto toDetailDto(
             EduReport report,

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/mapper/EduMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/mapper/EduMapper.java
@@ -41,7 +41,8 @@ public interface EduMapper {
     @Mapping(
             target = "authorName",
             expression =
-                    "java(report.getCreatedBy() != null ? report.getCreatedBy().getDisplayName() : null)")
+                    "java(report.getCreatedBy() != null ? report.getCreatedBy().getDisplayName() :"
+                        + " null)")
     @Mapping(target = "createdAt", source = "report.createdAt")
     @Mapping(target = "eduType", source = "report.eduType")
     @Mapping(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/mapper/EduMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/mapper/EduMapper.java
@@ -38,6 +38,11 @@ public interface EduMapper {
      */
     @Mapping(target = "attendance", ignore = true)
     @Mapping(target = "attachments", source = "report.attachments")
+    @Mapping(
+            target = "authorName",
+            expression =
+                    "java(report.getCreatedBy() != null ? report.getCreatedBy().getDisplayName() : null)")
+    @Mapping(target = "createdAt", source = "report.createdAt")
     @Mapping(target = "eduType", source = "report.eduType")
     @Mapping(
             target = "categoryId",

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
@@ -191,7 +191,8 @@ public class EduReportQueryRepository {
                 .fetch();
     }
 
-    public EduReportDetailDto.ReportInfo findPrevDepartmentReport(Long reportId, Department department) {
+    public EduReportDetailDto.ReportInfo findPrevDepartmentReport(
+            Long reportId, Department department) {
         QUser creatorUser = new QUser("creatorUserForPrevDepartment");
         return queryFactory
                 .select(
@@ -212,7 +213,8 @@ public class EduReportQueryRepository {
                 .fetchOne();
     }
 
-    public EduReportDetailDto.ReportInfo findNextDepartmentReport(Long reportId, Department department) {
+    public EduReportDetailDto.ReportInfo findNextDepartmentReport(
+            Long reportId, Department department) {
         QUser creatorUser = new QUser("creatorUserForNextDepartment");
         return queryFactory
                 .select(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
@@ -14,6 +14,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import kr.co.awesomelead.groupware_backend.domain.department.entity.Department;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
+import kr.co.awesomelead.groupware_backend.domain.education.dto.response.EduReportDetailDto;
 import kr.co.awesomelead.groupware_backend.domain.education.dto.response.EduReportSummaryDto;
 import kr.co.awesomelead.groupware_backend.domain.education.entity.EduReport;
 import kr.co.awesomelead.groupware_backend.domain.education.entity.QEduAttendance;
@@ -190,6 +191,102 @@ public class EduReportQueryRepository {
                 .fetch();
     }
 
+    public EduReportDetailDto.ReportInfo findPrevDepartmentReport(Long reportId, Department department) {
+        QUser creatorUser = new QUser("creatorUserForPrevDepartment");
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                EduReportDetailDto.ReportInfo.class,
+                                eduReport.id,
+                                eduReport.title,
+                                creatorUser.nameKor.coalesce(creatorUser.nameEng),
+                                eduReport.createdAt))
+                .from(eduReport)
+                .leftJoin(eduReport.createdBy, creatorUser)
+                .where(
+                        eduReport.eduType.eq(EduType.DEPARTMENT),
+                        eduReport.id.gt(reportId),
+                        sameDepartmentFilter(department))
+                .orderBy(eduReport.id.asc())
+                .limit(1)
+                .fetchOne();
+    }
+
+    public EduReportDetailDto.ReportInfo findNextDepartmentReport(Long reportId, Department department) {
+        QUser creatorUser = new QUser("creatorUserForNextDepartment");
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                EduReportDetailDto.ReportInfo.class,
+                                eduReport.id,
+                                eduReport.title,
+                                creatorUser.nameKor.coalesce(creatorUser.nameEng),
+                                eduReport.createdAt))
+                .from(eduReport)
+                .leftJoin(eduReport.createdBy, creatorUser)
+                .where(
+                        eduReport.eduType.eq(EduType.DEPARTMENT),
+                        eduReport.id.lt(reportId),
+                        sameDepartmentFilter(department))
+                .orderBy(eduReport.id.desc())
+                .limit(1)
+                .fetchOne();
+    }
+
+    public EduReportDetailDto.ReportInfo findPrevCompanyReportInCategory(
+            Long reportId,
+            EduType type,
+            Long categoryId,
+            Company company,
+            boolean canReadAllCompanies) {
+        QUser creatorUser = new QUser("creatorUserForPrevCompany");
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                EduReportDetailDto.ReportInfo.class,
+                                eduReport.id,
+                                eduReport.title,
+                                creatorUser.nameKor.coalesce(creatorUser.nameEng),
+                                eduReport.createdAt))
+                .from(eduReport)
+                .leftJoin(eduReport.createdBy, creatorUser)
+                .where(
+                        eduReport.eduType.eq(type),
+                        sameCategoryFilter(categoryId),
+                        eduReport.id.gt(reportId),
+                        companyDetailFilter(company, canReadAllCompanies))
+                .orderBy(eduReport.id.asc())
+                .limit(1)
+                .fetchOne();
+    }
+
+    public EduReportDetailDto.ReportInfo findNextCompanyReportInCategory(
+            Long reportId,
+            EduType type,
+            Long categoryId,
+            Company company,
+            boolean canReadAllCompanies) {
+        QUser creatorUser = new QUser("creatorUserForNextCompany");
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                EduReportDetailDto.ReportInfo.class,
+                                eduReport.id,
+                                eduReport.title,
+                                creatorUser.nameKor.coalesce(creatorUser.nameEng),
+                                eduReport.createdAt))
+                .from(eduReport)
+                .leftJoin(eduReport.createdBy, creatorUser)
+                .where(
+                        eduReport.eduType.eq(type),
+                        sameCategoryFilter(categoryId),
+                        eduReport.id.lt(reportId),
+                        companyDetailFilter(company, canReadAllCompanies))
+                .orderBy(eduReport.id.desc())
+                .limit(1)
+                .fetchOne();
+    }
+
     public record SignatureStatusRow(
             String nameKor,
             String nameEng,
@@ -316,5 +413,29 @@ public class EduReportQueryRepository {
                 .ne(EduType.PSM)
                 .or(eduReport.company.eq(psmCompany))
                 .or(eduReport.company.isNull());
+    }
+
+    private BooleanExpression sameDepartmentFilter(Department department) {
+        if (department == null) {
+            return eduReport.id.isNull();
+        }
+        return eduReport.department.eq(department);
+    }
+
+    private BooleanExpression sameCategoryFilter(Long categoryId) {
+        if (categoryId == null) {
+            return eduReport.id.isNull();
+        }
+        return eduReport.category.id.eq(categoryId);
+    }
+
+    private BooleanExpression companyDetailFilter(Company company, boolean canReadAllCompanies) {
+        if (canReadAllCompanies) {
+            return null;
+        }
+        if (company == null) {
+            return eduReport.id.isNull();
+        }
+        return eduReport.company.eq(company).or(eduReport.company.isNull());
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
@@ -58,6 +58,7 @@ public class EduReportQueryRepository {
             Company psmCompany,
             boolean canReadAllPsmCompanies) {
         QUser currentUser = new QUser("currentUserForCanSign");
+        QUser creatorUser = new QUser("creatorUser");
         BooleanExpression attendanceExists =
                 JPAExpressions.selectOne()
                         .from(eduAttendance)
@@ -93,9 +94,12 @@ public class EduReportQueryRepository {
                                 eduReport.signatureRequired,
                                 eduReport.status,
                                 educationCategory.id,
-                                educationCategory.name))
+                                educationCategory.name,
+                                creatorUser.nameKor.coalesce(creatorUser.nameEng),
+                                eduReport.createdAt))
                 .from(eduReport)
                 .leftJoin(eduReport.category, educationCategory)
+                .leftJoin(eduReport.createdBy, creatorUser)
                 .where(
                         eqEduType(type),
                         eqCategoryId(categoryId),
@@ -108,6 +112,7 @@ public class EduReportQueryRepository {
 
     public List<EduReportSummaryDto> findPsmEduReports(
             Long categoryId, Long userId, Company company, boolean canReadAllCompanies) {
+        QUser creatorUser = new QUser("creatorUserForPsm");
         BooleanExpression attendanceExists =
                 JPAExpressions.selectOne()
                         .from(eduAttendance)
@@ -131,9 +136,12 @@ public class EduReportQueryRepository {
                                 eduReport.signatureRequired,
                                 eduReport.status,
                                 educationCategory.id,
-                                educationCategory.name))
+                                educationCategory.name,
+                                creatorUser.nameKor.coalesce(creatorUser.nameEng),
+                                eduReport.createdAt))
                 .from(eduReport)
                 .leftJoin(eduReport.category, educationCategory)
+                .leftJoin(eduReport.createdBy, creatorUser)
                 .where(
                         eduReport.eduType.eq(EduType.PSM),
                         eqCategoryId(categoryId),
@@ -144,6 +152,7 @@ public class EduReportQueryRepository {
 
     public List<EduReportSummaryDto> findSafetyEduReports(
             Long categoryId, Long userId, Company company, boolean canReadAllCompanies) {
+        QUser creatorUser = new QUser("creatorUserForSafety");
         BooleanExpression attendanceExists =
                 JPAExpressions.selectOne()
                         .from(eduAttendance)
@@ -167,9 +176,12 @@ public class EduReportQueryRepository {
                                 eduReport.signatureRequired,
                                 eduReport.status,
                                 educationCategory.id,
-                                educationCategory.name))
+                                educationCategory.name,
+                                creatorUser.nameKor.coalesce(creatorUser.nameEng),
+                                eduReport.createdAt))
                 .from(eduReport)
                 .leftJoin(eduReport.category, educationCategory)
+                .leftJoin(eduReport.createdBy, creatorUser)
                 .where(
                         eduReport.eduType.eq(EduType.SAFETY),
                         eqCategoryId(categoryId),

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -145,6 +145,7 @@ public class EduReportService {
         } else {
             report.setCompany(null);
         }
+        report.setCreatedBy(user);
 
         if (files != null && !files.isEmpty()) {
             for (MultipartFile file : files) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -344,9 +344,11 @@ public class EduReportService {
 
         EduReportDetailDto dto = buildEduReportDetailDto(user, report, hasAccess, true);
         dto.setPrevReport(
-                eduReportQueryRepository.findPrevDepartmentReport(report.getId(), report.getDepartment()));
+                eduReportQueryRepository.findPrevDepartmentReport(
+                        report.getId(), report.getDepartment()));
         dto.setNextReport(
-                eduReportQueryRepository.findNextDepartmentReport(report.getId(), report.getDepartment()));
+                eduReportQueryRepository.findNextDepartmentReport(
+                        report.getId(), report.getDepartment()));
         return dto;
     }
 
@@ -791,7 +793,8 @@ public class EduReportService {
                 }
                 report.setDepartment(null);
                 if (requestDto.getCompanyScope() != null) {
-                    Company companyOverride = resolveCompanyScopeOverride(requestDto.getCompanyScope());
+                    Company companyOverride =
+                            resolveCompanyScopeOverride(requestDto.getCompanyScope());
                     report.setCompany(companyOverride);
                 }
             }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -790,6 +790,10 @@ public class EduReportService {
                     throw new CustomException(ErrorCode.EDUCATION_CATEGORY_REQUIRED);
                 }
                 report.setDepartment(null);
+                if (requestDto.getCompanyScope() != null) {
+                    Company companyOverride = resolveCompanyScopeOverride(requestDto.getCompanyScope());
+                    report.setCompany(companyOverride);
+                }
             }
 
             deleteAttachments(report, requestDto.getDeleteAttachmentIds());

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -342,7 +342,12 @@ public class EduReportService {
             }
         }
 
-        return buildEduReportDetailDto(user, report, hasAccess, true);
+        EduReportDetailDto dto = buildEduReportDetailDto(user, report, hasAccess, true);
+        dto.setPrevReport(
+                eduReportQueryRepository.findPrevDepartmentReport(report.getId(), report.getDepartment()));
+        dto.setNextReport(
+                eduReportQueryRepository.findNextDepartmentReport(report.getId(), report.getDepartment()));
+        return dto;
     }
 
     @Transactional(readOnly = true)
@@ -375,6 +380,21 @@ public class EduReportService {
         boolean hasAccess = user.hasAuthority(Authority.MANAGE_DEPARTMENT_EDUCATION);
         EduReportDetailDto dto = buildEduReportDetailDto(user, report, hasAccess, false);
         dto.setCompanyScope(toCompanyScopeList(report.getCompany()));
+        Long categoryId = report.getCategory() == null ? null : report.getCategory().getId();
+        dto.setPrevReport(
+                eduReportQueryRepository.findPrevCompanyReportInCategory(
+                        report.getId(),
+                        EduType.PSM,
+                        categoryId,
+                        user.getWorkLocation(),
+                        canReadAllCompanies));
+        dto.setNextReport(
+                eduReportQueryRepository.findNextCompanyReportInCategory(
+                        report.getId(),
+                        EduType.PSM,
+                        categoryId,
+                        user.getWorkLocation(),
+                        canReadAllCompanies));
         return dto;
     }
 
@@ -408,6 +428,21 @@ public class EduReportService {
         boolean hasAccess = user.hasAuthority(Authority.MANAGE_DEPARTMENT_EDUCATION);
         EduReportDetailDto dto = buildEduReportDetailDto(user, report, hasAccess, false);
         dto.setCompanyScope(toCompanyScopeList(report.getCompany()));
+        Long categoryId = report.getCategory() == null ? null : report.getCategory().getId();
+        dto.setPrevReport(
+                eduReportQueryRepository.findPrevCompanyReportInCategory(
+                        report.getId(),
+                        EduType.SAFETY,
+                        categoryId,
+                        user.getWorkLocation(),
+                        canReadAllCompanies));
+        dto.setNextReport(
+                eduReportQueryRepository.findNextCompanyReportInCategory(
+                        report.getId(),
+                        EduType.SAFETY,
+                        categoryId,
+                        user.getWorkLocation(),
+                        canReadAllCompanies));
         return dto;
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingSessionDetailResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingSessionDetailResponseDto.java
@@ -95,4 +95,28 @@ public class SafetyTrainingSessionDetailResponseDto {
 
     @Schema(description = "내가 서명 가능한지 여부", example = "true")
     private boolean canSign;
+
+    @Schema(description = "이전 교육일지 정보 (없으면 null)")
+    private SessionInfo prevSession;
+
+    @Schema(description = "다음 교육일지 정보 (없으면 null)")
+    private SessionInfo nextSession;
+
+    @Getter
+    @Builder
+    @Schema(description = "이전/다음 교육일지 요약 정보")
+    public static class SessionInfo {
+
+        @Schema(description = "교육일지 ID", example = "11")
+        private Long sessionId;
+
+        @Schema(description = "교육 제목", example = "2026년 1분기 정기 안전보건교육")
+        private String title;
+
+        @Schema(description = "작성자", example = "홍길동")
+        private String authorName;
+
+        @Schema(description = "작성일시", example = "2026-04-06T10:15:00")
+        private LocalDateTime createdAt;
+    }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingSessionDetailResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingSessionDetailResponseDto.java
@@ -27,6 +27,12 @@ public class SafetyTrainingSessionDetailResponseDto {
     @Schema(description = "교육 제목", example = "2026년 1분기 정기 안전보건교육")
     private String title;
 
+    @Schema(description = "작성자", example = "홍길동")
+    private String authorName;
+
+    @Schema(description = "작성일시", example = "2026-04-06T10:15:00")
+    private LocalDateTime createdAt;
+
     @Schema(description = "교육 구분", example = "REGULAR")
     private SafetyEducationType educationType;
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingSessionSummaryResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingSessionSummaryResponseDto.java
@@ -58,6 +58,9 @@ public class SafetyTrainingSessionSummaryResponseDto {
     @Schema(description = "현재 로그인 사용자의 서명 완료 여부 (대표이사/마스터 관리자/타회사 교육일지는 null)", example = "true")
     private Boolean mySigned;
 
+    @Schema(description = "작성자", example = "고영민")
+    private String authorName;
+
     @Schema(description = "생성 시각", example = "2026-03-24T11:00:00")
     private LocalDateTime createdAt;
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/repository/SafetyTrainingSessionRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/repository/SafetyTrainingSessionRepository.java
@@ -11,6 +11,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 public interface SafetyTrainingSessionRepository
         extends JpaRepository<SafetyTrainingSession, Long> {
 
@@ -31,4 +33,14 @@ public interface SafetyTrainingSessionRepository
             @Param("startAtFrom") java.time.LocalDateTime startAtFrom,
             @Param("startAtTo") java.time.LocalDateTime startAtTo,
             Pageable pageable);
+
+    Optional<SafetyTrainingSession> findFirstByIdGreaterThanOrderByIdAsc(Long sessionId);
+
+    Optional<SafetyTrainingSession> findFirstByIdLessThanOrderByIdDesc(Long sessionId);
+
+    Optional<SafetyTrainingSession> findFirstByCompanyScopeAndIdGreaterThanOrderByIdAsc(
+            Company companyScope, Long sessionId);
+
+    Optional<SafetyTrainingSession> findFirstByCompanyScopeAndIdLessThanOrderByIdDesc(
+            Company companyScope, Long sessionId);
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
@@ -914,6 +914,10 @@ public class SafetyTrainingSessionService {
                 .attendedCount(session.getAttendedCount())
                 .absentCount(session.getAbsentCount())
                 .mySigned(mySigned)
+                .authorName(
+                        session.getCreatedBy() == null
+                                ? null
+                                : session.getCreatedBy().getDisplayName())
                 .createdAt(session.getCreatedAt())
                 .build();
     }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
@@ -258,6 +258,11 @@ public class SafetyTrainingSessionService {
         return SafetyTrainingSessionDetailResponseDto.builder()
                 .sessionId(session.getId())
                 .title(session.getTitle())
+                .authorName(
+                        session.getCreatedBy() == null
+                                ? null
+                                : session.getCreatedBy().getDisplayName())
+                .createdAt(session.getCreatedAt())
                 .educationType(session.getEducationType())
                 .educationMethods(toMethods(session.getEducationMethodsJson()))
                 .startAt(session.getStartAt())

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
@@ -944,16 +944,15 @@ public class SafetyTrainingSessionService {
         return findNeighborSession(actor, current, false).orElse(null);
     }
 
-    private java.util.Optional<SafetyTrainingSessionDetailResponseDto.SessionInfo> findNeighborSession(
-            User actor, SafetyTrainingSession current, boolean previous) {
+    private java.util.Optional<SafetyTrainingSessionDetailResponseDto.SessionInfo>
+            findNeighborSession(User actor, SafetyTrainingSession current, boolean previous) {
         java.util.Optional<SafetyTrainingSession> neighbor;
         if (actor.hasAuthority(Authority.MANAGE_SAFETY)) {
             neighbor =
                     previous
                             ? sessionRepository.findFirstByIdGreaterThanOrderByIdAsc(
                                     current.getId())
-                            : sessionRepository.findFirstByIdLessThanOrderByIdDesc(
-                                    current.getId());
+                            : sessionRepository.findFirstByIdLessThanOrderByIdDesc(current.getId());
         } else {
             Company company = actor.getWorkLocation();
             if (company == null) {
@@ -961,12 +960,10 @@ public class SafetyTrainingSessionService {
             }
             neighbor =
                     previous
-                            ? sessionRepository
-                                    .findFirstByCompanyScopeAndIdGreaterThanOrderByIdAsc(
-                                            company, current.getId())
-                            : sessionRepository
-                                    .findFirstByCompanyScopeAndIdLessThanOrderByIdDesc(
-                                            company, current.getId());
+                            ? sessionRepository.findFirstByCompanyScopeAndIdGreaterThanOrderByIdAsc(
+                                    company, current.getId())
+                            : sessionRepository.findFirstByCompanyScopeAndIdLessThanOrderByIdDesc(
+                                    company, current.getId());
         }
 
         return neighbor.map(this::toSessionInfo);

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
@@ -250,6 +250,11 @@ public class SafetyTrainingSessionService {
                                 session.getReportFileKey(),
                                 buildExportFileName(session.getStartAt(), session.getTitle()));
 
+        SafetyTrainingSessionDetailResponseDto.SessionInfo prevSession =
+                findPrevSessionInfo(actor, session);
+        SafetyTrainingSessionDetailResponseDto.SessionInfo nextSession =
+                findNextSessionInfo(actor, session);
+
         return SafetyTrainingSessionDetailResponseDto.builder()
                 .sessionId(session.getId())
                 .title(session.getTitle())
@@ -293,6 +298,8 @@ public class SafetyTrainingSessionService {
                                 ? null
                                 : s3Service.getPresignedViewUrl(attendee.getSignatureKey()))
                 .canSign(canSignSession(actor, session, myStatus))
+                .prevSession(prevSession)
+                .nextSession(nextSession)
                 .build();
     }
 
@@ -914,6 +921,57 @@ public class SafetyTrainingSessionService {
                 .attendedCount(session.getAttendedCount())
                 .absentCount(session.getAbsentCount())
                 .mySigned(mySigned)
+                .authorName(
+                        session.getCreatedBy() == null
+                                ? null
+                                : session.getCreatedBy().getDisplayName())
+                .createdAt(session.getCreatedAt())
+                .build();
+    }
+
+    private SafetyTrainingSessionDetailResponseDto.SessionInfo findPrevSessionInfo(
+            User actor, SafetyTrainingSession current) {
+        return findNeighborSession(actor, current, true).orElse(null);
+    }
+
+    private SafetyTrainingSessionDetailResponseDto.SessionInfo findNextSessionInfo(
+            User actor, SafetyTrainingSession current) {
+        return findNeighborSession(actor, current, false).orElse(null);
+    }
+
+    private java.util.Optional<SafetyTrainingSessionDetailResponseDto.SessionInfo> findNeighborSession(
+            User actor, SafetyTrainingSession current, boolean previous) {
+        java.util.Optional<SafetyTrainingSession> neighbor;
+        if (actor.hasAuthority(Authority.MANAGE_SAFETY)) {
+            neighbor =
+                    previous
+                            ? sessionRepository.findFirstByIdGreaterThanOrderByIdAsc(
+                                    current.getId())
+                            : sessionRepository.findFirstByIdLessThanOrderByIdDesc(
+                                    current.getId());
+        } else {
+            Company company = actor.getWorkLocation();
+            if (company == null) {
+                return java.util.Optional.empty();
+            }
+            neighbor =
+                    previous
+                            ? sessionRepository
+                                    .findFirstByCompanyScopeAndIdGreaterThanOrderByIdAsc(
+                                            company, current.getId())
+                            : sessionRepository
+                                    .findFirstByCompanyScopeAndIdLessThanOrderByIdDesc(
+                                            company, current.getId());
+        }
+
+        return neighbor.map(this::toSessionInfo);
+    }
+
+    private SafetyTrainingSessionDetailResponseDto.SessionInfo toSessionInfo(
+            SafetyTrainingSession session) {
+        return SafetyTrainingSessionDetailResponseDto.SessionInfo.builder()
+                .sessionId(session.getId())
+                .title(session.getTitle())
                 .authorName(
                         session.getCreatedBy() == null
                                 ? null


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #312 

## 📝작업 내용
- 부서교육/PSM/안전보건 목록 조회 응답에 authorName, createdAt 추가
- 부서교육/PSM/안전보건 상세 조회 응답에 authorName, createdAt 추가
- 부서교육/PSM/안전보건 상세 조회에 이전/다음 글(prev/next) 정보 추가
- PATCH /api/educations/psm/{educationId} 및 안전보건 수정 시 companyScope 반영되도록 수정하고 500 오류 해결

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
상세 조회 prev/next 필터 기준 확인 부탁드립니다.
(부서교육: 같은 부서, PSM/안전보건: 같은 카테고리 기준)