### PR TITLE
feat(315): 직원 목록·교육 목록 응답 필드 추가 및 QueryDSL 동적 필터 적용

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportSummaryDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportSummaryDto.java
@@ -2,6 +2,7 @@ package kr.co.awesomelead.groupware_backend.domain.education.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
 import kr.co.awesomelead.groupware_backend.domain.education.enums.EduReportStatus;
 import kr.co.awesomelead.groupware_backend.domain.education.enums.EduType;
 
@@ -60,4 +61,7 @@ public class EduReportSummaryDto {
 
     @Schema(description = "작성일", example = "2026-04-06T10:15:00")
     private LocalDateTime createdAt;
+
+    @Schema(description = "교육 부서명", example = "경영지원부")
+    private DepartmentName departmentName;
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/mapper/EduMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/mapper/EduMapper.java
@@ -42,7 +42,7 @@ public interface EduMapper {
             target = "authorName",
             expression =
                     "java(report.getCreatedBy() != null ? report.getCreatedBy().getDisplayName() :"
-                        + " null)")
+                            + " null)")
     @Mapping(target = "createdAt", source = "report.createdAt")
     @Mapping(target = "eduType", source = "report.eduType")
     @Mapping(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
@@ -12,6 +12,7 @@ import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import kr.co.awesomelead.groupware_backend.domain.department.entity.Department;
+import kr.co.awesomelead.groupware_backend.domain.department.entity.QDepartment;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
 import kr.co.awesomelead.groupware_backend.domain.education.dto.response.EduReportDetailDto;
@@ -97,8 +98,10 @@ public class EduReportQueryRepository {
                                 educationCategory.id,
                                 educationCategory.name,
                                 creatorUser.nameKor.coalesce(creatorUser.nameEng),
-                                eduReport.createdAt))
+                                eduReport.createdAt,
+                                QDepartment.department.name))
                 .from(eduReport)
+                .leftJoin(eduReport.department, QDepartment.department)
                 .leftJoin(eduReport.category, educationCategory)
                 .leftJoin(eduReport.createdBy, creatorUser)
                 .where(
@@ -139,8 +142,10 @@ public class EduReportQueryRepository {
                                 educationCategory.id,
                                 educationCategory.name,
                                 creatorUser.nameKor.coalesce(creatorUser.nameEng),
-                                eduReport.createdAt))
+                                eduReport.createdAt,
+                                QDepartment.department.name))
                 .from(eduReport)
+                .leftJoin(eduReport.department, QDepartment.department)
                 .leftJoin(eduReport.category, educationCategory)
                 .leftJoin(eduReport.createdBy, creatorUser)
                 .where(
@@ -179,8 +184,10 @@ public class EduReportQueryRepository {
                                 educationCategory.id,
                                 educationCategory.name,
                                 creatorUser.nameKor.coalesce(creatorUser.nameEng),
-                                eduReport.createdAt))
+                                eduReport.createdAt,
+                                QDepartment.department.name))
                 .from(eduReport)
+                .leftJoin(eduReport.department, QDepartment.department)
                 .leftJoin(eduReport.category, educationCategory)
                 .leftJoin(eduReport.createdBy, creatorUser)
                 .where(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/controller/UserController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/controller/UserController.java
@@ -13,6 +13,9 @@ import kr.co.awesomelead.groupware_backend.domain.user.dto.response.MyInfoRespon
 import kr.co.awesomelead.groupware_backend.domain.user.dto.response.UpdateMyInfoRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.user.dto.response.UserDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.user.dto.response.UserSummaryResponseDto;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.JobType;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
 import kr.co.awesomelead.groupware_backend.domain.user.service.UserService;
 import kr.co.awesomelead.groupware_backend.global.common.response.ApiResponse;
 
@@ -116,12 +119,26 @@ public class UserController {
     public ResponseEntity<ApiResponse<Page<UserSummaryResponseDto>>> getEmployeeList(
             @RequestParam(required = false)
                     @io.swagger.v3.oas.annotations.Parameter(
-                            description = "직원 이름 검색어 (N-gram Full-Text Search, 미입력 시 전체 조회)",
+                            description = "검색어 (이름/영문이름/이메일 부분 일치)",
                             example = "김")
                     String keyword,
-            @PageableDefault(size = 20, sort = "id") Pageable pageable) {
+            @RequestParam(required = false)
+                    @io.swagger.v3.oas.annotations.Parameter(description = "직급 필터")
+                    Position position,
+            @RequestParam(required = false)
+                    @io.swagger.v3.oas.annotations.Parameter(description = "부서 ID 필터")
+                    Long departmentId,
+            @RequestParam(required = false)
+                    @io.swagger.v3.oas.annotations.Parameter(description = "근무 직종 필터")
+                    JobType jobType,
+            @RequestParam(required = false)
+                    @io.swagger.v3.oas.annotations.Parameter(description = "역할 필터")
+                    Role role,
+            @PageableDefault(size = 20) Pageable pageable) {
         return ResponseEntity.ok(
-                ApiResponse.onSuccess(userService.getEmployeeList(keyword, pageable)));
+                ApiResponse.onSuccess(
+                        userService.getEmployeeList(
+                                keyword, position, departmentId, jobType, role, pageable)));
     }
 
     @Operation(summary = "직원 상세 조회", description = "특정 직원의 상세 정보를 조회합니다. 인증 토큰이 필요합니다.")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/dto/response/UserSummaryResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/dto/response/UserSummaryResponseDto.java
@@ -4,10 +4,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.JobType;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
 
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDate;
 
 @Getter
 @Builder
@@ -26,6 +29,15 @@ public class UserSummaryResponseDto {
     @Schema(description = "부서명", example = "경영지원부")
     private DepartmentName departmentName;
 
+    @Schema(description = "근무 직종", example = "MANAGEMENT")
+    private JobType jobType;
+
+    @Schema(description = "입사일", example = "2022-03-01")
+    private LocalDate hireDate;
+
+    @Schema(description = "퇴사일", example = "2025-12-31")
+    private LocalDate resignationDate;
+
     public static UserSummaryResponseDto from(User user) {
         return UserSummaryResponseDto.builder()
                 .userId(user.getId())
@@ -33,6 +45,9 @@ public class UserSummaryResponseDto {
                 .position(user.getPosition())
                 .departmentName(
                         user.getDepartment() != null ? user.getDepartment().getName() : null)
+                .jobType(user.getJobType())
+                .hireDate(user.getHireDate())
+                .resignationDate(user.getResignationDate())
                 .build();
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/UserRepository.java
@@ -118,5 +118,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
             @Param("jobType") JobType jobType,
             @Param("role") Role role,
             Pageable pageable);
-
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/UserRepository.java
@@ -118,4 +118,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
             @Param("jobType") JobType jobType,
             @Param("role") Role role,
             Pageable pageable);
+
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/querydsl/UserQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/querydsl/UserQueryRepository.java
@@ -1,0 +1,100 @@
+package kr.co.awesomelead.groupware_backend.domain.user.repository.querydsl;
+
+import static kr.co.awesomelead.groupware_backend.domain.user.entity.QUser.user;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import kr.co.awesomelead.groupware_backend.domain.department.entity.QDepartment;
+import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.JobType;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class UserQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Page<User> findAllAvailableWithFilters(
+            String keyword,
+            Position position,
+            Long departmentId,
+            JobType jobType,
+            Role role,
+            Pageable pageable) {
+
+        List<User> content =
+                queryFactory
+                        .selectFrom(user)
+                        .leftJoin(user.department, QDepartment.department)
+                        .fetchJoin()
+                        .where(
+                                user.status.eq(Status.AVAILABLE),
+                                keywordFilter(keyword),
+                                positionFilter(position),
+                                departmentFilter(departmentId),
+                                jobTypeFilter(jobType),
+                                roleFilter(role))
+                        .orderBy(user.id.desc())
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize())
+                        .fetch();
+
+        return PageableExecutionUtils.getPage(
+                content,
+                pageable,
+                () ->
+                        queryFactory
+                                .select(user.count())
+                                .from(user)
+                                .where(
+                                        user.status.eq(Status.AVAILABLE),
+                                        keywordFilter(keyword),
+                                        positionFilter(position),
+                                        departmentFilter(departmentId),
+                                        jobTypeFilter(jobType),
+                                        roleFilter(role))
+                                .fetchOne());
+    }
+
+    private BooleanExpression keywordFilter(String keyword) {
+        if (!StringUtils.hasText(keyword)) {
+            return null;
+        }
+        String pattern = "%" + keyword.toLowerCase() + "%";
+        return user.nameKor
+                .lower()
+                .like(pattern)
+                .or(user.nameEng.lower().like(pattern))
+                .or(user.email.lower().like(pattern));
+    }
+
+    private BooleanExpression positionFilter(Position position) {
+        return position != null ? user.position.eq(position) : null;
+    }
+
+    private BooleanExpression departmentFilter(Long departmentId) {
+        return departmentId != null ? user.department.id.eq(departmentId) : null;
+    }
+
+    private BooleanExpression jobTypeFilter(JobType jobType) {
+        return jobType != null ? user.jobType.eq(jobType) : null;
+    }
+
+    private BooleanExpression roleFilter(Role role) {
+        return role != null ? user.role.eq(role) : null;
+    }
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserService.java
@@ -14,7 +14,6 @@ import kr.co.awesomelead.groupware_backend.domain.user.enums.JobType;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.MyInfoUpdateRequestStatus;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
-import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.MyInfoUpdateRequestRepository;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.querydsl.UserQueryRepository;
@@ -194,7 +193,8 @@ public class UserService {
             Pageable pageable) {
         Pageable unsorted = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
         return userQueryRepository
-                .findAllAvailableWithFilters(keyword, position, departmentId, jobType, role, unsorted)
+                .findAllAvailableWithFilters(
+                        keyword, position, departmentId, jobType, role, unsorted)
                 .map(UserSummaryResponseDto::from);
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserService.java
@@ -10,10 +10,14 @@ import kr.co.awesomelead.groupware_backend.domain.user.dto.response.UserDetailRe
 import kr.co.awesomelead.groupware_backend.domain.user.dto.response.UserSummaryResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.MyInfoUpdateRequest;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.JobType;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.MyInfoUpdateRequestStatus;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.MyInfoUpdateRequestRepository;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
+import kr.co.awesomelead.groupware_backend.domain.user.repository.querydsl.UserQueryRepository;
 import kr.co.awesomelead.groupware_backend.global.error.CustomException;
 import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
 
@@ -35,6 +39,7 @@ import java.util.Map;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final UserQueryRepository userQueryRepository;
     private final MyInfoUpdateRequestRepository myInfoUpdateRequestRepository;
     private final PhoneAuthService phoneAuthService;
     private final NotificationService notificationService;
@@ -180,15 +185,16 @@ public class UserService {
 
     // 전 직원 목록 조회 (AVAILABLE 상태)
     @Transactional(readOnly = true)
-    public Page<UserSummaryResponseDto> getEmployeeList(String keyword, Pageable pageable) {
-        if (keyword != null && !keyword.isBlank()) {
-            Pageable unsorted = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
-            return userRepository
-                    .searchByNameKorFullText(keyword, unsorted)
-                    .map(UserSummaryResponseDto::from);
-        }
-        return userRepository
-                .findAllByStatusWithDepartment(Status.AVAILABLE, pageable)
+    public Page<UserSummaryResponseDto> getEmployeeList(
+            String keyword,
+            Position position,
+            Long departmentId,
+            JobType jobType,
+            Role role,
+            Pageable pageable) {
+        Pageable unsorted = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
+        return userQueryRepository
+                .findAllAvailableWithFilters(keyword, position, departmentId, jobType, role, unsorted)
                 .map(UserSummaryResponseDto::from);
     }
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserServiceTest.java
@@ -438,8 +438,9 @@ class UserServiceTest {
                             .build();
             Page<User> userPage = new PageImpl<>(List.of(user1, user2), pageable, 2);
 
-            given(userQueryRepository.findAllAvailableWithFilters(
-                            null, null, null, null, null, unsorted))
+            given(
+                            userQueryRepository.findAllAvailableWithFilters(
+                                    null, null, null, null, null, unsorted))
                     .willReturn(userPage);
 
             // when
@@ -469,8 +470,9 @@ class UserServiceTest {
             Pageable unsorted = PageRequest.of(0, 20);
             Page<User> emptyPage = new PageImpl<>(List.of(), pageable, 0);
 
-            given(userQueryRepository.findAllAvailableWithFilters(
-                            null, null, null, null, null, unsorted))
+            given(
+                            userQueryRepository.findAllAvailableWithFilters(
+                                    null, null, null, null, null, unsorted))
                     .willReturn(emptyPage);
 
             // when
@@ -491,8 +493,9 @@ class UserServiceTest {
             User user = createTestUser();
             Page<User> userPage = new PageImpl<>(List.of(user), pageable, 3);
 
-            given(userQueryRepository.findAllAvailableWithFilters(
-                            null, null, null, null, null, unsorted))
+            given(
+                            userQueryRepository.findAllAvailableWithFilters(
+                                    null, null, null, null, null, unsorted))
                     .willReturn(userPage);
 
             // when
@@ -515,8 +518,9 @@ class UserServiceTest {
             User user = createTestUser();
             Page<User> userPage = new PageImpl<>(List.of(user), pageable, 1);
 
-            given(userQueryRepository.findAllAvailableWithFilters(
-                            "김철", null, null, null, null, unsorted))
+            given(
+                            userQueryRepository.findAllAvailableWithFilters(
+                                    "김철", null, null, null, null, unsorted))
                     .willReturn(userPage);
 
             // when
@@ -540,8 +544,9 @@ class UserServiceTest {
             User user = createTestUser();
             Page<User> userPage = new PageImpl<>(List.of(user), pageable, 1);
 
-            given(userQueryRepository.findAllAvailableWithFilters(
-                            null, null, null, JobType.MANAGEMENT, null, unsorted))
+            given(
+                            userQueryRepository.findAllAvailableWithFilters(
+                                    null, null, null, JobType.MANAGEMENT, null, unsorted))
                     .willReturn(userPage);
 
             // when

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserServiceTest.java
@@ -26,6 +26,7 @@ import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.MyInfoUpdateRequestRepository;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
+import kr.co.awesomelead.groupware_backend.domain.user.repository.querydsl.UserQueryRepository;
 import kr.co.awesomelead.groupware_backend.global.error.CustomException;
 import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
 
@@ -53,6 +54,7 @@ import java.util.Optional;
 class UserServiceTest {
 
     @Mock private UserRepository userRepository;
+    @Mock private UserQueryRepository userQueryRepository;
     @Mock private PhoneAuthService phoneAuthService;
     @Mock private MyInfoUpdateRequestRepository myInfoUpdateRequestRepository;
     @Mock private UserDetails userDetails;
@@ -420,10 +422,11 @@ class UserServiceTest {
     class GetEmployeeListTest {
 
         @Test
-        @DisplayName("성공: keyword 없으면 AVAILABLE 상태 직원 목록을 페이징으로 반환한다")
+        @DisplayName("성공: 필터 없이 AVAILABLE 상태 직원 목록을 페이징으로 반환한다")
         void getEmployeeList_success() {
             // given
             Pageable pageable = PageRequest.of(0, 20);
+            Pageable unsorted = PageRequest.of(0, 20);
             User user1 = createTestUser();
             User user2 =
                     User.builder()
@@ -435,11 +438,13 @@ class UserServiceTest {
                             .build();
             Page<User> userPage = new PageImpl<>(List.of(user1, user2), pageable, 2);
 
-            given(userRepository.findAllByStatusWithDepartment(Status.AVAILABLE, pageable))
+            given(userQueryRepository.findAllAvailableWithFilters(
+                            null, null, null, null, null, unsorted))
                     .willReturn(userPage);
 
             // when
-            Page<UserSummaryResponseDto> result = userService.getEmployeeList(null, pageable);
+            Page<UserSummaryResponseDto> result =
+                    userService.getEmployeeList(null, null, null, null, null, pageable);
 
             // then
             assertThat(result.getTotalElements()).isEqualTo(2);
@@ -452,8 +457,8 @@ class UserServiceTest {
             assertThat(result.getContent().get(1).getUserId()).isEqualTo(2L);
             assertThat(result.getContent().get(1).getName()).isEqualTo("이영희");
 
-            verify(userRepository).findAllByStatusWithDepartment(Status.AVAILABLE, pageable);
-            verify(userRepository, never()).searchByNameKorFullText(any(), any());
+            verify(userQueryRepository)
+                    .findAllAvailableWithFilters(null, null, null, null, null, unsorted);
         }
 
         @Test
@@ -461,34 +466,38 @@ class UserServiceTest {
         void getEmployeeList_empty() {
             // given
             Pageable pageable = PageRequest.of(0, 20);
+            Pageable unsorted = PageRequest.of(0, 20);
             Page<User> emptyPage = new PageImpl<>(List.of(), pageable, 0);
 
-            given(userRepository.findAllByStatusWithDepartment(Status.AVAILABLE, pageable))
+            given(userQueryRepository.findAllAvailableWithFilters(
+                            null, null, null, null, null, unsorted))
                     .willReturn(emptyPage);
 
             // when
-            Page<UserSummaryResponseDto> result = userService.getEmployeeList(null, pageable);
+            Page<UserSummaryResponseDto> result =
+                    userService.getEmployeeList(null, null, null, null, null, pageable);
 
             // then
             assertThat(result.getTotalElements()).isEqualTo(0);
             assertThat(result.getContent()).isEmpty();
-
-            verify(userRepository).findAllByStatusWithDepartment(Status.AVAILABLE, pageable);
         }
 
         @Test
         @DisplayName("성공: 페이지네이션이 정상적으로 동작한다")
         void getEmployeeList_pagination() {
             // given
-            Pageable pageable = PageRequest.of(1, 1); // 2번째 페이지, 1개씩
+            Pageable pageable = PageRequest.of(1, 1);
+            Pageable unsorted = PageRequest.of(1, 1);
             User user = createTestUser();
-            Page<User> userPage = new PageImpl<>(List.of(user), pageable, 3); // 전체 3명 중 2번째 페이지
+            Page<User> userPage = new PageImpl<>(List.of(user), pageable, 3);
 
-            given(userRepository.findAllByStatusWithDepartment(Status.AVAILABLE, pageable))
+            given(userQueryRepository.findAllAvailableWithFilters(
+                            null, null, null, null, null, unsorted))
                     .willReturn(userPage);
 
             // when
-            Page<UserSummaryResponseDto> result = userService.getEmployeeList(null, pageable);
+            Page<UserSummaryResponseDto> result =
+                    userService.getEmployeeList(null, null, null, null, null, pageable);
 
             // then
             assertThat(result.getTotalElements()).isEqualTo(3);
@@ -498,44 +507,55 @@ class UserServiceTest {
         }
 
         @Test
-        @DisplayName("성공: keyword가 있으면 Full-Text Search를 사용한다")
-        void getEmployeeList_withKeyword_usesFullTextSearch() {
+        @DisplayName("성공: keyword가 있으면 필터 쿼리에 keyword를 전달한다")
+        void getEmployeeList_withKeyword() {
             // given
             Pageable pageable = PageRequest.of(0, 20);
+            Pageable unsorted = PageRequest.of(0, 20);
             User user = createTestUser();
             Page<User> userPage = new PageImpl<>(List.of(user), pageable, 1);
 
-            given(userRepository.searchByNameKorFullText("김철", pageable)).willReturn(userPage);
+            given(userQueryRepository.findAllAvailableWithFilters(
+                            "김철", null, null, null, null, unsorted))
+                    .willReturn(userPage);
 
             // when
-            Page<UserSummaryResponseDto> result = userService.getEmployeeList("김철", pageable);
+            Page<UserSummaryResponseDto> result =
+                    userService.getEmployeeList("김철", null, null, null, null, pageable);
 
             // then
             assertThat(result.getTotalElements()).isEqualTo(1);
             assertThat(result.getContent().get(0).getName()).isEqualTo(TEST_NAME_KOR);
 
-            verify(userRepository).searchByNameKorFullText("김철", pageable);
-            verify(userRepository, never()).findAllByStatusWithDepartment(any(), any());
+            verify(userQueryRepository)
+                    .findAllAvailableWithFilters("김철", null, null, null, null, unsorted);
         }
 
         @Test
-        @DisplayName("성공: keyword가 공백 문자열이면 전체 목록을 조회한다")
-        void getEmployeeList_withBlankKeyword_usesDefaultQuery() {
+        @DisplayName("성공: jobType 필터를 전달하면 필터 쿼리에 반영된다")
+        void getEmployeeList_withJobTypeFilter() {
             // given
             Pageable pageable = PageRequest.of(0, 20);
-            Page<User> userPage = new PageImpl<>(List.of(createTestUser()), pageable, 1);
+            Pageable unsorted = PageRequest.of(0, 20);
+            User user = createTestUser();
+            Page<User> userPage = new PageImpl<>(List.of(user), pageable, 1);
 
-            given(userRepository.findAllByStatusWithDepartment(Status.AVAILABLE, pageable))
+            given(userQueryRepository.findAllAvailableWithFilters(
+                            null, null, null, JobType.MANAGEMENT, null, unsorted))
                     .willReturn(userPage);
 
             // when
-            Page<UserSummaryResponseDto> result = userService.getEmployeeList("   ", pageable);
+            Page<UserSummaryResponseDto> result =
+                    userService.getEmployeeList(
+                            null, null, null, JobType.MANAGEMENT, null, pageable);
 
             // then
             assertThat(result.getTotalElements()).isEqualTo(1);
+            assertThat(result.getContent().get(0).getJobType()).isEqualTo(JobType.MANAGEMENT);
 
-            verify(userRepository).findAllByStatusWithDepartment(Status.AVAILABLE, pageable);
-            verify(userRepository, never()).searchByNameKorFullText(any(), any());
+            verify(userQueryRepository)
+                    .findAllAvailableWithFilters(
+                            null, null, null, JobType.MANAGEMENT, null, unsorted);
         }
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #315

## 📝작업 내용

- `UserSummaryResponseDto`에 `jobType`, `hireDate`, `resignationDate` 필드 추가
- `EduReportSummaryDto`에 `departmentName` 필드 추가
    - `EduReportQueryRepository` 3개 메서드에 `department` LEFT JOIN 및 Projection 매핑 반영
- `UserQueryRepository` 신규 생성 (QueryDSL)
    - `status = AVAILABLE` 고정 조건 + `keyword` / `position` / `departmentId` / `jobType` / `role` 동적 필터
    - `PageableExecutionUtils`로 count 쿼리 최적화
- `UserRepository`의 `@Query` 기반 `findAllAvailableWithDepartmentAndFilters` 제거
- `UserController.getEmployeeList`에 필터 파라미터 추가, 기본 정렬 조건(`sort=id`) 제거

## 📸 스크린샷 (선택)

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)

- X