### PR TITLE
feat(318): 교육 목록 조회 API에 제목 기반 FULLTEXT 검색 기능 추가

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
@@ -503,9 +503,12 @@ public class EduReportController {
             @Parameter(description = "부서명 필터(권한 사용자 전용)", example = "SALES_DEPT")
                     @RequestParam(required = false)
                     DepartmentName departmentName,
+            @Parameter(description = "제목 검색 키워드 (FULLTEXT 검색)", example = "안전교육")
+                    @RequestParam(required = false)
+                    String title,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         List<EduReportSummaryDto> reports =
-                eduReportService.getDepartmentEduReports(departmentName, userDetails.getId());
+                eduReportService.getDepartmentEduReports(departmentName, userDetails.getId(), title);
         return ResponseEntity.ok(ApiResponse.onSuccess(reports));
     }
 
@@ -577,9 +580,12 @@ public class EduReportController {
             @Parameter(description = "카테고리 ID 필터(PSM)", example = "1")
                     @RequestParam(required = false)
                     Long categoryId,
+            @Parameter(description = "제목 검색 키워드 (FULLTEXT 검색)", example = "변경관리")
+                    @RequestParam(required = false)
+                    String title,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         List<EduReportSummaryDto> reports =
-                eduReportService.getPsmEduReports(categoryId, userDetails.getId());
+                eduReportService.getPsmEduReports(categoryId, userDetails.getId(), title);
         return ResponseEntity.ok(ApiResponse.onSuccess(reports));
     }
 
@@ -651,9 +657,12 @@ public class EduReportController {
             @Parameter(description = "카테고리 ID 필터(안전 보건)", example = "1")
                     @RequestParam(required = false)
                     Long categoryId,
+            @Parameter(description = "제목 검색 키워드 (FULLTEXT 검색)", example = "정기교육")
+                    @RequestParam(required = false)
+                    String title,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         List<EduReportSummaryDto> reports =
-                eduReportService.getSafetyEduReports(categoryId, userDetails.getId());
+                eduReportService.getSafetyEduReports(categoryId, userDetails.getId(), title);
         return ResponseEntity.ok(ApiResponse.onSuccess(reports));
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
@@ -508,7 +508,8 @@ public class EduReportController {
                     String title,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         List<EduReportSummaryDto> reports =
-                eduReportService.getDepartmentEduReports(departmentName, userDetails.getId(), title);
+                eduReportService.getDepartmentEduReports(
+                        departmentName, userDetails.getId(), title);
         return ResponseEntity.ok(ApiResponse.onSuccess(reports));
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
@@ -48,7 +48,7 @@ public class EduReportQueryRepository {
      */
     public List<EduReportSummaryDto> findEduReports(
             EduType type, Department dept, Long categoryId, Long userId, boolean hasAccess) {
-        return findEduReports(type, dept, categoryId, userId, hasAccess, null, true);
+        return findEduReports(type, dept, categoryId, userId, hasAccess, null, true, null);
     }
 
     public List<EduReportSummaryDto> findEduReports(
@@ -59,6 +59,18 @@ public class EduReportQueryRepository {
             boolean hasAccess,
             Company psmCompany,
             boolean canReadAllPsmCompanies) {
+        return findEduReports(type, dept, categoryId, userId, hasAccess, psmCompany, canReadAllPsmCompanies, null);
+    }
+
+    public List<EduReportSummaryDto> findEduReports(
+            EduType type,
+            Department dept,
+            Long categoryId,
+            Long userId,
+            boolean hasAccess,
+            Company psmCompany,
+            boolean canReadAllPsmCompanies,
+            String title) {
         QUser currentUser = new QUser("currentUserForCanSign");
         QUser creatorUser = new QUser("creatorUser");
         BooleanExpression attendanceExists =
@@ -108,7 +120,8 @@ public class EduReportQueryRepository {
                         eqEduType(type),
                         eqCategoryId(categoryId),
                         deptFilter(type, hasAccess, dept),
-                        psmFilter(psmCompany, canReadAllPsmCompanies))
+                        psmFilter(psmCompany, canReadAllPsmCompanies),
+                        titleFilter(title))
                 // 같은 eduDate(일자) 내에서는 최신 생성건이 위로 오도록 id DESC를 타이브레이커로 사용
                 .orderBy(eduReport.pinned.desc(), eduReport.eduDate.desc(), eduReport.id.desc())
                 .fetch();
@@ -116,6 +129,11 @@ public class EduReportQueryRepository {
 
     public List<EduReportSummaryDto> findPsmEduReports(
             Long categoryId, Long userId, Company company, boolean canReadAllCompanies) {
+        return findPsmEduReports(categoryId, userId, company, canReadAllCompanies, null);
+    }
+
+    public List<EduReportSummaryDto> findPsmEduReports(
+            Long categoryId, Long userId, Company company, boolean canReadAllCompanies, String title) {
         QUser creatorUser = new QUser("creatorUserForPsm");
         BooleanExpression attendanceExists =
                 JPAExpressions.selectOne()
@@ -151,13 +169,19 @@ public class EduReportQueryRepository {
                 .where(
                         eduReport.eduType.eq(EduType.PSM),
                         eqCategoryId(categoryId),
-                        psmCompanyFilter(company, canReadAllCompanies))
+                        psmCompanyFilter(company, canReadAllCompanies),
+                        titleFilter(title))
                 .orderBy(eduReport.pinned.desc(), eduReport.eduDate.desc(), eduReport.id.desc())
                 .fetch();
     }
 
     public List<EduReportSummaryDto> findSafetyEduReports(
             Long categoryId, Long userId, Company company, boolean canReadAllCompanies) {
+        return findSafetyEduReports(categoryId, userId, company, canReadAllCompanies, null);
+    }
+
+    public List<EduReportSummaryDto> findSafetyEduReports(
+            Long categoryId, Long userId, Company company, boolean canReadAllCompanies, String title) {
         QUser creatorUser = new QUser("creatorUserForSafety");
         BooleanExpression attendanceExists =
                 JPAExpressions.selectOne()
@@ -193,7 +217,8 @@ public class EduReportQueryRepository {
                 .where(
                         eduReport.eduType.eq(EduType.SAFETY),
                         eqCategoryId(categoryId),
-                        psmCompanyFilter(company, canReadAllCompanies))
+                        psmCompanyFilter(company, canReadAllCompanies),
+                        titleFilter(title))
                 .orderBy(eduReport.pinned.desc(), eduReport.eduDate.desc(), eduReport.id.desc())
                 .fetch();
     }
@@ -361,6 +386,14 @@ public class EduReportQueryRepository {
     }
 
     // ── BooleanExpression 모듈 ──────────────────────────────────────
+
+    private BooleanExpression titleFilter(String title) {
+        if (!StringUtils.hasText(title)) {
+            return null;
+        }
+        return Expressions.numberTemplate(Double.class,
+                "function('match_against', {0}, {1})", eduReport.title, Expressions.constant(title)).gt(0);
+    }
 
     /** 교육 유형 필터 — null 이면 조건 없음 (전체) */
     private BooleanExpression eqEduType(EduType type) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
@@ -59,7 +59,15 @@ public class EduReportQueryRepository {
             boolean hasAccess,
             Company psmCompany,
             boolean canReadAllPsmCompanies) {
-        return findEduReports(type, dept, categoryId, userId, hasAccess, psmCompany, canReadAllPsmCompanies, null);
+        return findEduReports(
+                type,
+                dept,
+                categoryId,
+                userId,
+                hasAccess,
+                psmCompany,
+                canReadAllPsmCompanies,
+                null);
     }
 
     public List<EduReportSummaryDto> findEduReports(
@@ -133,7 +141,11 @@ public class EduReportQueryRepository {
     }
 
     public List<EduReportSummaryDto> findPsmEduReports(
-            Long categoryId, Long userId, Company company, boolean canReadAllCompanies, String title) {
+            Long categoryId,
+            Long userId,
+            Company company,
+            boolean canReadAllCompanies,
+            String title) {
         QUser creatorUser = new QUser("creatorUserForPsm");
         BooleanExpression attendanceExists =
                 JPAExpressions.selectOne()
@@ -181,7 +193,11 @@ public class EduReportQueryRepository {
     }
 
     public List<EduReportSummaryDto> findSafetyEduReports(
-            Long categoryId, Long userId, Company company, boolean canReadAllCompanies, String title) {
+            Long categoryId,
+            Long userId,
+            Company company,
+            boolean canReadAllCompanies,
+            String title) {
         QUser creatorUser = new QUser("creatorUserForSafety");
         BooleanExpression attendanceExists =
                 JPAExpressions.selectOne()
@@ -391,8 +407,12 @@ public class EduReportQueryRepository {
         if (!StringUtils.hasText(title)) {
             return null;
         }
-        return Expressions.numberTemplate(Double.class,
-                "function('match_against', {0}, {1})", eduReport.title, Expressions.constant(title)).gt(0);
+        return Expressions.numberTemplate(
+                        Double.class,
+                        "function('match_against', {0}, {1})",
+                        eduReport.title,
+                        Expressions.constant(title))
+                .gt(0);
     }
 
     /** 교육 유형 필터 — null 이면 조건 없음 (전체) */

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -236,7 +236,7 @@ public class EduReportService {
 
     @Transactional(readOnly = true)
     public List<EduReportSummaryDto> getEduReports(
-            EduType type, DepartmentName departmentName, Long categoryId, Long id) {
+            EduType type, DepartmentName departmentName, Long categoryId, Long id, String title) {
 
         User user =
                 userRepository
@@ -265,17 +265,17 @@ public class EduReportService {
         }
 
         return eduReportQueryRepository.findEduReports(
-                type, dept, categoryId, id, hasAccess, psmCompanyFilter, canReadAllPsmCompanies);
+                type, dept, categoryId, id, hasAccess, psmCompanyFilter, canReadAllPsmCompanies, title);
     }
 
     @Transactional(readOnly = true)
     public List<EduReportSummaryDto> getDepartmentEduReports(
-            DepartmentName departmentName, Long id) {
-        return getEduReports(EduType.DEPARTMENT, departmentName, null, id);
+            DepartmentName departmentName, Long id, String title) {
+        return getEduReports(EduType.DEPARTMENT, departmentName, null, id, title);
     }
 
     @Transactional(readOnly = true)
-    public List<EduReportSummaryDto> getPsmEduReports(Long categoryId, Long id) {
+    public List<EduReportSummaryDto> getPsmEduReports(Long categoryId, Long id, String title) {
         User user =
                 userRepository
                         .findById(id)
@@ -284,11 +284,11 @@ public class EduReportService {
         boolean canReadAllCompanies = user.hasAuthority(Authority.MANAGE_PSM);
         Company companyFilter = canReadAllCompanies ? null : user.getWorkLocation();
         return eduReportQueryRepository.findPsmEduReports(
-                categoryId, id, companyFilter, canReadAllCompanies);
+                categoryId, id, companyFilter, canReadAllCompanies, title);
     }
 
     @Transactional(readOnly = true)
-    public List<EduReportSummaryDto> getSafetyEduReports(Long categoryId, Long id) {
+    public List<EduReportSummaryDto> getSafetyEduReports(Long categoryId, Long id, String title) {
         User user =
                 userRepository
                         .findById(id)
@@ -297,7 +297,7 @@ public class EduReportService {
         boolean canReadAllCompanies = user.hasAuthority(Authority.MANAGE_SAFETY);
         Company companyFilter = canReadAllCompanies ? null : user.getWorkLocation();
         return eduReportQueryRepository.findSafetyEduReports(
-                categoryId, id, companyFilter, canReadAllCompanies);
+                categoryId, id, companyFilter, canReadAllCompanies, title);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -265,7 +265,14 @@ public class EduReportService {
         }
 
         return eduReportQueryRepository.findEduReports(
-                type, dept, categoryId, id, hasAccess, psmCompanyFilter, canReadAllPsmCompanies, title);
+                type,
+                dept,
+                categoryId,
+                id,
+                hasAccess,
+                psmCompanyFilter,
+                canReadAllPsmCompanies,
+                title);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/config/MysqlFulltextFunctionContributor.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/config/MysqlFulltextFunctionContributor.java
@@ -1,0 +1,21 @@
+package kr.co.awesomelead.groupware_backend.global.config;
+
+import org.hibernate.boot.model.FunctionContributions;
+import org.hibernate.boot.model.FunctionContributor;
+import org.hibernate.type.StandardBasicTypes;
+
+public class MysqlFulltextFunctionContributor implements FunctionContributor {
+
+    @Override
+    public void contributeFunctions(FunctionContributions functionContributions) {
+        functionContributions
+                .getFunctionRegistry()
+                .registerPattern(
+                        "match_against",
+                        "match(?1) against (?2 in boolean mode)",
+                        functionContributions
+                                .getTypeConfiguration()
+                                .getBasicTypeRegistry()
+                                .resolve(StandardBasicTypes.DOUBLE));
+    }
+}

--- a/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
+++ b/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
@@ -1,0 +1,1 @@
+kr.co.awesomelead.groupware_backend.global.config.MysqlFulltextFunctionContributor

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
@@ -636,7 +636,8 @@ public class EduReportServiceTest {
                 .thenReturn(mockList);
 
         // when
-        List<EduReportSummaryDto> result = eduReportService.getEduReports(null, null, null, 1L, null);
+        List<EduReportSummaryDto> result =
+                eduReportService.getEduReports(null, null, null, 1L, null);
 
         // then
         assertThat(result).isNotNull();
@@ -671,7 +672,14 @@ public class EduReportServiceTest {
         when(departmentRepository.findByName(DepartmentName.SALES_DEPT))
                 .thenReturn(Optional.of(salesDept));
         when(eduReportQueryRepository.findEduReports(
-                        EduType.DEPARTMENT, salesDept, null, 1L, true, Company.AWESOME, false, null))
+                        EduType.DEPARTMENT,
+                        salesDept,
+                        null,
+                        1L,
+                        true,
+                        Company.AWESOME,
+                        false,
+                        null))
                 .thenReturn(List.of(report1));
 
         // when
@@ -687,7 +695,14 @@ public class EduReportServiceTest {
         verify(departmentRepository, times(1)).findByName(DepartmentName.SALES_DEPT);
         verify(eduReportQueryRepository, times(1))
                 .findEduReports(
-                        EduType.DEPARTMENT, salesDept, null, 1L, true, Company.AWESOME, false, null);
+                        EduType.DEPARTMENT,
+                        salesDept,
+                        null,
+                        1L,
+                        true,
+                        Company.AWESOME,
+                        false,
+                        null);
     }
 
     @Test
@@ -697,13 +712,15 @@ public class EduReportServiceTest {
         when(userRepository.findById(1L)).thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> eduReportService.getEduReports(EduType.SAFETY, null, null, 1L, null))
+        assertThatThrownBy(
+                        () -> eduReportService.getEduReports(EduType.SAFETY, null, null, 1L, null))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.USER_NOT_FOUND);
 
         verify(eduReportQueryRepository, never())
-                .findEduReports(any(), any(), any(), anyLong(), anyBoolean(), any(), anyBoolean(), any());
+                .findEduReports(
+                        any(), any(), any(), anyLong(), anyBoolean(), any(), anyBoolean(), any());
     }
 
     @Test

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
@@ -592,12 +592,12 @@ public class EduReportServiceTest {
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
         when(eduReportQueryRepository.findEduReports(
-                        EduType.SAFETY, department, null, 1L, false, Company.AWESOME, false))
+                        EduType.SAFETY, department, null, 1L, false, Company.AWESOME, false, null))
                 .thenReturn(mockList);
 
         // when
         List<EduReportSummaryDto> result =
-                eduReportService.getEduReports(EduType.SAFETY, null, null, 1L);
+                eduReportService.getEduReports(EduType.SAFETY, null, null, 1L, null);
 
         // then
         assertThat(result).isNotNull();
@@ -606,7 +606,7 @@ public class EduReportServiceTest {
 
         verify(eduReportQueryRepository, times(1))
                 .findEduReports(
-                        EduType.SAFETY, department, null, 1L, false, Company.AWESOME, false);
+                        EduType.SAFETY, department, null, 1L, false, Company.AWESOME, false, null);
     }
 
     @Test
@@ -632,11 +632,11 @@ public class EduReportServiceTest {
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
         // dept=null + PSM 조회 범위는 본인 회사 제한
         when(eduReportQueryRepository.findEduReports(
-                        null, null, null, 1L, true, Company.AWESOME, false))
+                        null, null, null, 1L, true, Company.AWESOME, false, null))
                 .thenReturn(mockList);
 
         // when
-        List<EduReportSummaryDto> result = eduReportService.getEduReports(null, null, null, 1L);
+        List<EduReportSummaryDto> result = eduReportService.getEduReports(null, null, null, 1L, null);
 
         // then
         assertThat(result).isNotNull();
@@ -644,7 +644,7 @@ public class EduReportServiceTest {
 
         // hasAccess=true, dept=null + PSM 조회 범위는 본인 회사 제한
         verify(eduReportQueryRepository, times(1))
-                .findEduReports(null, null, null, 1L, true, Company.AWESOME, false);
+                .findEduReports(null, null, null, 1L, true, Company.AWESOME, false, null);
     }
 
     @Test
@@ -671,13 +671,13 @@ public class EduReportServiceTest {
         when(departmentRepository.findByName(DepartmentName.SALES_DEPT))
                 .thenReturn(Optional.of(salesDept));
         when(eduReportQueryRepository.findEduReports(
-                        EduType.DEPARTMENT, salesDept, null, 1L, true, Company.AWESOME, false))
+                        EduType.DEPARTMENT, salesDept, null, 1L, true, Company.AWESOME, false, null))
                 .thenReturn(List.of(report1));
 
         // when
         List<EduReportSummaryDto> result =
                 eduReportService.getEduReports(
-                        EduType.DEPARTMENT, DepartmentName.SALES_DEPT, null, 1L);
+                        EduType.DEPARTMENT, DepartmentName.SALES_DEPT, null, 1L, null);
 
         // then
         assertThat(result).isNotNull();
@@ -687,7 +687,7 @@ public class EduReportServiceTest {
         verify(departmentRepository, times(1)).findByName(DepartmentName.SALES_DEPT);
         verify(eduReportQueryRepository, times(1))
                 .findEduReports(
-                        EduType.DEPARTMENT, salesDept, null, 1L, true, Company.AWESOME, false);
+                        EduType.DEPARTMENT, salesDept, null, 1L, true, Company.AWESOME, false, null);
     }
 
     @Test
@@ -697,13 +697,13 @@ public class EduReportServiceTest {
         when(userRepository.findById(1L)).thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> eduReportService.getEduReports(EduType.SAFETY, null, null, 1L))
+        assertThatThrownBy(() -> eduReportService.getEduReports(EduType.SAFETY, null, null, 1L, null))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.USER_NOT_FOUND);
 
         verify(eduReportQueryRepository, never())
-                .findEduReports(any(), any(), any(), anyLong(), anyBoolean(), any(), anyBoolean());
+                .findEduReports(any(), any(), any(), anyLong(), anyBoolean(), any(), anyBoolean(), any());
     }
 
     @Test
@@ -721,17 +721,17 @@ public class EduReportServiceTest {
                         .build();
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-        when(eduReportQueryRepository.findPsmEduReports(null, 1L, null, true))
+        when(eduReportQueryRepository.findPsmEduReports(null, 1L, null, true, null))
                 .thenReturn(List.of(psmReport));
 
         // when
-        List<EduReportSummaryDto> result = eduReportService.getPsmEduReports(null, 1L);
+        List<EduReportSummaryDto> result = eduReportService.getPsmEduReports(null, 1L, null);
 
         // then
         assertThat(result).isNotNull();
         assertThat(result.size()).isEqualTo(1);
         assertThat(result.get(0).getEduType()).isEqualTo(EduType.PSM);
-        verify(eduReportQueryRepository, times(1)).findPsmEduReports(null, 1L, null, true);
+        verify(eduReportQueryRepository, times(1)).findPsmEduReports(null, 1L, null, true, null);
     }
 
     @Test
@@ -741,16 +741,16 @@ public class EduReportServiceTest {
         User user = createNormalUser(); // workLocation=AWESOME
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-        when(eduReportQueryRepository.findPsmEduReports(null, 1L, Company.AWESOME, false))
+        when(eduReportQueryRepository.findPsmEduReports(null, 1L, Company.AWESOME, false, null))
                 .thenReturn(List.of());
 
         // when
-        List<EduReportSummaryDto> result = eduReportService.getPsmEduReports(null, 1L);
+        List<EduReportSummaryDto> result = eduReportService.getPsmEduReports(null, 1L, null);
 
         // then
         assertThat(result).isNotNull();
         verify(eduReportQueryRepository, times(1))
-                .findPsmEduReports(null, 1L, Company.AWESOME, false);
+                .findPsmEduReports(null, 1L, Company.AWESOME, false, null);
     }
 
     @Test
@@ -768,17 +768,17 @@ public class EduReportServiceTest {
                         .build();
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-        when(eduReportQueryRepository.findSafetyEduReports(null, 1L, null, true))
+        when(eduReportQueryRepository.findSafetyEduReports(null, 1L, null, true, null))
                 .thenReturn(List.of(safetyReport));
 
         // when
-        List<EduReportSummaryDto> result = eduReportService.getSafetyEduReports(null, 1L);
+        List<EduReportSummaryDto> result = eduReportService.getSafetyEduReports(null, 1L, null);
 
         // then
         assertThat(result).isNotNull();
         assertThat(result.size()).isEqualTo(1);
         assertThat(result.get(0).getEduType()).isEqualTo(EduType.SAFETY);
-        verify(eduReportQueryRepository, times(1)).findSafetyEduReports(null, 1L, null, true);
+        verify(eduReportQueryRepository, times(1)).findSafetyEduReports(null, 1L, null, true, null);
     }
 
     @Test
@@ -788,16 +788,16 @@ public class EduReportServiceTest {
         User user = createNormalUser(); // workLocation=AWESOME
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-        when(eduReportQueryRepository.findSafetyEduReports(null, 1L, Company.AWESOME, false))
+        when(eduReportQueryRepository.findSafetyEduReports(null, 1L, Company.AWESOME, false, null))
                 .thenReturn(List.of());
 
         // when
-        List<EduReportSummaryDto> result = eduReportService.getSafetyEduReports(null, 1L);
+        List<EduReportSummaryDto> result = eduReportService.getSafetyEduReports(null, 1L, null);
 
         // then
         assertThat(result).isNotNull();
         verify(eduReportQueryRepository, times(1))
-                .findSafetyEduReports(null, 1L, Company.AWESOME, false);
+                .findSafetyEduReports(null, 1L, Company.AWESOME, false, null);
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #318

## 📝작업 내용

- `edu_reports.title` 컬럼에 ngram 파서 FULLTEXT INDEX(`fx_edu_report_title`) 추가 (로컬 DB 및 운영 RDS 모두 적용)
- Hibernate 6 SPI(`FunctionContributor`)로 `match_against` 커스텀 함수 등록
    - `META-INF/services/org.hibernate.boot.model.FunctionContributor` 파일로 자동 로드
    - `match({1}) against ({2} in boolean mode)` 패턴으로 MySQL FULLTEXT 검색 지원
- `EduReportQueryRepository`에 `titleFilter(String title)` BooleanExpression 추가
    - `title` 미입력 시 조건 없음(전체 조회), 입력 시 MATCH AGAINST IN BOOLEAN MODE 적용
- `GET /api/educations/department`, `/psm`, `/safety` 에 `?title=` 쿼리 파라미터 추가
- Swagger `@Parameter` 설명 반영

## 📸 스크린샷 (선택)

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

**단위 테스트**: `EduReportServiceTest` PASSED

**API 테스트**:
- `GET /api/educations/department?title=격리` → 1건 (정밀 필터링 확인)
- `GET /api/educations/department?title=FCM` → 1건 (정밀 필터링 확인)
- `GET /api/educations/department?title=없는키워드xyz` → 0건 (미매칭 확인)

## 💬리뷰 요구사항(선택)
- X