### PR TITLE
refactor(323): 안전보건 교육일지 제목 검색(ngram) 및 교육 응답 개인 상태값 확장

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
@@ -433,6 +433,8 @@ public class EduReportController {
                 - `MANAGE_DEPARTMENT_EDUCATION` 권한 사용자는 `departmentName`으로 전체 부서 대상 필터 조회가 가능합니다.
                 - `MANAGE_DEPARTMENT_EDUCATION` 권한이 없는 사용자는 본인 소속 부서 게시물만 조회됩니다.
                 - `canSign`은 목록 기준 서명 가능 여부이며, `signatureRequired=true` + `OPEN` 상태 + 미서명 + 본인 소속 부서 게시물일 때 `true`입니다.
+                - `mySigned`, `myCompletionStatus`는 부서교육 + 본인 소속 부서 게시물일 때만 값이 채워집니다.
+                - `myCompletionStatus`는 `signatureRequired=false`이면 항상 `COMPLETED`이며, `signatureRequired=true`이면 내 서명 여부에 따라 `COMPLETED/INCOMPLETE`로 계산됩니다.
                 """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -457,6 +459,8 @@ public class EduReportController {
                                   "eduDate": "2026-03-16",
                                   "content": "부서교육 게시글입니다.",
                                   "attendance": false,
+                                  "mySigned": false,
+                                  "myCompletionStatus": "INCOMPLETE",
                                   "canSign": true,
                                   "pinned": false,
                                   "signatureRequired": true,
@@ -680,6 +684,8 @@ public class EduReportController {
                 - `MANAGE_DEPARTMENT_EDUCATION` 권한 사용자는 `attendees`, `numberOfPeople`, `numberOfAttendees`를 조회할 수 있으며, 권한이 없는 사용자는 위 필드가 `null`로 반환됩니다.
                 - `targetCount`, `signedCount`, `unsignedCount`는 부서 교육 상세에서 공통으로 제공됩니다.
                 - `canSign`은 현재 사용자의 서명 가능 여부를 의미하며, `signatureRequired=true` + `OPEN` 상태 + 미서명 + 본인 소속 부서 게시물인 경우 `true`입니다.
+                - `mySigned`, `myCompletionStatus`는 부서교육 + 본인 소속 부서 게시물일 때만 값이 채워집니다.
+                - `myCompletionStatus`는 `signatureRequired=false`이면 항상 `COMPLETED`이며, `signatureRequired=true`이면 내 서명 여부에 따라 `COMPLETED/INCOMPLETE`로 계산됩니다.
                 """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportDetailDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportDetailDto.java
@@ -61,7 +61,10 @@ public class EduReportDetailDto {
     @Schema(description = "출석 여부", example = "true")
     private boolean attendance;
 
-    @Schema(description = "현재 로그인 사용자의 서명 완료 여부(부서교육 + 본인 소속 부서 게시물일 때만 값 반환)", example = "true", nullable = true)
+    @Schema(
+            description = "현재 로그인 사용자의 서명 완료 여부(부서교육 + 본인 소속 부서 게시물일 때만 값 반환)",
+            example = "true",
+            nullable = true)
     private Boolean mySigned;
 
     @Schema(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportDetailDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportDetailDto.java
@@ -2,6 +2,7 @@ package kr.co.awesomelead.groupware_backend.domain.education.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import kr.co.awesomelead.groupware_backend.domain.education.enums.EduCompletionStatus;
 import kr.co.awesomelead.groupware_backend.domain.education.enums.EduReportStatus;
 import kr.co.awesomelead.groupware_backend.domain.education.enums.EduType;
 
@@ -59,6 +60,15 @@ public class EduReportDetailDto {
 
     @Schema(description = "출석 여부", example = "true")
     private boolean attendance;
+
+    @Schema(description = "현재 로그인 사용자의 서명 완료 여부(부서교육 + 본인 소속 부서 게시물일 때만 값 반환)", example = "true", nullable = true)
+    private Boolean mySigned;
+
+    @Schema(
+            description = "현재 로그인 사용자의 수료 상태(부서교육 + 본인 소속 부서 게시물일 때만 값 반환, 서명필수=false면 COMPLETED)",
+            example = "INCOMPLETE",
+            nullable = true)
+    private EduCompletionStatus myCompletionStatus;
 
     @Schema(description = "서명 필수 여부", example = "false")
     private boolean signatureRequired;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportSummaryDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportSummaryDto.java
@@ -3,6 +3,7 @@ package kr.co.awesomelead.groupware_backend.domain.education.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
+import kr.co.awesomelead.groupware_backend.domain.education.enums.EduCompletionStatus;
 import kr.co.awesomelead.groupware_backend.domain.education.enums.EduReportStatus;
 import kr.co.awesomelead.groupware_backend.domain.education.enums.EduType;
 
@@ -37,6 +38,15 @@ public class EduReportSummaryDto {
 
     @Schema(description = "출석 여부", example = "true")
     private boolean attendance;
+
+    @Schema(description = "현재 로그인 사용자의 서명 완료 여부(부서교육 + 본인 소속 부서 게시물일 때만 값 반환)", example = "true", nullable = true)
+    private Boolean mySigned;
+
+    @Schema(
+            description = "현재 로그인 사용자의 수료 상태(부서교육 + 본인 소속 부서 게시물일 때만 값 반환, 서명필수=false면 COMPLETED)",
+            example = "INCOMPLETE",
+            nullable = true)
+    private EduCompletionStatus myCompletionStatus;
 
     @Schema(description = "현재 사용자의 서명 가능 여부(목록 기준)", example = "true")
     private boolean canSign;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportSummaryDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportSummaryDto.java
@@ -39,7 +39,10 @@ public class EduReportSummaryDto {
     @Schema(description = "출석 여부", example = "true")
     private boolean attendance;
 
-    @Schema(description = "현재 로그인 사용자의 서명 완료 여부(부서교육 + 본인 소속 부서 게시물일 때만 값 반환)", example = "true", nullable = true)
+    @Schema(
+            description = "현재 로그인 사용자의 서명 완료 여부(부서교육 + 본인 소속 부서 게시물일 때만 값 반환)",
+            example = "true",
+            nullable = true)
     private Boolean mySigned;
 
     @Schema(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/enums/EduCompletionStatus.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/enums/EduCompletionStatus.java
@@ -11,4 +11,3 @@ public enum EduCompletionStatus {
 
     private final String description;
 }
-

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/enums/EduCompletionStatus.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/enums/EduCompletionStatus.java
@@ -1,0 +1,14 @@
+package kr.co.awesomelead.groupware_backend.domain.education.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum EduCompletionStatus {
+    COMPLETED("수료"),
+    INCOMPLETE("미수료");
+
+    private final String description;
+}
+

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/mapper/EduMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/mapper/EduMapper.java
@@ -68,6 +68,8 @@ public interface EduMapper {
     @Mapping(target = "signedCount", ignore = true)
     @Mapping(target = "unsignedCount", ignore = true)
     @Mapping(target = "canSign", ignore = true)
+    @Mapping(target = "mySigned", ignore = true)
+    @Mapping(target = "myCompletionStatus", ignore = true)
     @Mapping(target = "prevReport", ignore = true)
     @Mapping(target = "nextReport", ignore = true)
     @Mapping(target = "attendees", source = "attendances")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
@@ -19,6 +19,7 @@ import kr.co.awesomelead.groupware_backend.domain.education.dto.response.EduRepo
 import kr.co.awesomelead.groupware_backend.domain.education.dto.response.EduReportSummaryDto;
 import kr.co.awesomelead.groupware_backend.domain.education.entity.EduReport;
 import kr.co.awesomelead.groupware_backend.domain.education.entity.QEduAttendance;
+import kr.co.awesomelead.groupware_backend.domain.education.enums.EduCompletionStatus;
 import kr.co.awesomelead.groupware_backend.domain.education.enums.EduReportStatus;
 import kr.co.awesomelead.groupware_backend.domain.education.enums.EduType;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.QUser;
@@ -111,6 +112,8 @@ public class EduReportQueryRepository {
                                 eduReport.eduDate,
                                 eduReport.content,
                                 attendanceExists,
+                                Expressions.nullExpression(Boolean.class),
+                                Expressions.nullExpression(EduCompletionStatus.class),
                                 canSignDepartment,
                                 eduReport.pinned,
                                 eduReport.signatureRequired,
@@ -165,6 +168,8 @@ public class EduReportQueryRepository {
                                 eduReport.eduDate,
                                 eduReport.content,
                                 attendanceExists,
+                                Expressions.nullExpression(Boolean.class),
+                                Expressions.nullExpression(EduCompletionStatus.class),
                                 Expressions.constant(false),
                                 eduReport.pinned,
                                 eduReport.signatureRequired,
@@ -217,6 +222,8 @@ public class EduReportQueryRepository {
                                 eduReport.eduDate,
                                 eduReport.content,
                                 attendanceExists,
+                                Expressions.nullExpression(Boolean.class),
+                                Expressions.nullExpression(EduCompletionStatus.class),
                                 Expressions.constant(false),
                                 eduReport.pinned,
                                 eduReport.signatureRequired,

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -17,6 +17,7 @@ import kr.co.awesomelead.groupware_backend.domain.education.entity.EduAttachment
 import kr.co.awesomelead.groupware_backend.domain.education.entity.EduAttendance;
 import kr.co.awesomelead.groupware_backend.domain.education.entity.EduReport;
 import kr.co.awesomelead.groupware_backend.domain.education.entity.EducationCategory;
+import kr.co.awesomelead.groupware_backend.domain.education.enums.EduCompletionStatus;
 import kr.co.awesomelead.groupware_backend.domain.education.enums.EduReportStatus;
 import kr.co.awesomelead.groupware_backend.domain.education.enums.EduType;
 import kr.co.awesomelead.groupware_backend.domain.education.enums.EducationCategoryType;
@@ -264,15 +265,19 @@ public class EduReportService {
             dept = user.getDepartment();
         }
 
-        return eduReportQueryRepository.findEduReports(
-                type,
-                dept,
-                categoryId,
-                id,
-                hasAccess,
-                psmCompanyFilter,
-                canReadAllPsmCompanies,
-                title);
+        List<EduReportSummaryDto> summaries =
+                eduReportQueryRepository.findEduReports(
+                        type,
+                        dept,
+                        categoryId,
+                        id,
+                        hasAccess,
+                        psmCompanyFilter,
+                        canReadAllPsmCompanies,
+                        title);
+
+        summaries.forEach(summary -> applyDepartmentMyStatusToSummary(user, summary));
+        return summaries;
     }
 
     @Transactional(readOnly = true)
@@ -481,8 +486,63 @@ public class EduReportService {
 
         boolean isAttended = eduAttendanceRepository.existsByEduReportAndUser(report, user);
         dto.setAttendance(isAttended);
+        Boolean mySigned = resolveDepartmentMySigned(user, report, isAttended);
+        dto.setMySigned(mySigned);
+        dto.setMyCompletionStatus(resolveDepartmentMyCompletionStatus(report, mySigned));
         dto.setCanSign(canSignDepartmentEduReport(report, user, isAttended));
         return dto;
+    }
+
+    private void applyDepartmentMyStatusToSummary(User user, EduReportSummaryDto summary) {
+        if (summary.getEduType() != EduType.DEPARTMENT) {
+            summary.setMySigned(null);
+            summary.setMyCompletionStatus(null);
+            return;
+        }
+
+        Boolean mySigned =
+                resolveDepartmentMySigned(
+                        user, summary.getDepartmentName(), summary.isAttendance());
+        summary.setMySigned(mySigned);
+        summary.setMyCompletionStatus(
+                resolveDepartmentMyCompletionStatus(summary.isSignatureRequired(), mySigned));
+    }
+
+    private Boolean resolveDepartmentMySigned(
+            User user, DepartmentName reportDepartmentName, boolean attended) {
+        if (user.getDepartment() == null
+                || user.getDepartment().getName() == null
+                || reportDepartmentName == null
+                || user.getDepartment().getName() != reportDepartmentName) {
+            return null;
+        }
+        return attended;
+    }
+
+    private Boolean resolveDepartmentMySigned(User user, EduReport report, boolean attended) {
+        if (report.getEduType() != EduType.DEPARTMENT
+                || user.getDepartment() == null
+                || report.getDepartment() == null
+                || !report.getDepartment().getId().equals(user.getDepartment().getId())) {
+            return null;
+        }
+        return attended;
+    }
+
+    private EduCompletionStatus resolveDepartmentMyCompletionStatus(
+            EduReport report, Boolean mySigned) {
+        return resolveDepartmentMyCompletionStatus(report.isSignatureRequired(), mySigned);
+    }
+
+    private EduCompletionStatus resolveDepartmentMyCompletionStatus(
+            boolean signatureRequired, Boolean mySigned) {
+        if (mySigned == null) {
+            return null;
+        }
+        if (!signatureRequired) {
+            return EduCompletionStatus.COMPLETED;
+        }
+        return mySigned ? EduCompletionStatus.COMPLETED : EduCompletionStatus.INCOMPLETE;
     }
 
     private boolean canSignDepartmentEduReport(EduReport report, User user, boolean isAttended) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/controller/SafetyTrainingSessionController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/controller/SafetyTrainingSessionController.java
@@ -81,7 +81,8 @@ public class SafetyTrainingSessionController {
             summary = "안전보건 교육일지 목록 조회",
             description =
                     "일반 사용자는 본인 회사 데이터를 조회할 수 있으며, MANAGE_SAFETY 권한 사용자는 전체 회사/상태 조회가 가능합니다. 각 교육일지"
-                            + " 항목에 현재 로그인 사용자의 서명 완료 여부(mySigned)를 포함합니다.")
+                            + " 항목에 현재 로그인 사용자의 서명 완료 여부(mySigned)를 포함합니다."
+                            + " titleKeyword 파라미터로 제목 검색이 가능하며, MySQL FULLTEXT ngram 인덱스를 사용합니다.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/request/SafetyTrainingSessionSearchConditionDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/request/SafetyTrainingSessionSearchConditionDto.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
 
@@ -19,6 +20,11 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Schema(description = "안전보건 교육일지 목록 조회 필터")
 public class SafetyTrainingSessionSearchConditionDto {
+
+    @Schema(
+            description = "제목 검색어 (MySQL FULLTEXT ngram 기반 검색)",
+            example = "정기 안전보건")
+    private String titleKeyword;
 
     @Schema(
             description = "회사 필터 (AWESOME: 어썸리드, MARUI: 마루이)",
@@ -47,4 +53,8 @@ public class SafetyTrainingSessionSearchConditionDto {
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @Schema(description = "교육 시작시각 상한(이 값 이하)", example = "2026-03-31T23:59:59")
     private LocalDateTime startAtTo;
+
+    public String getNormalizedTitleKeyword() {
+        return StringUtils.hasText(titleKeyword) ? titleKeyword.trim() : null;
+    }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/request/SafetyTrainingSessionSearchConditionDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/request/SafetyTrainingSessionSearchConditionDto.java
@@ -21,9 +21,7 @@ import java.time.LocalDateTime;
 @Schema(description = "안전보건 교육일지 목록 조회 필터")
 public class SafetyTrainingSessionSearchConditionDto {
 
-    @Schema(
-            description = "제목 검색어 (MySQL FULLTEXT ngram 기반 검색)",
-            example = "정기 안전보건")
+    @Schema(description = "제목 검색어 (MySQL FULLTEXT ngram 기반 검색)", example = "정기 안전보건")
     private String titleKeyword;
 
     @Schema(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingSessionDetailResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingSessionDetailResponseDto.java
@@ -87,6 +87,9 @@ public class SafetyTrainingSessionDetailResponseDto {
     @Schema(description = "내 참석 상태", example = "SIGNED")
     private SafetyTrainingAttendeeStatus myAttendanceStatus;
 
+    @Schema(description = "현재 로그인 사용자의 서명 완료 여부 (대표이사/마스터 관리자/타회사 교육일지는 null)", example = "true")
+    private Boolean mySigned;
+
     @Schema(
             description = "내 수료 상태(대표이사/MASTER_ADMIN 또는 세션 회사와 내 회사가 다르면 null)",
             example = "COMPLETED",

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/repository/SafetyTrainingSessionRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/repository/SafetyTrainingSessionRepository.java
@@ -25,6 +25,7 @@ public interface SafetyTrainingSessionRepository
               AND (:status IS NULL OR s.status = :status)
               AND (:startAtFrom IS NULL OR s.startAt >= :startAtFrom)
               AND (:startAtTo IS NULL OR s.startAt <= :startAtTo)
+              AND (:titleKeyword IS NULL OR function('match_against', s.title, :titleKeyword) > 0)
             """)
     Page<SafetyTrainingSession> findAllByFilters(
             @Param("companyScope") Company companyScope,
@@ -32,6 +33,7 @@ public interface SafetyTrainingSessionRepository
             @Param("status") SafetyTrainingSessionStatus status,
             @Param("startAtFrom") java.time.LocalDateTime startAtFrom,
             @Param("startAtTo") java.time.LocalDateTime startAtTo,
+            @Param("titleKeyword") String titleKeyword,
             Pageable pageable);
 
     Optional<SafetyTrainingSession> findFirstByIdGreaterThanOrderByIdAsc(Long sessionId);

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
@@ -296,6 +296,9 @@ public class SafetyTrainingSessionService {
                 .absentReasonSummary(session.getAbsentReasonSummary())
                 .reportFileUrl(reportFileUrl)
                 .myAttendanceStatus(myStatus)
+                .mySigned(
+                        resolveMySigned(
+                                actor, session, myStatus == SafetyTrainingAttendeeStatus.SIGNED))
                 .myCompletionStatus(completionStatus)
                 .mySignedAt(attendee.getSignedAt())
                 .mySignatureUrl(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
@@ -191,6 +191,7 @@ public class SafetyTrainingSessionService {
                         status,
                         filter.getStartAtFrom(),
                         filter.getStartAtTo(),
+                        filter.getNormalizedTitleKeyword(),
                         pageable);
 
         List<Long> sessionIds =


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #323 

## 📝작업 내용
- 안전보건 교육일지 목록 조회에 `titleKeyword` 검색 파라미터를 추가했습니다.
- 목록 쿼리에 MySQL FULLTEXT 검색(`match_against`)을 적용해 제목 검색을 지원합니다.
- 안전보건 교육일지 상세 응답에 `mySigned` 필드를 추가했습니다.
- 부서교육 목록/상세 응답에 `mySigned`, `myCompletionStatus`를 추가했습니다.
- `myCompletionStatus` 계산 로직을 추가했습니다.
  - 부서교육 + 본인 소속 부서 게시물에서만 값 노출
  - `signatureRequired=false`면 `COMPLETED`
  - `signatureRequired=true`면 내 서명 여부에 따라 `COMPLETED/INCOMPLETE`
- Swagger 문서를 로직에 맞게 동기화했습니다.

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X