### PR TITLE
fix(327): JWT 만료 시 500 반환 및 EduReport 삭제 FK 오류 수정

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/config/SecurityConfig.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package kr.co.awesomelead.groupware_backend.config;
 
 import jakarta.servlet.http.HttpServletResponse;
 
+import kr.co.awesomelead.groupware_backend.domain.auth.filter.JwtExceptionFilter;
 import kr.co.awesomelead.groupware_backend.domain.auth.filter.JwtFilter;
 import kr.co.awesomelead.groupware_backend.domain.auth.util.JWTUtil;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
@@ -124,6 +125,7 @@ public class SecurityConfig {
 
         http.addFilterBefore(
                 new JwtFilter(jwtUtil, userRepository), UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(new JwtExceptionFilter(), JwtFilter.class);
 
         http.sessionManagement(
                 (session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/filter/JwtExceptionFilter.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/filter/JwtExceptionFilter.java
@@ -1,0 +1,39 @@
+package kr.co.awesomelead.groupware_backend.domain.auth.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jsonwebtoken.ExpiredJwtException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import kr.co.awesomelead.groupware_backend.global.common.response.ApiResponse;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (ExpiredJwtException e) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+            response.getWriter()
+                    .write(
+                            OBJECT_MAPPER.writeValueAsString(
+                                    ApiResponse.onFailure("AUTH401", "토큰이 만료되었습니다.")));
+        }
+    }
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduAttendanceRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduAttendanceRepository.java
@@ -21,4 +21,6 @@ public interface EduAttendanceRepository extends JpaRepository<EduAttendance, Lo
                     + "JOIN FETCH ea.user "
                     + "WHERE ea.eduReport.id = :reportId")
     List<EduAttendance> findAllByEduReportIdWithUser(@Param("reportId") Long reportId);
+
+    void deleteByEduReportId(Long eduReportId);
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -620,6 +620,7 @@ public class EduReportService {
                         attachment -> {
                             s3Service.deleteFile(attachment.getS3Key());
                         });
+        eduAttendanceRepository.deleteByEduReportId(report.getId());
         eduReportRepository.delete(report);
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #327

## 📝작업 내용

- `JwtExceptionFilter` 신규 추가: `ExpiredJwtException` catch → HTTP 401 + `{"code":"AUTH401","message":"토큰이 만료되었습니다."}` JSON 응답 반환
- `SecurityConfig`에 `JwtExceptionFilter`를 `JwtFilter` 앞에 등록하여 필터 체인에서 만료 예외 선처리
- `EduAttendanceRepository`에 `deleteByEduReportId(Long)` 추가
- `EduReportService.performDeleteEduReport`에서 `eduReportRepository.delete` 전 `deleteByEduReportId` 호출로 FK 제약 위반 해소

## 📸 스크린샷 (선택)

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)

- `EduAttachment`는 `CascadeType.ALL`로 JPA가 삭제를 관리하는 반면, `EduAttendance`는 서비스에서 Repository를 직접 호출하는 방식임. 연관관계 삭제 전략을 통일이 필요할 수 있음.