### PR TITLE
feat(333): 알림 목록 조회 응답에 messageType 필드 추가

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/dto/response/NotificationResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/dto/response/NotificationResponseDto.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import kr.co.awesomelead.groupware_backend.domain.notification.entity.Notification;
 import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationDomainType;
+import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationMessage;
 
 import lombok.Getter;
 
@@ -43,6 +44,9 @@ public class NotificationResponseDto {
     @Schema(description = "승인 대기 여부 (true인 알림만 필터링 가능)", example = "false")
     private final boolean requiresApproval;
 
+    @Schema(description = "알림 메시지 유형", example = "VISIT_CHECK_IN")
+    private final NotificationMessage messageType;
+
     private NotificationResponseDto(Notification notification) {
         this.id = notification.getId();
         this.title = notification.getTitle();
@@ -53,6 +57,7 @@ public class NotificationResponseDto {
         this.createdAt = notification.getCreatedAt();
         this.metadata = notification.getMetadata();
         this.requiresApproval = notification.isRequiresApproval();
+        this.messageType = notification.getMessageType();
     }
 
     public static NotificationResponseDto from(Notification notification) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/entity/Notification.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/entity/Notification.java
@@ -149,7 +149,8 @@ public class Notification {
             Long domainId,
             NotificationMessage messageType) {
         validate(userId, title, content, domainType);
-        return new Notification(userId, title, content, domainType, domainId, null, false, messageType);
+        return new Notification(
+                userId, title, content, domainType, domainId, null, false, messageType);
     }
 
     public static Notification of(
@@ -176,7 +177,14 @@ public class Notification {
             NotificationMessage messageType) {
         validate(userId, title, content, domainType);
         return new Notification(
-                userId, title, content, domainType, domainId, metadata, requiresApproval, messageType);
+                userId,
+                title,
+                content,
+                domainType,
+                domainId,
+                metadata,
+                requiresApproval,
+                messageType);
     }
 
     private static void validate(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/entity/Notification.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/entity/Notification.java
@@ -12,6 +12,7 @@ import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 
 import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationDomainType;
+import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationMessage;
 import kr.co.awesomelead.groupware_backend.global.util.NotificationMetadataConverter;
 
 import lombok.Getter;
@@ -55,6 +56,10 @@ public class Notification {
     @Column(nullable = false)
     private boolean requiresApproval;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "message_type", length = 50, nullable = true)
+    private NotificationMessage messageType;
+
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
@@ -79,6 +84,27 @@ public class Notification {
         this.metadata = metadata;
         this.isRead = false;
         this.requiresApproval = requiresApproval;
+        this.messageType = null;
+    }
+
+    private Notification(
+            Long userId,
+            String title,
+            String content,
+            NotificationDomainType domainType,
+            Long domainId,
+            Map<String, Object> metadata,
+            boolean requiresApproval,
+            NotificationMessage messageType) {
+        this.userId = userId;
+        this.title = title;
+        this.content = content;
+        this.domainType = domainType;
+        this.domainId = domainId;
+        this.metadata = metadata;
+        this.isRead = false;
+        this.requiresApproval = requiresApproval;
+        this.messageType = messageType;
     }
 
     public static Notification of(
@@ -113,6 +139,44 @@ public class Notification {
         validate(userId, title, content, domainType);
         return new Notification(
                 userId, title, content, domainType, domainId, metadata, requiresApproval);
+    }
+
+    public static Notification of(
+            Long userId,
+            String title,
+            String content,
+            NotificationDomainType domainType,
+            Long domainId,
+            NotificationMessage messageType) {
+        validate(userId, title, content, domainType);
+        return new Notification(userId, title, content, domainType, domainId, null, false, messageType);
+    }
+
+    public static Notification of(
+            Long userId,
+            String title,
+            String content,
+            NotificationDomainType domainType,
+            Long domainId,
+            Map<String, Object> metadata,
+            NotificationMessage messageType) {
+        validate(userId, title, content, domainType);
+        return new Notification(
+                userId, title, content, domainType, domainId, metadata, false, messageType);
+    }
+
+    public static Notification of(
+            Long userId,
+            String title,
+            String content,
+            NotificationDomainType domainType,
+            Long domainId,
+            Map<String, Object> metadata,
+            boolean requiresApproval,
+            NotificationMessage messageType) {
+        validate(userId, title, content, domainType);
+        return new Notification(
+                userId, title, content, domainType, domainId, metadata, requiresApproval, messageType);
     }
 
     private static void validate(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/service/NotificationService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/service/NotificationService.java
@@ -76,6 +76,22 @@ public class NotificationService {
         log.info("알림 생성 - userId: {}, domainType: {}", userId, domainType);
     }
 
+    private void doCreateNotification(
+            Long userId,
+            String title,
+            String content,
+            NotificationMessage messageType,
+            NotificationDomainType domainType,
+            Long domainId,
+            Map<String, Object> metadata,
+            boolean requiresApproval) {
+        Notification notification =
+                Notification.of(
+                        userId, title, content, domainType, domainId, metadata, requiresApproval, messageType);
+        notificationRepository.save(notification);
+        log.info("알림 생성 - userId: {}, domainType: {}", userId, domainType);
+    }
+
     @Transactional(readOnly = true)
     public Page<NotificationResponseDto> getNotifications(
             Long userId, boolean pendingApproval, Pageable pageable) {
@@ -165,10 +181,11 @@ public class NotificationService {
 
         for (User admin : admins) {
             // 1. 알림함 저장
-            createNotification(
+            doCreateNotification(
                     admin.getId(),
                     title,
                     content,
+                    template,
                     domainType,
                     domainId,
                     metadata,
@@ -217,7 +234,7 @@ public class NotificationService {
         String content = template.formatContent(args);
 
         // 1. 알림함 저장
-        createNotification(userId, title, content, domainType, domainId, metadata);
+        doCreateNotification(userId, title, content, template, domainType, domainId, metadata, false);
 
         // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
         eventPublisher.publishEvent(
@@ -247,7 +264,7 @@ public class NotificationService {
 
         for (Long userId : targetUserIds) {
             // 1. 알림함 저장
-            createNotification(userId, title, content, NotificationDomainType.NOTICE, noticeId);
+            doCreateNotification(userId, title, content, NotificationMessage.NOTICE_CREATED, NotificationDomainType.NOTICE, noticeId, null, false);
 
             // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
             eventPublisher.publishEvent(
@@ -293,8 +310,7 @@ public class NotificationService {
 
         for (Long userId : targetUserIds) {
             // 1. 알림함 저장
-            createNotification(
-                    userId, title, content, NotificationDomainType.EDUCATION, reportId, metadata);
+            doCreateNotification(userId, title, content, NotificationMessage.EDU_REPORT_CREATED, NotificationDomainType.EDUCATION, reportId, metadata, false);
 
             // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
             eventPublisher.publishEvent(
@@ -346,10 +362,11 @@ public class NotificationService {
 
         for (Long userId : targetUserIds) {
             // 1. 알림함 저장
-            createNotification(
+            doCreateNotification(
                     userId,
                     title,
                     content,
+                    template,
                     NotificationDomainType.VISIT,
                     visitId,
                     metadata,
@@ -384,7 +401,7 @@ public class NotificationService {
         String content = template.formatContent(baseDateFormatted);
 
         // 1. 알림함 DB 저장 (domainId는 단일 엔티티 연차 특성상 null 처리)
-        createNotification(userId, title, content, NotificationDomainType.ANNUAL_LEAVE, null);
+        doCreateNotification(userId, title, content, template, NotificationDomainType.ANNUAL_LEAVE, null, null, false);
 
         // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
         eventPublisher.publishEvent(
@@ -410,7 +427,7 @@ public class NotificationService {
         String content = template.formatContent();
 
         // 1. 알림함 DB 저장
-        createNotification(userId, title, content, NotificationDomainType.PAYSLIP, payslipId);
+        doCreateNotification(userId, title, content, template, NotificationDomainType.PAYSLIP, payslipId, null, false);
 
         // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
         eventPublisher.publishEvent(
@@ -439,10 +456,11 @@ public class NotificationService {
         String approverTitle = NotificationMessage.APPROVAL_CREATED_APPROVER.getTitle();
         String approverContent =
                 NotificationMessage.APPROVAL_CREATED_APPROVER.formatContent(docTitle);
-        createNotification(
+        doCreateNotification(
                 firstApproverId,
                 approverTitle,
                 approverContent,
+                NotificationMessage.APPROVAL_CREATED_APPROVER,
                 NotificationDomainType.APPROVAL,
                 approvalId,
                 null,
@@ -461,12 +479,15 @@ public class NotificationService {
         String referrerContent =
                 NotificationMessage.APPROVAL_CREATED_REFERRER.formatContent(docTitle);
         for (Long referrerId : referrerIds) {
-            createNotification(
+            doCreateNotification(
                     referrerId,
                     referrerTitle,
                     referrerContent,
+                    NotificationMessage.APPROVAL_CREATED_REFERRER,
                     NotificationDomainType.APPROVAL,
-                    approvalId);
+                    approvalId,
+                    null,
+                    false);
             eventPublisher.publishEvent(
                     new FcmSendEvent(
                             referrerId,
@@ -489,10 +510,11 @@ public class NotificationService {
         String title = NotificationMessage.APPROVAL_CREATED_APPROVER.getTitle();
         String content = NotificationMessage.APPROVAL_CREATED_APPROVER.formatContent(docTitle);
 
-        createNotification(
+        doCreateNotification(
                 nextApproverId,
                 title,
                 content,
+                NotificationMessage.APPROVAL_CREATED_APPROVER,
                 NotificationDomainType.APPROVAL,
                 approvalId,
                 null,
@@ -524,7 +546,7 @@ public class NotificationService {
         String title = NotificationMessage.APPROVAL_REJECTED.getTitle();
         String content = NotificationMessage.APPROVAL_REJECTED.formatContent(docTitle, comment);
 
-        createNotification(drafterId, title, content, NotificationDomainType.APPROVAL, approvalId);
+        doCreateNotification(drafterId, title, content, NotificationMessage.APPROVAL_REJECTED, NotificationDomainType.APPROVAL, approvalId, null, false);
         eventPublisher.publishEvent(
                 new FcmSendEvent(
                         drafterId,
@@ -550,7 +572,7 @@ public class NotificationService {
         String content = NotificationMessage.APPROVAL_FINALLY_APPROVED.formatContent(docTitle);
 
         // 1. 기안자에게 알림
-        createNotification(drafterId, title, content, NotificationDomainType.APPROVAL, approvalId);
+        doCreateNotification(drafterId, title, content, NotificationMessage.APPROVAL_FINALLY_APPROVED, NotificationDomainType.APPROVAL, approvalId, null, false);
         eventPublisher.publishEvent(
                 new FcmSendEvent(
                         drafterId,
@@ -560,8 +582,8 @@ public class NotificationService {
 
         // 2. 열람권자들에게 알림
         for (Long viewerId : viewerIds) {
-            createNotification(
-                    viewerId, title, content, NotificationDomainType.APPROVAL, approvalId);
+            doCreateNotification(
+                    viewerId, title, content, NotificationMessage.APPROVAL_FINALLY_APPROVED, NotificationDomainType.APPROVAL, approvalId, null, false);
             eventPublisher.publishEvent(
                     new FcmSendEvent(
                             viewerId,
@@ -598,13 +620,15 @@ public class NotificationService {
         Map<String, Object> metadata = Map.of("educationType", "SAFETY", "detailType", "SESSION");
 
         for (Long userId : targetUserIds) {
-            createNotification(
+            doCreateNotification(
                     userId,
                     title,
                     content,
+                    NotificationMessage.SAFETY_TRAINING_SESSION_CREATED,
                     NotificationDomainType.SAFETY_TRAINING,
                     sessionId,
-                    metadata);
+                    metadata,
+                    false);
             eventPublisher.publishEvent(
                     new FcmSendEvent(
                             userId,

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/service/NotificationService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/service/NotificationService.java
@@ -87,7 +87,14 @@ public class NotificationService {
             boolean requiresApproval) {
         Notification notification =
                 Notification.of(
-                        userId, title, content, domainType, domainId, metadata, requiresApproval, messageType);
+                        userId,
+                        title,
+                        content,
+                        domainType,
+                        domainId,
+                        metadata,
+                        requiresApproval,
+                        messageType);
         notificationRepository.save(notification);
         log.info("알림 생성 - userId: {}, domainType: {}", userId, domainType);
     }
@@ -234,7 +241,8 @@ public class NotificationService {
         String content = template.formatContent(args);
 
         // 1. 알림함 저장
-        doCreateNotification(userId, title, content, template, domainType, domainId, metadata, false);
+        doCreateNotification(
+                userId, title, content, template, domainType, domainId, metadata, false);
 
         // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
         eventPublisher.publishEvent(
@@ -264,7 +272,15 @@ public class NotificationService {
 
         for (Long userId : targetUserIds) {
             // 1. 알림함 저장
-            doCreateNotification(userId, title, content, NotificationMessage.NOTICE_CREATED, NotificationDomainType.NOTICE, noticeId, null, false);
+            doCreateNotification(
+                    userId,
+                    title,
+                    content,
+                    NotificationMessage.NOTICE_CREATED,
+                    NotificationDomainType.NOTICE,
+                    noticeId,
+                    null,
+                    false);
 
             // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
             eventPublisher.publishEvent(
@@ -310,7 +326,15 @@ public class NotificationService {
 
         for (Long userId : targetUserIds) {
             // 1. 알림함 저장
-            doCreateNotification(userId, title, content, NotificationMessage.EDU_REPORT_CREATED, NotificationDomainType.EDUCATION, reportId, metadata, false);
+            doCreateNotification(
+                    userId,
+                    title,
+                    content,
+                    NotificationMessage.EDU_REPORT_CREATED,
+                    NotificationDomainType.EDUCATION,
+                    reportId,
+                    metadata,
+                    false);
 
             // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
             eventPublisher.publishEvent(
@@ -401,7 +425,15 @@ public class NotificationService {
         String content = template.formatContent(baseDateFormatted);
 
         // 1. 알림함 DB 저장 (domainId는 단일 엔티티 연차 특성상 null 처리)
-        doCreateNotification(userId, title, content, template, NotificationDomainType.ANNUAL_LEAVE, null, null, false);
+        doCreateNotification(
+                userId,
+                title,
+                content,
+                template,
+                NotificationDomainType.ANNUAL_LEAVE,
+                null,
+                null,
+                false);
 
         // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
         eventPublisher.publishEvent(
@@ -427,7 +459,15 @@ public class NotificationService {
         String content = template.formatContent();
 
         // 1. 알림함 DB 저장
-        doCreateNotification(userId, title, content, template, NotificationDomainType.PAYSLIP, payslipId, null, false);
+        doCreateNotification(
+                userId,
+                title,
+                content,
+                template,
+                NotificationDomainType.PAYSLIP,
+                payslipId,
+                null,
+                false);
 
         // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
         eventPublisher.publishEvent(
@@ -546,7 +586,15 @@ public class NotificationService {
         String title = NotificationMessage.APPROVAL_REJECTED.getTitle();
         String content = NotificationMessage.APPROVAL_REJECTED.formatContent(docTitle, comment);
 
-        doCreateNotification(drafterId, title, content, NotificationMessage.APPROVAL_REJECTED, NotificationDomainType.APPROVAL, approvalId, null, false);
+        doCreateNotification(
+                drafterId,
+                title,
+                content,
+                NotificationMessage.APPROVAL_REJECTED,
+                NotificationDomainType.APPROVAL,
+                approvalId,
+                null,
+                false);
         eventPublisher.publishEvent(
                 new FcmSendEvent(
                         drafterId,
@@ -572,7 +620,15 @@ public class NotificationService {
         String content = NotificationMessage.APPROVAL_FINALLY_APPROVED.formatContent(docTitle);
 
         // 1. 기안자에게 알림
-        doCreateNotification(drafterId, title, content, NotificationMessage.APPROVAL_FINALLY_APPROVED, NotificationDomainType.APPROVAL, approvalId, null, false);
+        doCreateNotification(
+                drafterId,
+                title,
+                content,
+                NotificationMessage.APPROVAL_FINALLY_APPROVED,
+                NotificationDomainType.APPROVAL,
+                approvalId,
+                null,
+                false);
         eventPublisher.publishEvent(
                 new FcmSendEvent(
                         drafterId,
@@ -583,7 +639,14 @@ public class NotificationService {
         // 2. 열람권자들에게 알림
         for (Long viewerId : viewerIds) {
             doCreateNotification(
-                    viewerId, title, content, NotificationMessage.APPROVAL_FINALLY_APPROVED, NotificationDomainType.APPROVAL, approvalId, null, false);
+                    viewerId,
+                    title,
+                    content,
+                    NotificationMessage.APPROVAL_FINALLY_APPROVED,
+                    NotificationDomainType.APPROVAL,
+                    approvalId,
+                    null,
+                    false);
             eventPublisher.publishEvent(
                     new FcmSendEvent(
                             viewerId,

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/notification/NotificationEntityTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/notification/NotificationEntityTest.java
@@ -1,0 +1,119 @@
+package kr.co.awesomelead.groupware_backend.domain.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import kr.co.awesomelead.groupware_backend.domain.notification.entity.Notification;
+import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationDomainType;
+import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationMessage;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+@DisplayName("Notification 엔티티 구조 변경 테스트")
+class NotificationEntityTest {
+
+    @Nested
+    @DisplayName("messageType 필드 null 허용 (기존 of() 호환성)")
+    class MessageTypeNullability {
+
+        @Test
+        @DisplayName("of_5param_messageTypeIsNull: 5-param of() 호출 시 messageType이 null이다")
+        void of_5param_messageTypeIsNull() {
+            // given
+            Long userId = 1L;
+            String title = "제목";
+            String content = "내용";
+            NotificationDomainType domainType = NotificationDomainType.GENERAL;
+            Long domainId = 10L;
+
+            // when
+            Notification notification = Notification.of(userId, title, content, domainType, domainId);
+
+            // then
+            assertThat(notification.getMessageType()).isNull();
+        }
+
+        @Test
+        @DisplayName("of_6param_messageTypeIsNull: 6-param of() 호출 시 messageType이 null이다")
+        void of_6param_messageTypeIsNull() {
+            // given
+            Map<String, Object> metadata = Map.of("key", "value");
+
+            // when
+            Notification notification = Notification.of(
+                    1L, "제목", "내용", NotificationDomainType.GENERAL, 10L, metadata);
+
+            // then
+            assertThat(notification.getMessageType()).isNull();
+        }
+
+        @Test
+        @DisplayName("of_7param_messageTypeIsNull: 7-param of() 호출 시 messageType이 null이다")
+        void of_7param_messageTypeIsNull() {
+            // given
+            Map<String, Object> metadata = Map.of("key", "value");
+
+            // when
+            Notification notification = Notification.of(
+                    1L, "제목", "내용", NotificationDomainType.GENERAL, 10L, metadata, true);
+
+            // then
+            assertThat(notification.getMessageType()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("messageType 포함 새 of() 팩토리 메서드")
+    class MessageTypeFactory {
+
+        @Test
+        @DisplayName("of_withMessageType_5param_storesMessageType: messageType 포함 5-param of() 호출 시 값이 저장된다")
+        void of_withMessageType_5param_storesMessageType() {
+            // given
+            NotificationMessage messageType = NotificationMessage.NOTICE_CREATED;
+
+            // when
+            Notification notification = Notification.of(
+                    1L, "제목", "내용", NotificationDomainType.NOTICE, 10L, messageType);
+            assertThat(notification.getMessageType()).isEqualTo(NotificationMessage.NOTICE_CREATED);
+        }
+
+        @Test
+        @DisplayName("of_withMessageType_6param_storesMessageType: messageType 포함 6-param of() 호출 시 값이 저장된다")
+        void of_withMessageType_6param_storesMessageType() {
+            // given
+            NotificationMessage messageType = NotificationMessage.APPROVAL_CREATED_APPROVER;
+            Map<String, Object> metadata = Map.of("approvalId", 42);
+
+            // when
+            Notification notification = Notification.of(
+                    1L, "제목", "내용", NotificationDomainType.APPROVAL, 10L, metadata, messageType);
+            assertThat(notification.getMessageType()).isEqualTo(NotificationMessage.APPROVAL_CREATED_APPROVER);
+        }
+
+        @Test
+        @DisplayName("of_withMessageType_7param_storesMessageType: messageType 포함 7-param of() 호출 시 값이 저장된다")
+        void of_withMessageType_7param_storesMessageType() {
+            // given
+            NotificationMessage messageType = NotificationMessage.VISIT_LONG_TERM_PRE;
+            Map<String, Object> metadata = Map.of("visitId", 99);
+
+            // when
+            Notification notification = Notification.of(
+                    1L, "제목", "내용", NotificationDomainType.VISIT, 10L, metadata, true, messageType);
+            assertThat(notification.getMessageType()).isEqualTo(NotificationMessage.VISIT_LONG_TERM_PRE);
+        }
+
+        @Test
+        @DisplayName("of_withMessageType_null_storesNull: messageType에 null 전달 시 null로 저장된다")
+        void of_withMessageType_null_storesNull() {
+            // given / when
+            Notification notification = Notification.of(
+                    1L, "제목", "내용", NotificationDomainType.GENERAL, 10L, null, (NotificationMessage) null);
+            assertThat(notification.getMessageType()).isNull();
+        }
+    }
+}

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/notification/NotificationEntityTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/notification/NotificationEntityTest.java
@@ -30,7 +30,8 @@ class NotificationEntityTest {
             Long domainId = 10L;
 
             // when
-            Notification notification = Notification.of(userId, title, content, domainType, domainId);
+            Notification notification =
+                    Notification.of(userId, title, content, domainType, domainId);
 
             // then
             assertThat(notification.getMessageType()).isNull();
@@ -43,8 +44,8 @@ class NotificationEntityTest {
             Map<String, Object> metadata = Map.of("key", "value");
 
             // when
-            Notification notification = Notification.of(
-                    1L, "제목", "내용", NotificationDomainType.GENERAL, 10L, metadata);
+            Notification notification =
+                    Notification.of(1L, "제목", "내용", NotificationDomainType.GENERAL, 10L, metadata);
 
             // then
             assertThat(notification.getMessageType()).isNull();
@@ -57,8 +58,9 @@ class NotificationEntityTest {
             Map<String, Object> metadata = Map.of("key", "value");
 
             // when
-            Notification notification = Notification.of(
-                    1L, "제목", "내용", NotificationDomainType.GENERAL, 10L, metadata, true);
+            Notification notification =
+                    Notification.of(
+                            1L, "제목", "내용", NotificationDomainType.GENERAL, 10L, metadata, true);
 
             // then
             assertThat(notification.getMessageType()).isNull();
@@ -70,49 +72,80 @@ class NotificationEntityTest {
     class MessageTypeFactory {
 
         @Test
-        @DisplayName("of_withMessageType_5param_storesMessageType: messageType 포함 5-param of() 호출 시 값이 저장된다")
+        @DisplayName(
+                "of_withMessageType_5param_storesMessageType: messageType 포함 5-param of() 호출 시 값이"
+                    + " 저장된다")
         void of_withMessageType_5param_storesMessageType() {
             // given
             NotificationMessage messageType = NotificationMessage.NOTICE_CREATED;
 
             // when
-            Notification notification = Notification.of(
-                    1L, "제목", "내용", NotificationDomainType.NOTICE, 10L, messageType);
+            Notification notification =
+                    Notification.of(
+                            1L, "제목", "내용", NotificationDomainType.NOTICE, 10L, messageType);
             assertThat(notification.getMessageType()).isEqualTo(NotificationMessage.NOTICE_CREATED);
         }
 
         @Test
-        @DisplayName("of_withMessageType_6param_storesMessageType: messageType 포함 6-param of() 호출 시 값이 저장된다")
+        @DisplayName(
+                "of_withMessageType_6param_storesMessageType: messageType 포함 6-param of() 호출 시 값이"
+                    + " 저장된다")
         void of_withMessageType_6param_storesMessageType() {
             // given
             NotificationMessage messageType = NotificationMessage.APPROVAL_CREATED_APPROVER;
             Map<String, Object> metadata = Map.of("approvalId", 42);
 
             // when
-            Notification notification = Notification.of(
-                    1L, "제목", "내용", NotificationDomainType.APPROVAL, 10L, metadata, messageType);
-            assertThat(notification.getMessageType()).isEqualTo(NotificationMessage.APPROVAL_CREATED_APPROVER);
+            Notification notification =
+                    Notification.of(
+                            1L,
+                            "제목",
+                            "내용",
+                            NotificationDomainType.APPROVAL,
+                            10L,
+                            metadata,
+                            messageType);
+            assertThat(notification.getMessageType())
+                    .isEqualTo(NotificationMessage.APPROVAL_CREATED_APPROVER);
         }
 
         @Test
-        @DisplayName("of_withMessageType_7param_storesMessageType: messageType 포함 7-param of() 호출 시 값이 저장된다")
+        @DisplayName(
+                "of_withMessageType_7param_storesMessageType: messageType 포함 7-param of() 호출 시 값이"
+                    + " 저장된다")
         void of_withMessageType_7param_storesMessageType() {
             // given
             NotificationMessage messageType = NotificationMessage.VISIT_LONG_TERM_PRE;
             Map<String, Object> metadata = Map.of("visitId", 99);
 
             // when
-            Notification notification = Notification.of(
-                    1L, "제목", "내용", NotificationDomainType.VISIT, 10L, metadata, true, messageType);
-            assertThat(notification.getMessageType()).isEqualTo(NotificationMessage.VISIT_LONG_TERM_PRE);
+            Notification notification =
+                    Notification.of(
+                            1L,
+                            "제목",
+                            "내용",
+                            NotificationDomainType.VISIT,
+                            10L,
+                            metadata,
+                            true,
+                            messageType);
+            assertThat(notification.getMessageType())
+                    .isEqualTo(NotificationMessage.VISIT_LONG_TERM_PRE);
         }
 
         @Test
         @DisplayName("of_withMessageType_null_storesNull: messageType에 null 전달 시 null로 저장된다")
         void of_withMessageType_null_storesNull() {
             // given / when
-            Notification notification = Notification.of(
-                    1L, "제목", "내용", NotificationDomainType.GENERAL, 10L, null, (NotificationMessage) null);
+            Notification notification =
+                    Notification.of(
+                            1L,
+                            "제목",
+                            "내용",
+                            NotificationDomainType.GENERAL,
+                            10L,
+                            null,
+                            (NotificationMessage) null);
             assertThat(notification.getMessageType()).isNull();
         }
     }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/notification/NotificationServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/notification/NotificationServiceTest.java
@@ -123,7 +123,8 @@ class NotificationServiceTest {
 
         ArgumentCaptor<Notification> captor = forClass(Notification.class);
         verify(notificationRepository).save(captor.capture());
-        assertThat(captor.getValue().getMessageType()).isEqualTo(NotificationMessage.VISIT_CHECK_IN);
+        assertThat(captor.getValue().getMessageType())
+                .isEqualTo(NotificationMessage.VISIT_CHECK_IN);
     }
 
     @Test
@@ -154,7 +155,8 @@ class NotificationServiceTest {
     }
 
     @Test
-    @DisplayName("sendEduReportAlertToTargets - 저장된 Notification의 messageType이 EDU_REPORT_CREATED이다")
+    @DisplayName(
+            "sendEduReportAlertToTargets - 저장된 Notification의 messageType이 EDU_REPORT_CREATED이다")
     void sendEduReportAlertToTargets_messageType_isEduReportCreated() {
         notificationService.sendEduReportAlertToTargets("SAFETY", "교육 제목", 10L, List.of(1L));
 
@@ -174,11 +176,13 @@ class NotificationServiceTest {
 
         ArgumentCaptor<Notification> captor = forClass(Notification.class);
         verify(notificationRepository).save(captor.capture());
-        assertThat(captor.getValue().getMessageType()).isEqualTo(NotificationMessage.VISIT_CHECK_IN);
+        assertThat(captor.getValue().getMessageType())
+                .isEqualTo(NotificationMessage.VISIT_CHECK_IN);
     }
 
     @Test
-    @DisplayName("sendAnnualLeaveAlertToUser - 저장된 Notification의 messageType이 ANNUAL_LEAVE_UPDATED이다")
+    @DisplayName(
+            "sendAnnualLeaveAlertToUser - 저장된 Notification의 messageType이 ANNUAL_LEAVE_UPDATED이다")
     void sendAnnualLeaveAlertToUser_messageType_isAnnualLeaveUpdated() {
         notificationService.sendAnnualLeaveAlertToUser(1L, "2026년 01월 01일");
 
@@ -199,7 +203,9 @@ class NotificationServiceTest {
     }
 
     @Test
-    @DisplayName("sendApprovalCreatedAlert - 결재자에게 저장된 Notification의 messageType이 APPROVAL_CREATED_APPROVER이다")
+    @DisplayName(
+            "sendApprovalCreatedAlert - 결재자에게 저장된 Notification의 messageType이"
+                + " APPROVAL_CREATED_APPROVER이다")
     void sendApprovalCreatedAlert_approver_messageType() {
         notificationService.sendApprovalCreatedAlert(100L, "결재문서", 11L, List.of());
 
@@ -210,7 +216,9 @@ class NotificationServiceTest {
     }
 
     @Test
-    @DisplayName("sendApprovalCreatedAlert - 참조자에게 저장된 Notification의 messageType이 APPROVAL_CREATED_REFERRER이다")
+    @DisplayName(
+            "sendApprovalCreatedAlert - 참조자에게 저장된 Notification의 messageType이"
+                + " APPROVAL_CREATED_REFERRER이다")
     void sendApprovalCreatedAlert_referrer_messageType() {
         notificationService.sendApprovalCreatedAlert(100L, "결재문서", 11L, List.of(22L));
 
@@ -225,7 +233,9 @@ class NotificationServiceTest {
     }
 
     @Test
-    @DisplayName("sendApprovalNextStepAlert - 저장된 Notification의 messageType이 APPROVAL_CREATED_APPROVER이다")
+    @DisplayName(
+            "sendApprovalNextStepAlert - 저장된 Notification의 messageType이"
+                + " APPROVAL_CREATED_APPROVER이다")
     void sendApprovalNextStepAlert_messageType() {
         notificationService.sendApprovalNextStepAlert(33L, 100L, "결재문서");
 
@@ -242,14 +252,16 @@ class NotificationServiceTest {
 
         ArgumentCaptor<Notification> captor = forClass(Notification.class);
         verify(notificationRepository).save(captor.capture());
-        assertThat(captor.getValue().getMessageType()).isEqualTo(NotificationMessage.APPROVAL_REJECTED);
+        assertThat(captor.getValue().getMessageType())
+                .isEqualTo(NotificationMessage.APPROVAL_REJECTED);
     }
 
     @Test
-    @DisplayName("sendApprovalFinallyApprovedAlert - 기안자와 열람권자 모두 messageType이 APPROVAL_FINALLY_APPROVED이다")
+    @DisplayName(
+            "sendApprovalFinallyApprovedAlert - 기안자와 열람권자 모두 messageType이"
+                + " APPROVAL_FINALLY_APPROVED이다")
     void sendApprovalFinallyApprovedAlert_messageType() {
-        notificationService.sendApprovalFinallyApprovedAlert(
-                100L, "결재문서", 55L, List.of(66L, 77L));
+        notificationService.sendApprovalFinallyApprovedAlert(100L, "결재문서", 55L, List.of(66L, 77L));
 
         // 기안자(1) + 열람권자(2) = 3회 save
         ArgumentCaptor<Notification> captor = forClass(Notification.class);
@@ -263,7 +275,9 @@ class NotificationServiceTest {
     }
 
     @Test
-    @DisplayName("sendSafetyTrainingSessionAlertToAttendees - 저장된 Notification의 messageType이 SAFETY_TRAINING_SESSION_CREATED이다")
+    @DisplayName(
+            "sendSafetyTrainingSessionAlertToAttendees - 저장된 Notification의 messageType이"
+                + " SAFETY_TRAINING_SESSION_CREATED이다")
     void sendSafetyTrainingSessionAlertToAttendees_messageType() {
         notificationService.sendSafetyTrainingSessionAlertToAttendees(
                 200L, "안전보건교육 세션", List.of(1L));
@@ -292,7 +306,8 @@ class NotificationServiceTest {
                     Notification.of(
                             userId,
                             NotificationMessage.VISIT_CHECK_IN.getTitle(),
-                            NotificationMessage.VISIT_CHECK_IN.formatContent("홍길동", "2026-05-13 09:00"),
+                            NotificationMessage.VISIT_CHECK_IN.formatContent(
+                                    "홍길동", "2026-05-13 09:00"),
                             NotificationDomainType.VISIT,
                             99L,
                             NotificationMessage.VISIT_CHECK_IN);

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/notification/NotificationServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/notification/NotificationServiceTest.java
@@ -3,12 +3,14 @@ package kr.co.awesomelead.groupware_backend.domain.notification;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import kr.co.awesomelead.groupware_backend.domain.fcm.event.FcmSendEvent;
+import kr.co.awesomelead.groupware_backend.domain.notification.dto.response.NotificationResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.notification.entity.Notification;
 import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationDomainType;
 import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationMessage;
@@ -20,6 +22,7 @@ import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -27,11 +30,18 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
 class NotificationServiceTest {
 
     @Mock private NotificationRepository notificationRepository;
@@ -42,7 +52,7 @@ class NotificationServiceTest {
 
     @BeforeEach
     void setUp() {
-        when(notificationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        lenient().when(notificationRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
     }
 
     @Test
@@ -88,6 +98,216 @@ class NotificationServiceTest {
         Map<String, String> fcmData = fcmCaptor.getValue().data();
         assertThat(fcmData).containsKey("metadata");
         assertThat(fcmData.get("metadata")).contains("approvalTargetId");
+    }
+
+    // -------------------------------------------------------------------------
+    // messageType 검증 테스트
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("sendAlertToAdmins - 저장된 Notification의 messageType이 전달된 template과 동일하다")
+    void sendAlertToAdmins_messageType_matchesTemplate() {
+        User admin1 = mock(User.class);
+        when(admin1.getId()).thenReturn(10L);
+        when(userRepository.findAllByRole(Role.ADMIN))
+                .thenReturn(new java.util.ArrayList<>(List.of(admin1)));
+        when(userRepository.findAllByRole(Role.MASTER_ADMIN))
+                .thenReturn(new java.util.ArrayList<>());
+
+        notificationService.sendAlertToAdmins(
+                NotificationMessage.VISIT_CHECK_IN,
+                NotificationDomainType.VISIT,
+                77L,
+                "홍길동",
+                "2026-04-09 09:00");
+
+        ArgumentCaptor<Notification> captor = forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+        assertThat(captor.getValue().getMessageType()).isEqualTo(NotificationMessage.VISIT_CHECK_IN);
+    }
+
+    @Test
+    @DisplayName("sendAlertToUser - 저장된 Notification의 messageType이 전달된 template과 동일하다")
+    void sendAlertToUser_messageType_matchesTemplate() {
+        notificationService.sendAlertToUser(
+                2L,
+                NotificationMessage.APPROVAL_CREATED_APPROVER,
+                NotificationDomainType.APPROVAL,
+                20L,
+                "결재문서");
+
+        ArgumentCaptor<Notification> captor = forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+        assertThat(captor.getValue().getMessageType())
+                .isEqualTo(NotificationMessage.APPROVAL_CREATED_APPROVER);
+    }
+
+    @Test
+    @DisplayName("sendNoticeAlertToTargets - 저장된 Notification의 messageType이 NOTICE_CREATED이다")
+    void sendNoticeAlertToTargets_messageType_isNoticeCreated() {
+        notificationService.sendNoticeAlertToTargets("공지 제목", 5L, Set.of(1L));
+
+        ArgumentCaptor<Notification> captor = forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+        assertThat(captor.getValue().getMessageType())
+                .isEqualTo(NotificationMessage.NOTICE_CREATED);
+    }
+
+    @Test
+    @DisplayName("sendEduReportAlertToTargets - 저장된 Notification의 messageType이 EDU_REPORT_CREATED이다")
+    void sendEduReportAlertToTargets_messageType_isEduReportCreated() {
+        notificationService.sendEduReportAlertToTargets("SAFETY", "교육 제목", 10L, List.of(1L));
+
+        ArgumentCaptor<Notification> captor = forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+        assertThat(captor.getValue().getMessageType())
+                .isEqualTo(NotificationMessage.EDU_REPORT_CREATED);
+    }
+
+    @Test
+    @DisplayName("sendVisitAlertToDepartment - 저장된 Notification의 messageType이 전달된 template과 동일하다")
+    void sendVisitAlertToDepartment_messageType_matchesTemplate() {
+        when(userRepository.findAllIdsByDepartmentId(3L)).thenReturn(List.of(1L));
+
+        notificationService.sendVisitAlertToDepartment(
+                NotificationMessage.VISIT_CHECK_IN, 99L, 3L, "홍길동", "2026-04-09 09:00");
+
+        ArgumentCaptor<Notification> captor = forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+        assertThat(captor.getValue().getMessageType()).isEqualTo(NotificationMessage.VISIT_CHECK_IN);
+    }
+
+    @Test
+    @DisplayName("sendAnnualLeaveAlertToUser - 저장된 Notification의 messageType이 ANNUAL_LEAVE_UPDATED이다")
+    void sendAnnualLeaveAlertToUser_messageType_isAnnualLeaveUpdated() {
+        notificationService.sendAnnualLeaveAlertToUser(1L, "2026년 01월 01일");
+
+        ArgumentCaptor<Notification> captor = forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+        assertThat(captor.getValue().getMessageType())
+                .isEqualTo(NotificationMessage.ANNUAL_LEAVE_UPDATED);
+    }
+
+    @Test
+    @DisplayName("sendPayslipAlertToUser - 저장된 Notification의 messageType이 PAYSLIP_SENT이다")
+    void sendPayslipAlertToUser_messageType_isPayslipSent() {
+        notificationService.sendPayslipAlertToUser(1L, 50L);
+
+        ArgumentCaptor<Notification> captor = forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+        assertThat(captor.getValue().getMessageType()).isEqualTo(NotificationMessage.PAYSLIP_SENT);
+    }
+
+    @Test
+    @DisplayName("sendApprovalCreatedAlert - 결재자에게 저장된 Notification의 messageType이 APPROVAL_CREATED_APPROVER이다")
+    void sendApprovalCreatedAlert_approver_messageType() {
+        notificationService.sendApprovalCreatedAlert(100L, "결재문서", 11L, List.of());
+
+        ArgumentCaptor<Notification> captor = forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+        assertThat(captor.getValue().getMessageType())
+                .isEqualTo(NotificationMessage.APPROVAL_CREATED_APPROVER);
+    }
+
+    @Test
+    @DisplayName("sendApprovalCreatedAlert - 참조자에게 저장된 Notification의 messageType이 APPROVAL_CREATED_REFERRER이다")
+    void sendApprovalCreatedAlert_referrer_messageType() {
+        notificationService.sendApprovalCreatedAlert(100L, "결재문서", 11L, List.of(22L));
+
+        // 결재자(1번) + 참조자(1번) = 총 2회 save
+        ArgumentCaptor<Notification> captor = forClass(Notification.class);
+        verify(notificationRepository, times(2)).save(captor.capture());
+
+        // 두 번째 save가 참조자
+        Notification referrerNotification = captor.getAllValues().get(1);
+        assertThat(referrerNotification.getMessageType())
+                .isEqualTo(NotificationMessage.APPROVAL_CREATED_REFERRER);
+    }
+
+    @Test
+    @DisplayName("sendApprovalNextStepAlert - 저장된 Notification의 messageType이 APPROVAL_CREATED_APPROVER이다")
+    void sendApprovalNextStepAlert_messageType() {
+        notificationService.sendApprovalNextStepAlert(33L, 100L, "결재문서");
+
+        ArgumentCaptor<Notification> captor = forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+        assertThat(captor.getValue().getMessageType())
+                .isEqualTo(NotificationMessage.APPROVAL_CREATED_APPROVER);
+    }
+
+    @Test
+    @DisplayName("sendApprovalRejectedAlert - 저장된 Notification의 messageType이 APPROVAL_REJECTED이다")
+    void sendApprovalRejectedAlert_messageType() {
+        notificationService.sendApprovalRejectedAlert(44L, 100L, "결재문서", "반려 사유");
+
+        ArgumentCaptor<Notification> captor = forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+        assertThat(captor.getValue().getMessageType()).isEqualTo(NotificationMessage.APPROVAL_REJECTED);
+    }
+
+    @Test
+    @DisplayName("sendApprovalFinallyApprovedAlert - 기안자와 열람권자 모두 messageType이 APPROVAL_FINALLY_APPROVED이다")
+    void sendApprovalFinallyApprovedAlert_messageType() {
+        notificationService.sendApprovalFinallyApprovedAlert(
+                100L, "결재문서", 55L, List.of(66L, 77L));
+
+        // 기안자(1) + 열람권자(2) = 3회 save
+        ArgumentCaptor<Notification> captor = forClass(Notification.class);
+        verify(notificationRepository, times(3)).save(captor.capture());
+
+        captor.getAllValues()
+                .forEach(
+                        n ->
+                                assertThat(n.getMessageType())
+                                        .isEqualTo(NotificationMessage.APPROVAL_FINALLY_APPROVED));
+    }
+
+    @Test
+    @DisplayName("sendSafetyTrainingSessionAlertToAttendees - 저장된 Notification의 messageType이 SAFETY_TRAINING_SESSION_CREATED이다")
+    void sendSafetyTrainingSessionAlertToAttendees_messageType() {
+        notificationService.sendSafetyTrainingSessionAlertToAttendees(
+                200L, "안전보건교육 세션", List.of(1L));
+
+        ArgumentCaptor<Notification> captor = forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+        assertThat(captor.getValue().getMessageType())
+                .isEqualTo(NotificationMessage.SAFETY_TRAINING_SESSION_CREATED);
+    }
+
+    // -------------------------------------------------------------------------
+    // getNotifications - responseDto messageType 검증 테스트
+    // -------------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("getNotifications")
+    class GetNotifications {
+
+        @Test
+        @DisplayName("반환된 NotificationResponseDto에 엔티티의 messageType이 포함된다")
+        void getNotifications_responseDto_containsMessageType() {
+            // given
+            Long userId = 1L;
+            Pageable pageable = PageRequest.of(0, 10);
+            Notification notification =
+                    Notification.of(
+                            userId,
+                            NotificationMessage.VISIT_CHECK_IN.getTitle(),
+                            NotificationMessage.VISIT_CHECK_IN.formatContent("홍길동", "2026-05-13 09:00"),
+                            NotificationDomainType.VISIT,
+                            99L,
+                            NotificationMessage.VISIT_CHECK_IN);
+            Page<Notification> page = new PageImpl<>(List.of(notification));
+            when(notificationRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable))
+                    .thenReturn(page);
+
+            // when
+            Page<NotificationResponseDto> result =
+                    notificationService.getNotifications(userId, false, pageable);
+
+            // then
+            NotificationResponseDto dto = result.getContent().get(0);
+            assertThat(dto.getMessageType()).isEqualTo(NotificationMessage.VISIT_CHECK_IN);
+        }
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #333

## 📝작업 내용

- `Notification` 엔티티에 `messageType` 필드 추가 (`@Enumerated(EnumType.STRING)`, nullable)
    - 기존 `of()` 팩토리 3개는 하위 호환 유지 (`messageType = null`)
    - `messageType` 포함 새 `of()` 오버로드 3개 추가
- `NotificationService`에 `doCreateNotification()` private 메서드 도입
    - 기존 public `createNotification` 시그니처 유지
    - 13개 `send*` 헬퍼 메서드 전체를 `doCreateNotification`으로 교체 — 각 템플릿 Enum을 `messageType`으로 저장
- `NotificationResponseDto`에 `messageType` 필드 추가 및 엔티티 값 할당

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함
    - `NotificationEntityTest`: 엔티티 `messageType` 저장 검증 7개
    - `NotificationServiceTest`: 헬퍼 메서드별 `messageType` 검증 13개 + DTO 반환 검증 1개 (총 18개)
    - API 테스트: `GET /api/notifications` 응답에 `messageType` 필드 포함 확인 ✅
