### PR TITLE
fix(336): deleteUser에서 AnnualLeave JPQL 중복 삭제로 인한 StaleObjectStateException 수정

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
@@ -423,7 +423,6 @@ public class AuthService {
         deleteByQuery("delete from EduAttendance ea where ea.user.id = :userId", "userId", userId);
         deleteByQuery("delete from CheckSheet cs where cs.user.id = :userId", "userId", userId);
         deleteByQuery("delete from Payslip p where p.user.id = :userId", "userId", userId);
-        deleteByQuery("delete from AnnualLeave al where al.user.id = :userId", "userId", userId);
         deleteByQuery(
                 "delete from VisitRecord vr where vr.visit.user.id = :userId", "userId", userId);
         deleteByQuery("delete from Visit v where v.user.id = :userId", "userId", userId);

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
@@ -896,14 +896,16 @@ class AuthServiceTest {
 
             // then
             ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
-            verify(entityManager, org.mockito.Mockito.atLeastOnce()).createQuery(jpqlCaptor.capture());
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
 
             List<String> executedJpqls = jpqlCaptor.getAllValues();
-            boolean annualLeaveQueryFound = executedJpqls.stream()
-                    .anyMatch(jpql -> jpql.contains("AnnualLeave"));
+            boolean annualLeaveQueryFound =
+                    executedJpqls.stream().anyMatch(jpql -> jpql.contains("AnnualLeave"));
             assertThat(annualLeaveQueryFound)
-                    .as("AnnualLeave는 CascadeType.ALL + orphanRemoval=true로 매핑되어 있으므로"
-                            + " JPQL로 수동 삭제하면 안 된다")
+                    .as(
+                            "AnnualLeave는 CascadeType.ALL + orphanRemoval=true로 매핑되어 있으므로"
+                                    + " JPQL로 수동 삭제하면 안 된다")
                     .isFalse();
         }
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
@@ -1,7 +1,7 @@
 package kr.co.awesomelead.groupware_backend.domain.auth;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -11,6 +11,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
 
 import kr.co.awesomelead.groupware_backend.domain.aligo.service.PhoneAuthService;
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.LoginRequestDto;
@@ -41,6 +44,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -48,8 +52,10 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -71,6 +77,7 @@ class AuthServiceTest {
     @Mock private AuthenticationManager authenticationManager;
     @Mock private JWTUtil jwtUtil;
     @Mock private RefreshTokenService refreshTokenService;
+    @Mock private EntityManager entityManager;
 
     @InjectMocks private AuthService authService;
 
@@ -853,6 +860,66 @@ class AuthServiceTest {
 
             verify(bCryptPasswordEncoder).matches(OLD_PASSWORD, ENCODED_OLD_PASSWORD);
             verify(userRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 탈퇴(deleteUser)")
+    class DeleteUserTest {
+
+        private Query mockQuery;
+
+        @BeforeEach
+        void setUp() {
+            // EntityManager는 @PersistenceContext로 주입되어 @InjectMocks가 처리하지 못하므로
+            // ReflectionTestUtils로 직접 주입한다.
+            ReflectionTestUtils.setField(authService, "entityManager", entityManager);
+
+            mockQuery = org.mockito.Mockito.mock(Query.class);
+            org.mockito.BDDMockito.lenient()
+                    .when(entityManager.createQuery(anyString()))
+                    .thenReturn(mockQuery);
+            org.mockito.BDDMockito.lenient()
+                    .when(mockQuery.setParameter(anyString(), any()))
+                    .thenReturn(mockQuery);
+        }
+
+        @Test
+        @DisplayName("성공: deleteUser 실행 시 AnnualLeave JPQL 삭제 쿼리가 실행되지 않는다")
+        void deleteUser_doesNotExecuteAnnualLeaveJpqlQuery() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce()).createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+            boolean annualLeaveQueryFound = executedJpqls.stream()
+                    .anyMatch(jpql -> jpql.contains("AnnualLeave"));
+            assertThat(annualLeaveQueryFound)
+                    .as("AnnualLeave는 CascadeType.ALL + orphanRemoval=true로 매핑되어 있으므로"
+                            + " JPQL로 수동 삭제하면 안 된다")
+                    .isFalse();
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 userId로 deleteUser 호출 시 USER_NOT_FOUND 예외가 발생한다")
+        void deleteUser_throwsWhenUserNotFound() {
+            // given
+            Long nonExistentUserId = 999L;
+            given(userRepository.findById(nonExistentUserId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> authService.deleteUser(nonExistentUserId))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+
+            verify(entityManager, never()).createQuery(anyString());
         }
     }
 }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/notification/NotificationEntityTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/notification/NotificationEntityTest.java
@@ -74,7 +74,7 @@ class NotificationEntityTest {
         @Test
         @DisplayName(
                 "of_withMessageType_5param_storesMessageType: messageType 포함 5-param of() 호출 시 값이"
-                    + " 저장된다")
+                        + " 저장된다")
         void of_withMessageType_5param_storesMessageType() {
             // given
             NotificationMessage messageType = NotificationMessage.NOTICE_CREATED;
@@ -89,7 +89,7 @@ class NotificationEntityTest {
         @Test
         @DisplayName(
                 "of_withMessageType_6param_storesMessageType: messageType 포함 6-param of() 호출 시 값이"
-                    + " 저장된다")
+                        + " 저장된다")
         void of_withMessageType_6param_storesMessageType() {
             // given
             NotificationMessage messageType = NotificationMessage.APPROVAL_CREATED_APPROVER;
@@ -112,7 +112,7 @@ class NotificationEntityTest {
         @Test
         @DisplayName(
                 "of_withMessageType_7param_storesMessageType: messageType 포함 7-param of() 호출 시 값이"
-                    + " 저장된다")
+                        + " 저장된다")
         void of_withMessageType_7param_storesMessageType() {
             // given
             NotificationMessage messageType = NotificationMessage.VISIT_LONG_TERM_PRE;

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/notification/NotificationServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/notification/NotificationServiceTest.java
@@ -205,7 +205,7 @@ class NotificationServiceTest {
     @Test
     @DisplayName(
             "sendApprovalCreatedAlert - 결재자에게 저장된 Notification의 messageType이"
-                + " APPROVAL_CREATED_APPROVER이다")
+                    + " APPROVAL_CREATED_APPROVER이다")
     void sendApprovalCreatedAlert_approver_messageType() {
         notificationService.sendApprovalCreatedAlert(100L, "결재문서", 11L, List.of());
 
@@ -218,7 +218,7 @@ class NotificationServiceTest {
     @Test
     @DisplayName(
             "sendApprovalCreatedAlert - 참조자에게 저장된 Notification의 messageType이"
-                + " APPROVAL_CREATED_REFERRER이다")
+                    + " APPROVAL_CREATED_REFERRER이다")
     void sendApprovalCreatedAlert_referrer_messageType() {
         notificationService.sendApprovalCreatedAlert(100L, "결재문서", 11L, List.of(22L));
 
@@ -235,7 +235,7 @@ class NotificationServiceTest {
     @Test
     @DisplayName(
             "sendApprovalNextStepAlert - 저장된 Notification의 messageType이"
-                + " APPROVAL_CREATED_APPROVER이다")
+                    + " APPROVAL_CREATED_APPROVER이다")
     void sendApprovalNextStepAlert_messageType() {
         notificationService.sendApprovalNextStepAlert(33L, 100L, "결재문서");
 
@@ -259,7 +259,7 @@ class NotificationServiceTest {
     @Test
     @DisplayName(
             "sendApprovalFinallyApprovedAlert - 기안자와 열람권자 모두 messageType이"
-                + " APPROVAL_FINALLY_APPROVED이다")
+                    + " APPROVAL_FINALLY_APPROVED이다")
     void sendApprovalFinallyApprovedAlert_messageType() {
         notificationService.sendApprovalFinallyApprovedAlert(100L, "결재문서", 55L, List.of(66L, 77L));
 
@@ -277,7 +277,7 @@ class NotificationServiceTest {
     @Test
     @DisplayName(
             "sendSafetyTrainingSessionAlertToAttendees - 저장된 Notification의 messageType이"
-                + " SAFETY_TRAINING_SESSION_CREATED이다")
+                    + " SAFETY_TRAINING_SESSION_CREATED이다")
     void sendSafetyTrainingSessionAlertToAttendees_messageType() {
         notificationService.sendSafetyTrainingSessionAlertToAttendees(
                 200L, "안전보건교육 세션", List.of(1L));


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #336

## 📝작업 내용

- `AuthService.deleteUser` 메서드에서 불필요한 AnnualLeave JPQL 삭제 로직 제거
  - `deleteByQuery("delete from AnnualLeave al where al.user.id = :userId", ...)` 라인 삭제
  - `User ↔ AnnualLeave`는 `CascadeType.ALL + orphanRemoval=true` 관계로 `userRepository.delete(user)` 시 Hibernate가 자동 삭제 처리하므로 명시적 삭제 불필요

## 📸 스크린샷 (선택)

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)

- X