### PR TITLE
fix(339): 유저 삭제 시 safety_training_sessions FK 제약 조건 위반 해결

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
@@ -17,6 +17,7 @@ import kr.co.awesomelead.groupware_backend.domain.auth.dto.response.SignupRespon
 import kr.co.awesomelead.groupware_backend.domain.auth.entity.RefreshToken;
 import kr.co.awesomelead.groupware_backend.domain.auth.util.JWTUtil;
 import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationDomainType;
+import kr.co.awesomelead.groupware_backend.domain.safetytraining.repository.SafetyTrainingSessionRepository;
 import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationMessage;
 import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
 import kr.co.awesomelead.groupware_backend.domain.user.dto.response.MyInfoAuthorityItemDto;
@@ -63,6 +64,7 @@ public class AuthService {
     private final JWTUtil jwtUtil;
     private final RefreshTokenService refreshTokenService;
     private final NotificationService notificationService;
+    private final SafetyTrainingSessionRepository safetyTrainingSessionRepository;
 
     @PersistenceContext private EntityManager entityManager;
 
@@ -448,6 +450,7 @@ public class AuthService {
 
         // 2) 권한 테이블 정리 후 사용자 삭제
         user.getAuthorities().clear();
+        safetyTrainingSessionRepository.updateCreatedByToNull(userId);
         userRepository.delete(user);
 
         log.info("계정 삭제 완료 - userId: {}, email: {}", userId, user.getEmail());

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
@@ -17,9 +17,9 @@ import kr.co.awesomelead.groupware_backend.domain.auth.dto.response.SignupRespon
 import kr.co.awesomelead.groupware_backend.domain.auth.entity.RefreshToken;
 import kr.co.awesomelead.groupware_backend.domain.auth.util.JWTUtil;
 import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationDomainType;
-import kr.co.awesomelead.groupware_backend.domain.safetytraining.repository.SafetyTrainingSessionRepository;
 import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationMessage;
 import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
+import kr.co.awesomelead.groupware_backend.domain.safetytraining.repository.SafetyTrainingSessionRepository;
 import kr.co.awesomelead.groupware_backend.domain.user.dto.response.MyInfoAuthorityItemDto;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Authority;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/repository/SafetyTrainingSessionRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/repository/SafetyTrainingSessionRepository.java
@@ -8,6 +8,7 @@ import kr.co.awesomelead.groupware_backend.domain.safetytraining.enums.SafetyTra
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -45,4 +46,8 @@ public interface SafetyTrainingSessionRepository
 
     Optional<SafetyTrainingSession> findFirstByCompanyScopeAndIdLessThanOrderByIdDesc(
             Company companyScope, Long sessionId);
+
+    @Modifying
+    @Query("UPDATE SafetyTrainingSession s SET s.createdBy = NULL WHERE s.createdBy.id = :userId")
+    void updateCreatedByToNull(@Param("userId") Long userId);
 }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
@@ -7,13 +7,18 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.mockito.InOrder;
+
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
+
+import kr.co.awesomelead.groupware_backend.domain.safetytraining.repository.SafetyTrainingSessionRepository;
 
 import kr.co.awesomelead.groupware_backend.domain.aligo.service.PhoneAuthService;
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.LoginRequestDto;
@@ -78,6 +83,7 @@ class AuthServiceTest {
     @Mock private JWTUtil jwtUtil;
     @Mock private RefreshTokenService refreshTokenService;
     @Mock private EntityManager entityManager;
+    @Mock private SafetyTrainingSessionRepository safetyTrainingSessionRepository;
 
     @InjectMocks private AuthService authService;
 
@@ -922,6 +928,32 @@ class AuthServiceTest {
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
 
             verify(entityManager, never()).createQuery(anyString());
+        }
+
+        @Test
+        @DisplayName("성공: deleteUser 실행 시 userRepository.delete() 전에 safetyTrainingSessionRepository.updateCreatedByToNull()이 호출된다")
+        void deleteUser_callsUpdateCreatedByToNullBeforeDelete() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+            verify(safetyTrainingSessionRepository).updateCreatedByToNull(userId);
+        }
+
+        @Test
+        @DisplayName("성공: deleteUser 실행 시 safetyTrainingSessionRepository.updateCreatedByToNull()이 userRepository.delete() 보다 먼저 호출된다 - 호출 순서 검증")
+        void deleteUser_updateCreatedByToNullCalledBeforeDeleteInOrder() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+            InOrder inOrder = inOrder(safetyTrainingSessionRepository, userRepository);
+            inOrder.verify(safetyTrainingSessionRepository).updateCreatedByToNull(userId);
+            inOrder.verify(userRepository).delete(testUser);
         }
     }
 }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
@@ -13,12 +13,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.mockito.InOrder;
-
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
-
-import kr.co.awesomelead.groupware_backend.domain.safetytraining.repository.SafetyTrainingSessionRepository;
 
 import kr.co.awesomelead.groupware_backend.domain.aligo.service.PhoneAuthService;
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.LoginRequestDto;
@@ -34,6 +30,7 @@ import kr.co.awesomelead.groupware_backend.domain.auth.service.RefreshTokenServi
 import kr.co.awesomelead.groupware_backend.domain.auth.util.JWTUtil;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
+import kr.co.awesomelead.groupware_backend.domain.safetytraining.repository.SafetyTrainingSessionRepository;
 import kr.co.awesomelead.groupware_backend.domain.user.dto.response.MyInfoAuthorityItemDto;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Authority;
@@ -50,6 +47,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -931,7 +929,9 @@ class AuthServiceTest {
         }
 
         @Test
-        @DisplayName("성공: deleteUser 실행 시 userRepository.delete() 전에 safetyTrainingSessionRepository.updateCreatedByToNull()이 호출된다")
+        @DisplayName(
+                "성공: deleteUser 실행 시 userRepository.delete() 전에"
+                    + " safetyTrainingSessionRepository.updateCreatedByToNull()이 호출된다")
         void deleteUser_callsUpdateCreatedByToNullBeforeDelete() {
             // given
             Long userId = 1L;
@@ -943,7 +943,9 @@ class AuthServiceTest {
         }
 
         @Test
-        @DisplayName("성공: deleteUser 실행 시 safetyTrainingSessionRepository.updateCreatedByToNull()이 userRepository.delete() 보다 먼저 호출된다 - 호출 순서 검증")
+        @DisplayName(
+                "성공: deleteUser 실행 시 safetyTrainingSessionRepository.updateCreatedByToNull()이"
+                    + " userRepository.delete() 보다 먼저 호출된다 - 호출 순서 검증")
         void deleteUser_updateCreatedByToNullCalledBeforeDeleteInOrder() {
             // given
             Long userId = 1L;


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #339

## 📝작업 내용

- `SafetyTrainingSessionRepository`에 `created_by` NULL 업데이트 JPQL 쿼리 추가
  - `@Modifying` + `UPDATE SafetyTrainingSession SET createdBy = NULL WHERE createdBy.id = :userId`
- `AuthService.deleteUser()`에서 `userRepository.delete()` 호출 직전 `updateCreatedByToNull()` 선행 실행
  - 퇴사자/삭제자의 교육 기록은 보존하고 생성자 정보만 NULL 처리하여 FK 제약 조건 위반 해결

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)

- `deleteUser` 내 삭제 순서: `updateCreatedByToNull()` → `userRepository.delete()` 순서가 보장되어야 FK 위반이 발생하지 않음 (InOrder 테스트로 검증 완료)