### PR TITLE
fix(340): FCM 비동기 무효 토큰 삭제 트랜잭션 오류 및 @Recover 시그니처 수정

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/fcm/service/FcmService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/fcm/service/FcmService.java
@@ -30,6 +30,7 @@ import java.util.Map;
 public class FcmService {
 
     private final FcmTokenRepository fcmTokenRepository;
+    private final FcmTokenService fcmTokenService;
 
     /** 특정 유저의 모든 디바이스로 메시지 발송 */
     @Async("fcmTaskExecutor")
@@ -78,7 +79,7 @@ public class FcmService {
                             userId,
                             invalidToken.substring(0, 10),
                             invalidToken.substring(invalidToken.length() - 6));
-                    fcmTokenRepository.deleteByToken(invalidToken);
+                    fcmTokenService.removeInvalidToken(invalidToken);
                 }
             }
         }
@@ -86,15 +87,14 @@ public class FcmService {
 
     @Recover
     public void recoverSendToUser(
-            FirebaseMessagingException e,
+            Exception e,
             Long userId,
             String title,
             String body,
             Map<String, String> data) {
         log.error(
-                "FCM 전송 최종 실패 (Retry 종료) - userId: {}, errorCode: {}, error: {}",
+                "FCM 전송 최종 실패 (Retry 종료) - userId: {}, error: {}",
                 userId,
-                e.getMessagingErrorCode(),
                 e.getMessage());
 
         // API 레벨 실패(네트워크/인증 오류)이므로 토큰 삭제 없이 로그만 기록
@@ -120,7 +120,7 @@ public class FcmService {
 
     @Recover
     public void recoverSendToTopic(
-            FirebaseMessagingException e, String topicName, String title, String body) {
+            Exception e, String topicName, String title, String body) {
         log.error("FCM 전송 최종 실패 (Retry 종료) - topic: {}, error: {}", topicName, e.getMessage());
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/fcm/service/FcmService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/fcm/service/FcmService.java
@@ -87,15 +87,8 @@ public class FcmService {
 
     @Recover
     public void recoverSendToUser(
-            Exception e,
-            Long userId,
-            String title,
-            String body,
-            Map<String, String> data) {
-        log.error(
-                "FCM 전송 최종 실패 (Retry 종료) - userId: {}, error: {}",
-                userId,
-                e.getMessage());
+            Exception e, Long userId, String title, String body, Map<String, String> data) {
+        log.error("FCM 전송 최종 실패 (Retry 종료) - userId: {}, error: {}", userId, e.getMessage());
 
         // API 레벨 실패(네트워크/인증 오류)이므로 토큰 삭제 없이 로그만 기록
     }
@@ -119,8 +112,7 @@ public class FcmService {
     }
 
     @Recover
-    public void recoverSendToTopic(
-            Exception e, String topicName, String title, String body) {
+    public void recoverSendToTopic(Exception e, String topicName, String title, String body) {
         log.error("FCM 전송 최종 실패 (Retry 종료) - topic: {}, error: {}", topicName, e.getMessage());
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/fcm/service/FcmTokenService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/fcm/service/FcmTokenService.java
@@ -45,6 +45,12 @@ public class FcmTokenService {
         }
     }
 
+    /** 무효 토큰 삭제 (Firebase UNREGISTERED 응답 시) */
+    @Transactional
+    public void removeInvalidToken(String token) {
+        fcmTokenRepository.deleteByToken(token);
+    }
+
     /** FCM 토큰 삭제 (로그아웃 시) */
     @Transactional
     public void deleteToken(Long userId, String token) {

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
@@ -931,7 +931,7 @@ class AuthServiceTest {
         @Test
         @DisplayName(
                 "성공: deleteUser 실행 시 userRepository.delete() 전에"
-                    + " safetyTrainingSessionRepository.updateCreatedByToNull()이 호출된다")
+                        + " safetyTrainingSessionRepository.updateCreatedByToNull()이 호출된다")
         void deleteUser_callsUpdateCreatedByToNullBeforeDelete() {
             // given
             Long userId = 1L;
@@ -945,7 +945,7 @@ class AuthServiceTest {
         @Test
         @DisplayName(
                 "성공: deleteUser 실행 시 safetyTrainingSessionRepository.updateCreatedByToNull()이"
-                    + " userRepository.delete() 보다 먼저 호출된다 - 호출 순서 검증")
+                        + " userRepository.delete() 보다 먼저 호출된다 - 호출 순서 검증")
         void deleteUser_updateCreatedByToNullCalledBeforeDeleteInOrder() {
             // given
             Long userId = 1L;

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/fcm/FcmServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/fcm/FcmServiceTest.java
@@ -18,6 +18,7 @@ import com.google.firebase.messaging.SendResponse;
 import kr.co.awesomelead.groupware_backend.domain.fcm.entity.FcmToken;
 import kr.co.awesomelead.groupware_backend.domain.fcm.repository.FcmTokenRepository;
 import kr.co.awesomelead.groupware_backend.domain.fcm.service.FcmService;
+import kr.co.awesomelead.groupware_backend.domain.fcm.service.FcmTokenService;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -45,8 +46,13 @@ class FcmServiceTest {
         }
 
         @Bean
-        public FcmService fcmService(FcmTokenRepository fcmTokenRepository) {
-            return new FcmService(fcmTokenRepository);
+        public FcmTokenService fcmTokenService() {
+            return mock(FcmTokenService.class);
+        }
+
+        @Bean
+        public FcmService fcmService(FcmTokenRepository fcmTokenRepository, FcmTokenService fcmTokenService) {
+            return new FcmService(fcmTokenRepository, fcmTokenService);
         }
     }
 
@@ -54,9 +60,11 @@ class FcmServiceTest {
 
     @Autowired private FcmTokenRepository fcmTokenRepository;
 
+    @Autowired private FcmTokenService fcmTokenService;
+
     @BeforeEach
     void setUp() {
-        reset(fcmTokenRepository);
+        reset(fcmTokenRepository, fcmTokenService);
     }
 
     // ─── sendToTopic ─────────────────────────────────────────────────────────
@@ -171,7 +179,7 @@ class FcmServiceTest {
 
             fcmService.sendToUser(1L, "제목", "내용", Map.of());
 
-            verify(fcmTokenRepository, times(1)).deleteByToken(tokenValue);
+            verify(fcmTokenService, times(1)).removeInvalidToken(tokenValue);
         }
     }
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/fcm/FcmServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/fcm/FcmServiceTest.java
@@ -51,7 +51,8 @@ class FcmServiceTest {
         }
 
         @Bean
-        public FcmService fcmService(FcmTokenRepository fcmTokenRepository, FcmTokenService fcmTokenService) {
+        public FcmService fcmService(
+                FcmTokenRepository fcmTokenRepository, FcmTokenService fcmTokenService) {
             return new FcmService(fcmTokenRepository, fcmTokenService);
         }
     }


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #340

## 📝작업 내용

- `FcmTokenService`에 `removeInvalidToken(@Transactional)` 메서드 추가
- `FcmService.sendToUser()` 내 `fcmTokenRepository.deleteByToken()` 직접 호출 제거
    - `@Async` 메서드 내 직접 Repository 호출은 트랜잭션 컨텍스트가 없어 `TransactionRequiredException` 발생
    - `FcmTokenService.removeInvalidToken()`에 위임하여 트랜잭션 보장 (자기참조 없이 AOP 프록시 정상 적용)
- `@Recover` 메서드(`recoverSendToUser`, `recoverSendToTopic`) 첫 번째 파라미터를 `Exception`으로 통일
    - `@Async` 컨텍스트에서 Spring Retry가 `FirebaseMessagingException` 타입의 `@Recover`를 우선 선택해 잘못된 메서드를 호출하는 문제 방지
    - 두 메서드 모두 `Exception`으로 통일하면 나머지 파라미터 타입(`Long` vs `String`)으로만 구분되어 매칭이 명확해짐

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
