### PR TITLE
feat(344): 방문 정보 수정 API에 hostId, carNumber, visitorPhoneNumber 필드 추가

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/request/MyVisitUpdateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/request/MyVisitUpdateRequestDto.java
@@ -3,6 +3,8 @@ package kr.co.awesomelead.groupware_backend.domain.visit.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.AdditionalPermissionType;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitPurpose;
@@ -22,13 +24,18 @@ import java.time.LocalTime;
 public class MyVisitUpdateRequestDto implements VisitRequest {
 
     @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 4, max = 4, message = "비밀번호는 4자리여야 합니다.")
     @Schema(description = "방문 비밀번호", example = "1234")
     private String password;
 
     @Schema(description = "내방객 이름", example = "홍길동")
     private String visitorName;
 
-    @Schema(description = "내방객 전화번호 (하이픈 제외)", example = "01012345678")
+    @Pattern(regexp = "^\\d{10,11}$", message = "전화번호는 숫자 10~11자리여야 합니다.")
+    @Schema(description = "내방객 전화번호", example = "01012345678")
+    private String visitorPhoneNumber;
+
+    @Schema(description = "내방객 소속 회사", example = "ABC 주식회사")
     private String visitorCompany;
 
     @Schema(description = "방문 목적", example = "고객 검수")
@@ -53,21 +60,9 @@ public class MyVisitUpdateRequestDto implements VisitRequest {
     @Schema(description = "퇴실 예정 시간", example = "18:00")
     private LocalTime plannedExitTime;
 
-    @Override
-    @Schema(hidden = true)
-    public String getVisitorPhoneNumber() {
-        return null;
-    }
+    @Schema(description = "차량 번호", example = "12가3456")
+    private String carNumber;
 
-    @Override
-    @Schema(hidden = true)
-    public String getCarNumber() {
-        return null;
-    }
-
-    @Override
-    @Schema(hidden = true)
-    public Long getHostId() {
-        return null;
-    }
+    @Schema(description = "담당자 직원 ID", example = "1")
+    private Long hostId;
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/entity/Visit.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/entity/Visit.java
@@ -137,7 +137,7 @@ public class Visit {
     @PreUpdate
     public void onPrePersist() {
         // 전화번호 해시 생성
-        if (this.visitorPhoneNumber != null && this.phoneNumberHash == null) {
+        if (this.visitorPhoneNumber != null) {
             this.phoneNumberHash = hashValue(this.visitorPhoneNumber);
         }
     }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/mapper/VisitMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/mapper/VisitMapper.java
@@ -174,6 +174,9 @@ public interface VisitMapper {
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "password", ignore = true)
     @Mapping(target = "status", ignore = true) // 상태는 서비스 로직에서 직접 변경하므로 무시
+    @Mapping(target = "user", ignore = true) // user는 서비스 로직에서 직접 변경하므로 무시
+    @Mapping(target = "visitorPhoneNumber", ignore = true) // 전화번호는 서비스 로직에서 hash와 함께 처리
+    @Mapping(target = "phoneNumberHash", ignore = true)
     @Mapping(target = "startDate", source = "startDate")
     @Mapping(target = "endDate", source = "endDate")
     void updateVisitFromDto(MyVisitUpdateRequestDto dto, @MappingTarget Visit visit);

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
@@ -388,6 +388,18 @@ public class VisitService {
 
         visitMapper.updateVisitFromDto(dto, visit);
 
+        if (dto.getHostId() != null) {
+            User host =
+                    userRepository
+                            .findById(dto.getHostId())
+                            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+            visit.setUser(host);
+        }
+        if (dto.getVisitorPhoneNumber() != null) {
+            visit.setVisitorPhoneNumber(dto.getVisitorPhoneNumber());
+            visit.setPhoneNumberHash(hashValue(dto.getVisitorPhoneNumber()));
+        }
+
         if (visit.getVisitCategory() != VisitCategory.PRE_LONG_TERM) {
             visit.setEndDate(visit.getStartDate());
         }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
@@ -469,6 +469,68 @@ public class VisitServiceTest {
                         .hasMessage("승인 가능한 상태가 아닙니다."); // ErrorCode.INVALID_VISIT_STATUS
             }
         }
+
+        @Nested
+        @DisplayName("hostId가 주어지면")
+        class Context_with_host_id {
+
+            @Test
+            @DisplayName("담당자가 새 User로 변경된다.")
+            void it_updates_host() {
+                // given
+                Long newHostId = 2L;
+                MyVisitUpdateRequestDto dto =
+                        MyVisitUpdateRequestDto.builder()
+                                .password(PLAIN_PASSWORD)
+                                .hostId(newHostId)
+                                .build();
+
+                Visit visit = createBaseVisit(VisitStatus.NOT_VISITED, VisitCategory.PRE_ONE_DAY);
+                User newHost = User.builder().id(newHostId).build();
+
+                given(visitRepository.findById(VISIT_ID)).willReturn(Optional.of(visit));
+                given(passwordEncoder.matches(PLAIN_PASSWORD, ENCODED_PASSWORD)).willReturn(true);
+                given(userRepository.findById(newHostId)).willReturn(Optional.of(newHost));
+
+                // when
+                visitService.updateMyVisit(VISIT_ID, dto);
+
+                // then
+                assertThat(visit.getUser()).isNotNull();
+                assertThat(visit.getUser().getId()).isEqualTo(newHostId);
+            }
+        }
+
+        @Nested
+        @DisplayName("visitorPhoneNumber가 주어지면")
+        class Context_with_visitor_phone_number {
+
+            @Test
+            @DisplayName("전화번호와 phoneNumberHash가 함께 업데이트된다.")
+            void it_updates_phone_and_hash() {
+                // given
+                String newPhone = "01099998888";
+                MyVisitUpdateRequestDto dto =
+                        MyVisitUpdateRequestDto.builder()
+                                .password(PLAIN_PASSWORD)
+                                .visitorPhoneNumber(newPhone)
+                                .build();
+
+                Visit visit = createBaseVisit(VisitStatus.NOT_VISITED, VisitCategory.PRE_ONE_DAY);
+                visit.setPhoneNumberHash("old-hash");
+
+                given(visitRepository.findById(VISIT_ID)).willReturn(Optional.of(visit));
+                given(passwordEncoder.matches(PLAIN_PASSWORD, ENCODED_PASSWORD)).willReturn(true);
+
+                // when
+                visitService.updateMyVisit(VISIT_ID, dto);
+
+                // then
+                assertThat(visit.getVisitorPhoneNumber()).isEqualTo(newPhone);
+                assertThat(visit.getPhoneNumberHash()).isNotNull();
+                assertThat(visit.getPhoneNumberHash()).isEqualTo(Visit.hashValue(newPhone));
+            }
+        }
     }
 
     @Nested


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #344

## 📝작업 내용

- `MyVisitUpdateRequestDto`에 `visitorPhoneNumber`, `carNumber`, `hostId` 필드 추가
    - 기존에 null을 반환하던 `@Override` 메서드 3개를 실제 필드로 교체 (Lombok `@Getter` 활용)
    - `visitorCompany` `@Schema` 설명 오탈자 수정 ("내방객 소속 회사")
- `VisitService.updateMyVisit`에 신규 필드 수정 로직 추가
    - `hostId` non-null 시 `userRepository` 조회 후 `visit.setUser()` 호출
    - `visitorPhoneNumber` non-null 시 전화번호와 `phoneNumberHash` 동시 갱신
- `VisitMapper.updateVisitFromDto`에 `user`, `visitorPhoneNumber`, `phoneNumberHash` ignore 명시
    - `carNumber`는 필드명 동일로 MapStruct 자동 매핑 유지
- `Visit.onPrePersist` 해시 로직 개선: `phoneNumberHash == null` 조건 제거 → 항상 최신화 보장
- `MyVisitUpdateRequestDto` 입력 검증 추가: `@Pattern`(전화번호 10~11자리), `@Size`(비밀번호 4자리)

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)

- `visitorPhoneNumber` 수정은 매퍼에서 ignore하고 서비스에서 직접 처리 — hash 동시 갱신이 필요하기 때문
- `carNumber`는 서비스 개입 없이 MapStruct 자동 매핑으로만 처리