### PR TITLE
fix(348): 사용자 삭제 시 safety_training_sessions NOT NULL 제약 조건 충돌 해결

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
@@ -451,6 +451,7 @@ public class AuthService {
         // 2) 권한 테이블 정리 후 사용자 삭제
         user.getAuthorities().clear();
         safetyTrainingSessionRepository.updateCreatedByToNull(userId);
+        safetyTrainingSessionRepository.updateInstructorUserToNull(userId);
         userRepository.delete(user);
 
         log.info("계정 삭제 완료 - userId: {}, email: {}", userId, user.getEmail());

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/entity/SafetyTrainingSession.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/entity/SafetyTrainingSession.java
@@ -73,7 +73,7 @@ public class SafetyTrainingSession {
     private Company companyScope;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "instructor_user_id", nullable = false)
+    @JoinColumn(name = "instructor_user_id")
     private User instructorUser;
 
     @Column(name = "instructor_name_snapshot", nullable = false, length = 100)
@@ -104,7 +104,7 @@ public class SafetyTrainingSession {
     private String reportFileKey;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "created_by", nullable = false)
+    @JoinColumn(name = "created_by", nullable = true)
     private User createdBy;
 
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/repository/SafetyTrainingSessionRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/repository/SafetyTrainingSessionRepository.java
@@ -50,4 +50,9 @@ public interface SafetyTrainingSessionRepository
     @Modifying
     @Query("UPDATE SafetyTrainingSession s SET s.createdBy = NULL WHERE s.createdBy.id = :userId")
     void updateCreatedByToNull(@Param("userId") Long userId);
+
+    @Modifying
+    @Query(
+            "UPDATE SafetyTrainingSession s SET s.instructorUser = NULL WHERE s.instructorUser.id = :userId")
+    void updateInstructorUserToNull(@Param("userId") Long userId);
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/repository/SafetyTrainingSessionRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/repository/SafetyTrainingSessionRepository.java
@@ -53,6 +53,7 @@ public interface SafetyTrainingSessionRepository
 
     @Modifying
     @Query(
-            "UPDATE SafetyTrainingSession s SET s.instructorUser = NULL WHERE s.instructorUser.id = :userId")
+            "UPDATE SafetyTrainingSession s SET s.instructorUser = NULL WHERE s.instructorUser.id ="
+                + " :userId")
     void updateInstructorUserToNull(@Param("userId") Long userId);
 }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
@@ -957,5 +957,39 @@ class AuthServiceTest {
             inOrder.verify(safetyTrainingSessionRepository).updateCreatedByToNull(userId);
             inOrder.verify(userRepository).delete(testUser);
         }
+
+        @Test
+        @DisplayName(
+                "성공: deleteUser 실행 시"
+                        + " safetyTrainingSessionRepository.updateInstructorUserToNull()이 호출된다")
+        void deleteUser_callsUpdateInstructorUserToNull_success() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            verify(safetyTrainingSessionRepository).updateInstructorUserToNull(userId);
+        }
+
+        @Test
+        @DisplayName(
+                "성공: deleteUser 실행 시 safetyTrainingSessionRepository.updateInstructorUserToNull()이"
+                        + " userRepository.delete() 보다 먼저 호출된다 - 호출 순서 검증")
+        void deleteUser_updateInstructorUserToNullCalledBeforeDeleteInOrder() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            InOrder inOrder = inOrder(safetyTrainingSessionRepository, userRepository);
+            inOrder.verify(safetyTrainingSessionRepository).updateInstructorUserToNull(userId);
+            inOrder.verify(userRepository).delete(testUser);
+        }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #348

## 📝작업 내용

- `SafetyTrainingSession` 엔티티의 `instructorUser`, `createdBy` 필드 `@JoinColumn` nullable 제약 해제
    - 강사/작성자가 삭제되어도 교육 이력을 보존하기 위함 (`instructorNameSnapshot` 존재)
- `SafetyTrainingSessionRepository`에 `updateInstructorUserToNull(Long userId)` JPQL 메서드 추가
- `AuthService.deleteUser()` 내 강사 참조 해제 로직 추가
    - `updateInstructorUserToNull()` 호출을 `userRepository.delete()` 이전에 수행

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)

- 운영 DB 반영 필요: `ALTER TABLE safety_training_sessions MODIFY created_by BIGINT NULL;` / `MODIFY instructor_user_id BIGINT NULL;`