### PR TITLE
fix(351): 장기 방문자 재입실 버그 수정 및 checkIn 검증 로직 캡슐화

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/repository/SafetyTrainingSessionRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/repository/SafetyTrainingSessionRepository.java
@@ -54,6 +54,6 @@ public interface SafetyTrainingSessionRepository
     @Modifying
     @Query(
             "UPDATE SafetyTrainingSession s SET s.instructorUser = NULL WHERE s.instructorUser.id ="
-                + " :userId")
+                    + " :userId")
     void updateInstructorUserToNull(@Param("userId") Long userId);
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/entity/Visit.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/entity/Visit.java
@@ -28,6 +28,8 @@ import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitCategory;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitPurpose;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitStatus;
 import kr.co.awesomelead.groupware_backend.global.encryption.Encryptor;
+import kr.co.awesomelead.groupware_backend.global.error.CustomException;
+import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -152,6 +154,26 @@ public class Visit {
             return Base64.getEncoder().encodeToString(hash);
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException("SHA-256 알고리즘 부재", e);
+        }
+    }
+
+    public void validateCheckInEligible() {
+        if (this.status == VisitStatus.IN_PROGRESS) {
+            throw new CustomException(ErrorCode.ALREADY_CHECKED_IN);
+        }
+
+        if (this.visitCategory == VisitCategory.PRE_LONG_TERM) {
+            LocalDate today = LocalDate.now();
+            if (today.isBefore(this.startDate) || today.isAfter(this.endDate)) {
+                throw new CustomException(ErrorCode.NOT_VISIT_DATE);
+            }
+        } else {
+            if (!this.startDate.equals(LocalDate.now())) {
+                throw new CustomException(ErrorCode.NOT_VISIT_DATE);
+            }
+            if (this.visited) {
+                throw new CustomException(ErrorCode.VISIT_ALREADY_CHECKED_OUT);
+            }
         }
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
@@ -227,15 +227,8 @@ public class VisitService {
                         .findById(dto.getVisitId())
                         .orElseThrow(() -> new CustomException(ErrorCode.VISIT_NOT_FOUND));
 
-        // 2. 날짜 검증 (하루 방문의 경우 오늘 날짜인지 확인)
-        if (visit.getVisitCategory() != VisitCategory.PRE_LONG_TERM
-                && !visit.getStartDate().equals(LocalDate.now())) {
-            throw new CustomException(ErrorCode.NOT_VISIT_DATE); // "방문 예정일이 아닙니다" 에러
-        }
-
-        if (visit.isVisited()) {
-            throw new CustomException(ErrorCode.VISIT_ALREADY_CHECKED_OUT);
-        }
+        // 2. 입실 가능 상태 검증
+        visit.validateCheckInEligible();
 
         // 5. 서명 이미지 S3 업로드
         String signatureKey = s3Service.uploadFile(dto.getSignatureFile());

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "이메일 인증이 필요합니다."),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     VISIT_ALREADY_CHECKED_OUT(HttpStatus.BAD_REQUEST, "이미 체크아웃된 방문정보입니다."),
+    ALREADY_CHECKED_IN(HttpStatus.BAD_REQUEST, "이미 입실 처리된 방문정보입니다."),
     VISITOR_PASSWORD_REQUIRED_FOR_PRE_REGISTRATION(
             HttpStatus.BAD_REQUEST, "사전 방문 예약 시 내방객 비밀번호가 필요합니다."),
     DEPARTMENT_ID_REQUIRED(HttpStatus.BAD_REQUEST, "부서교육인 경우 부서 ID가 필요합니다."),

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
@@ -624,18 +624,21 @@ public class VisitServiceTest {
                 // given
                 Long visitId = 200L;
                 Long adminId = 2L;
-                MockMultipartFile sig = new MockMultipartFile("signature", "sig.png", "image/png", "test".getBytes());
+                MockMultipartFile sig =
+                        new MockMultipartFile(
+                                "signature", "sig.png", "image/png", "test".getBytes());
                 CheckInRequestDto checkInDto = new CheckInRequestDto(visitId, sig);
 
-                Visit visit = Visit.builder()
-                        .id(visitId)
-                        .status(VisitStatus.APPROVED)
-                        .visitCategory(VisitCategory.PRE_LONG_TERM)
-                        .startDate(LocalDate.now().minusDays(5))
-                        .endDate(LocalDate.now().plusDays(5))
-                        .records(new ArrayList<>())
-                        .visited(false)
-                        .build();
+                Visit visit =
+                        Visit.builder()
+                                .id(visitId)
+                                .status(VisitStatus.APPROVED)
+                                .visitCategory(VisitCategory.PRE_LONG_TERM)
+                                .startDate(LocalDate.now().minusDays(5))
+                                .endDate(LocalDate.now().plusDays(5))
+                                .records(new ArrayList<>())
+                                .visited(false)
+                                .build();
 
                 User admin = User.builder().id(adminId).jobType(JobType.MANAGEMENT).build();
                 admin.addAuthority(Authority.MANAGE_VISITOR);
@@ -652,7 +655,8 @@ public class VisitServiceTest {
 
                 // 2. 퇴실 처리
                 given(userRepository.findById(adminId)).willReturn(Optional.of(admin));
-                CheckOutRequestDto checkOutDto = new CheckOutRequestDto(visitId, recordId, LocalDateTime.now());
+                CheckOutRequestDto checkOutDto =
+                        new CheckOutRequestDto(visitId, recordId, LocalDateTime.now());
                 visitService.checkOut(adminId, checkOutDto);
                 assertThat(visit.getStatus()).isEqualTo(VisitStatus.APPROVED);
 
@@ -672,18 +676,21 @@ public class VisitServiceTest {
             void it_throws_already_checked_in() throws IOException {
                 // given
                 Long visitId = 201L;
-                MockMultipartFile sig = new MockMultipartFile("signature", "sig.png", "image/png", "test".getBytes());
+                MockMultipartFile sig =
+                        new MockMultipartFile(
+                                "signature", "sig.png", "image/png", "test".getBytes());
                 CheckInRequestDto dto = new CheckInRequestDto(visitId, sig);
 
-                Visit visit = Visit.builder()
-                        .id(visitId)
-                        .status(VisitStatus.IN_PROGRESS)
-                        .visitCategory(VisitCategory.PRE_LONG_TERM)
-                        .startDate(LocalDate.now().minusDays(5))
-                        .endDate(LocalDate.now().plusDays(5))
-                        .records(new ArrayList<>())
-                        .visited(true)
-                        .build();
+                Visit visit =
+                        Visit.builder()
+                                .id(visitId)
+                                .status(VisitStatus.IN_PROGRESS)
+                                .visitCategory(VisitCategory.PRE_LONG_TERM)
+                                .startDate(LocalDate.now().minusDays(5))
+                                .endDate(LocalDate.now().plusDays(5))
+                                .records(new ArrayList<>())
+                                .visited(true)
+                                .build();
 
                 given(visitRepository.findById(visitId)).willReturn(Optional.of(visit));
 
@@ -703,18 +710,21 @@ public class VisitServiceTest {
             void it_throws_not_visit_date_for_long_term() throws IOException {
                 // given
                 Long visitId = 202L;
-                MockMultipartFile sig = new MockMultipartFile("signature", "sig.png", "image/png", "test".getBytes());
+                MockMultipartFile sig =
+                        new MockMultipartFile(
+                                "signature", "sig.png", "image/png", "test".getBytes());
                 CheckInRequestDto dto = new CheckInRequestDto(visitId, sig);
 
-                Visit visit = Visit.builder()
-                        .id(visitId)
-                        .status(VisitStatus.APPROVED)
-                        .visitCategory(VisitCategory.PRE_LONG_TERM)
-                        .startDate(LocalDate.now().plusDays(10))
-                        .endDate(LocalDate.now().plusDays(20))
-                        .records(new ArrayList<>())
-                        .visited(false)
-                        .build();
+                Visit visit =
+                        Visit.builder()
+                                .id(visitId)
+                                .status(VisitStatus.APPROVED)
+                                .visitCategory(VisitCategory.PRE_LONG_TERM)
+                                .startDate(LocalDate.now().plusDays(10))
+                                .endDate(LocalDate.now().plusDays(20))
+                                .records(new ArrayList<>())
+                                .visited(false)
+                                .build();
 
                 given(visitRepository.findById(visitId)).willReturn(Optional.of(visit));
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
@@ -34,6 +34,7 @@ import kr.co.awesomelead.groupware_backend.domain.visit.repository.VisitReposito
 import kr.co.awesomelead.groupware_backend.domain.visit.repository.querydsl.VisitQueryRepository;
 import kr.co.awesomelead.groupware_backend.domain.visit.service.VisitService;
 import kr.co.awesomelead.groupware_backend.global.error.CustomException;
+import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
 import kr.co.awesomelead.groupware_backend.global.infra.s3.service.S3Service;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -610,6 +611,117 @@ public class VisitServiceTest {
                         .isEqualTo("s3-signature-key");
 
                 verify(s3Service, times(1)).uploadFile(any());
+            }
+        }
+
+        @Nested
+        @DisplayName("장기 방문자가 한 번 입퇴실한 후 다시 입실을 시도하면")
+        class Context_long_term_reentry {
+
+            @Test
+            @DisplayName("정상적으로 재입실할 수 있어야 한다")
+            void it_allows_reentry_for_long_term_visit() throws IOException {
+                // given
+                Long visitId = 200L;
+                Long adminId = 2L;
+                MockMultipartFile sig = new MockMultipartFile("signature", "sig.png", "image/png", "test".getBytes());
+                CheckInRequestDto checkInDto = new CheckInRequestDto(visitId, sig);
+
+                Visit visit = Visit.builder()
+                        .id(visitId)
+                        .status(VisitStatus.APPROVED)
+                        .visitCategory(VisitCategory.PRE_LONG_TERM)
+                        .startDate(LocalDate.now().minusDays(5))
+                        .endDate(LocalDate.now().plusDays(5))
+                        .records(new ArrayList<>())
+                        .visited(false)
+                        .build();
+
+                User admin = User.builder().id(adminId).jobType(JobType.MANAGEMENT).build();
+                admin.addAuthority(Authority.MANAGE_VISITOR);
+
+                given(visitRepository.findById(visitId)).willReturn(Optional.of(visit));
+                given(s3Service.uploadFile(any())).willReturn("s3-key");
+
+                // 1. 첫 번째 입실
+                visitService.checkIn(checkInDto);
+                assertThat(visit.getStatus()).isEqualTo(VisitStatus.IN_PROGRESS);
+                assertThat(visit.getRecords()).hasSize(1);
+                Long recordId = 10L;
+                visit.getRecords().get(0).setId(recordId);
+
+                // 2. 퇴실 처리
+                given(userRepository.findById(adminId)).willReturn(Optional.of(admin));
+                CheckOutRequestDto checkOutDto = new CheckOutRequestDto(visitId, recordId, LocalDateTime.now());
+                visitService.checkOut(adminId, checkOutDto);
+                assertThat(visit.getStatus()).isEqualTo(VisitStatus.APPROVED);
+
+                // 3. 두 번째 입실 — 버그 수정 후 성공해야 한다
+                assertDoesNotThrow(() -> visitService.checkIn(checkInDto));
+                assertThat(visit.getStatus()).isEqualTo(VisitStatus.IN_PROGRESS);
+                assertThat(visit.getRecords()).hasSize(2);
+            }
+        }
+
+        @Nested
+        @DisplayName("장기 방문자가 이미 입실 중(IN_PROGRESS)일 때 재입실 시도하면")
+        class Context_long_term_already_in_progress {
+
+            @Test
+            @DisplayName("ALREADY_CHECKED_IN 예외를 던진다")
+            void it_throws_already_checked_in() throws IOException {
+                // given
+                Long visitId = 201L;
+                MockMultipartFile sig = new MockMultipartFile("signature", "sig.png", "image/png", "test".getBytes());
+                CheckInRequestDto dto = new CheckInRequestDto(visitId, sig);
+
+                Visit visit = Visit.builder()
+                        .id(visitId)
+                        .status(VisitStatus.IN_PROGRESS)
+                        .visitCategory(VisitCategory.PRE_LONG_TERM)
+                        .startDate(LocalDate.now().minusDays(5))
+                        .endDate(LocalDate.now().plusDays(5))
+                        .records(new ArrayList<>())
+                        .visited(true)
+                        .build();
+
+                given(visitRepository.findById(visitId)).willReturn(Optional.of(visit));
+
+                // when / then — ALREADY_CHECKED_IN은 아직 ErrorCode에 없으므로 컴파일 에러 (Red)
+                assertThatThrownBy(() -> visitService.checkIn(dto))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessageContaining(ErrorCode.ALREADY_CHECKED_IN.getMessage());
+            }
+        }
+
+        @Nested
+        @DisplayName("장기 방문 기간 외 날짜에 입실을 시도하면")
+        class Context_long_term_outside_date_range {
+
+            @Test
+            @DisplayName("NOT_VISIT_DATE 예외를 던진다")
+            void it_throws_not_visit_date_for_long_term() throws IOException {
+                // given
+                Long visitId = 202L;
+                MockMultipartFile sig = new MockMultipartFile("signature", "sig.png", "image/png", "test".getBytes());
+                CheckInRequestDto dto = new CheckInRequestDto(visitId, sig);
+
+                Visit visit = Visit.builder()
+                        .id(visitId)
+                        .status(VisitStatus.APPROVED)
+                        .visitCategory(VisitCategory.PRE_LONG_TERM)
+                        .startDate(LocalDate.now().plusDays(10))
+                        .endDate(LocalDate.now().plusDays(20))
+                        .records(new ArrayList<>())
+                        .visited(false)
+                        .build();
+
+                given(visitRepository.findById(visitId)).willReturn(Optional.of(visit));
+
+                // when / then
+                assertThatThrownBy(() -> visitService.checkIn(dto))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessageContaining(ErrorCode.NOT_VISIT_DATE.getMessage());
             }
         }
     }


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #351

## 📝작업 내용

- `ErrorCode`에 `ALREADY_CHECKED_IN` 에러 코드 추가
- `VisitService.checkIn` 로직 수정
    - 공통: `status == IN_PROGRESS` 시 `ALREADY_CHECKED_IN` 예외 발생
    - `PRE_LONG_TERM`: `isVisited()` 대신 날짜 범위(`startDate ~ endDate`) + 상태 기반으로 검증
    - `PRE_ONE_DAY`: 기존 날짜 체크 + `isVisited()` 로직 유지
- `Visit.validateCheckInEligible()` 메서드 추가 — 입실 검증 로직 엔티티 캡슐화, 서비스 위임
- `VisitServiceTest` 테스트 3개 추가: 재입실 성공 / 중복 입실 에러 / 기간 외 입실 에러

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)

- `isVisited()` 플래그는 `PRE_ONE_DAY` 전용으로 유지하고, `PRE_LONG_TERM` 재입실 차단은 `status == IN_PROGRESS` 조건으로 대체했습니다. 이 설계 결정이 적절한지 검토 부탁드립니다.