### PR TITLE
bug(354): 사용자 삭제 시 safety_training_session_attendees FK 제약 조건 오류 해결

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
@@ -450,6 +450,10 @@ public class AuthService {
 
         // 2) 권한 테이블 정리 후 사용자 삭제
         user.getAuthorities().clear();
+        deleteByQuery(
+                "delete from SafetyTrainingSessionAttendee a where a.user.id = :userId",
+                "userId",
+                userId);
         safetyTrainingSessionRepository.updateCreatedByToNull(userId);
         safetyTrainingSessionRepository.updateInstructorUserToNull(userId);
         userRepository.delete(user);


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #354

## 📝작업 내용

- `AuthService.deleteUser`에서 `SafetyTrainingSessionAttendee` 레코드 선삭제 로직 추가
  - 사용자 삭제 전 해당 user_id를 참조하는 attendee 레코드를 JPQL로 먼저 삭제하여 FK 제약 조건 위반 방지
  - 기존에 누락된 처리로 인해 `ConstraintViolationException` 발생하던 문제 수정

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함