### PR TITLE
fix(357): 사용자 삭제 시 누락된 FK 참조 엔티티 처리 추가

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
@@ -416,13 +416,26 @@ public class AuthService {
         deleteByQuery(
                 "delete from RefreshToken rt where rt.email = :email", "email", user.getEmail());
         deleteByQuery(
+                "delete from FcmToken ft where ft.user.id = :userId", "userId", userId);
+        deleteByQuery(
+                "delete from TopicMember tm where tm.user.id = :userId", "userId", userId);
+        deleteByQuery(
                 "delete from MyInfoUpdateRequest r where r.reviewedBy.id = :userId",
                 "userId",
                 userId);
         deleteByQuery(
                 "delete from MyInfoUpdateRequest r where r.user.id = :userId", "userId", userId);
+        deleteByQuery(
+                "update RequestHistory rh set rh.processedBy = null where rh.processedBy.id ="
+                        + " :userId",
+                "userId",
+                userId);
         deleteByQuery("delete from RequestHistory rh where rh.user.id = :userId", "userId", userId);
         deleteByQuery("delete from EduAttendance ea where ea.user.id = :userId", "userId", userId);
+        deleteByQuery(
+                "update EduReport er set er.createdBy = null where er.createdBy.id = :userId",
+                "userId",
+                userId);
         deleteByQuery("delete from CheckSheet cs where cs.user.id = :userId", "userId", userId);
         deleteByQuery("delete from Payslip p where p.user.id = :userId", "userId", userId);
         deleteByQuery(
@@ -447,6 +460,72 @@ public class AuthService {
                 "userId",
                 userId);
         deleteByQuery("delete from Notice n where n.author.id = :userId", "userId", userId);
+        deleteByQuery(
+                "delete from ApprovalPersonalViewerTarget vt where vt.setting.user.id = :userId",
+                "userId",
+                userId);
+        deleteByQuery(
+                "delete from ApprovalPersonalSetting aps where aps.user.id = :userId",
+                "userId",
+                userId);
+        deleteByQuery(
+                "delete from SavedApprovalLineDetail d where d.savedLine.ownerUser.id = :userId",
+                "userId",
+                userId);
+        deleteByQuery(
+                "delete from SavedApprovalLine sal where sal.ownerUser.id = :userId",
+                "userId",
+                userId);
+        deleteByQuery(
+                "update SavedApprovalLine sal set sal.createdByUser = null where"
+                        + " sal.createdByUser.id = :userId",
+                "userId",
+                userId);
+        deleteByQuery(
+                "delete from ApprovalActionHistory ah where ah.document.drafterUser.id = :userId",
+                "userId",
+                userId);
+        deleteByQuery(
+                "delete from ApprovalDocumentLine dl where dl.document.drafterUser.id = :userId",
+                "userId",
+                userId);
+        deleteByQuery(
+                "delete from ApprovalDocumentRead dr where dr.document.drafterUser.id = :userId",
+                "userId",
+                userId);
+        deleteByQuery(
+                "delete from ApprovalAttachment aa where aa.document.drafterUser.id = :userId",
+                "userId",
+                userId);
+        deleteByQuery(
+                "delete from ApprovalDocument ad where ad.drafterUser.id = :userId",
+                "userId",
+                userId);
+        deleteByQuery(
+                "update ApprovalDocumentLine dl set dl.targetUser = null where dl.targetUser.id ="
+                        + " :userId",
+                "userId",
+                userId);
+        deleteByQuery(
+                "update ApprovalDocumentLine dl set dl.processedByUser = null where"
+                        + " dl.processedByUser.id = :userId",
+                "userId",
+                userId);
+        deleteByQuery(
+                "update ApprovalDocumentRead dr set dr.targetUser = null where dr.targetUser.id ="
+                        + " :userId",
+                "userId",
+                userId);
+        deleteByQuery(
+                "update ApprovalActionHistory ah set ah.actorUser = null where ah.actorUser.id ="
+                        + " :userId",
+                "userId",
+                userId);
+        deleteByQuery(
+                "update ApprovalAttachment aa set aa.uploadedByUser = null where"
+                        + " aa.uploadedByUser.id = :userId",
+                "userId",
+                userId);
 
         // 2) 권한 테이블 정리 후 사용자 삭제
         user.getAuthorities().clear();
@@ -456,6 +535,14 @@ public class AuthService {
                 userId);
         safetyTrainingSessionRepository.updateCreatedByToNull(userId);
         safetyTrainingSessionRepository.updateInstructorUserToNull(userId);
+        deleteByQuery(
+                "update ApprovalTemplate at set at.createdBy = null where at.createdBy.id = :userId",
+                "userId",
+                userId);
+        deleteByQuery(
+                "update ApprovalTemplateLine atl set atl.targetUser = null where atl.targetUser.id = :userId",
+                "userId",
+                userId);
         userRepository.delete(user);
 
         log.info("계정 삭제 완료 - userId: {}, email: {}", userId, user.getEmail());

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
@@ -415,10 +415,8 @@ public class AuthService {
         // 1) 토큰 및 사용자 직접 참조 데이터 정리
         deleteByQuery(
                 "delete from RefreshToken rt where rt.email = :email", "email", user.getEmail());
-        deleteByQuery(
-                "delete from FcmToken ft where ft.user.id = :userId", "userId", userId);
-        deleteByQuery(
-                "delete from TopicMember tm where tm.user.id = :userId", "userId", userId);
+        deleteByQuery("delete from FcmToken ft where ft.user.id = :userId", "userId", userId);
+        deleteByQuery("delete from TopicMember tm where tm.user.id = :userId", "userId", userId);
         deleteByQuery(
                 "delete from MyInfoUpdateRequest r where r.reviewedBy.id = :userId",
                 "userId",
@@ -536,11 +534,13 @@ public class AuthService {
         safetyTrainingSessionRepository.updateCreatedByToNull(userId);
         safetyTrainingSessionRepository.updateInstructorUserToNull(userId);
         deleteByQuery(
-                "update ApprovalTemplate at set at.createdBy = null where at.createdBy.id = :userId",
+                "update ApprovalTemplate at set at.createdBy = null where at.createdBy.id ="
+                    + " :userId",
                 "userId",
                 userId);
         deleteByQuery(
-                "update ApprovalTemplateLine atl set atl.targetUser = null where atl.targetUser.id = :userId",
+                "update ApprovalTemplateLine atl set atl.targetUser = null where atl.targetUser.id"
+                    + " = :userId",
                 "userId",
                 userId);
         userRepository.delete(user);

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
@@ -1049,9 +1049,7 @@ class AuthServiceTest {
                 }
             }
 
-            assertThat(fcmTokenIdx)
-                    .as("FcmToken 삭제 JPQL이 실행되어야 한다")
-                    .isGreaterThanOrEqualTo(0);
+            assertThat(fcmTokenIdx).as("FcmToken 삭제 JPQL이 실행되어야 한다").isGreaterThanOrEqualTo(0);
             assertThat(refreshTokenIdx)
                     .as("RefreshToken 삭제 JPQL이 실행되어야 한다")
                     .isGreaterThanOrEqualTo(0);
@@ -1117,9 +1115,7 @@ class AuthServiceTest {
                 }
             }
 
-            assertThat(fcmTokenIdx)
-                    .as("FcmToken 삭제 JPQL이 실행되어야 한다")
-                    .isGreaterThanOrEqualTo(0);
+            assertThat(fcmTokenIdx).as("FcmToken 삭제 JPQL이 실행되어야 한다").isGreaterThanOrEqualTo(0);
             assertThat(topicMemberIdx)
                     .as("TopicMember 삭제 JPQL이 실행되어야 한다")
                     .isGreaterThanOrEqualTo(0);
@@ -1186,7 +1182,8 @@ class AuthServiceTest {
 
         @Test
         @DisplayName(
-                "성공: deleteUser 실행 시 ApprovalPersonalSetting 삭제가 ApprovalPersonalViewerTarget 삭제 직후에 실행된다 - 호출 순서 검증")
+                "성공: deleteUser 실행 시 ApprovalPersonalSetting 삭제가 ApprovalPersonalViewerTarget 삭제"
+                    + " 직후에 실행된다 - 호출 순서 검증")
         void deleteUser_deletesApprovalPersonalSettingAfterViewerTarget_orderCheck() {
             // given
             Long userId = 1L;
@@ -1255,7 +1252,8 @@ class AuthServiceTest {
 
         @Test
         @DisplayName(
-                "성공: deleteUser 실행 시 SavedApprovalLineDetail 삭제가 ApprovalPersonalSetting 삭제 직후에 실행된다 - 호출 순서 검증")
+                "성공: deleteUser 실행 시 SavedApprovalLineDetail 삭제가 ApprovalPersonalSetting 삭제 직후에"
+                    + " 실행된다 - 호출 순서 검증")
         void deleteUser_deletesSavedApprovalLineDetailAfterApprovalPersonalSetting_orderCheck() {
             // given
             Long userId = 1L;
@@ -1325,7 +1323,8 @@ class AuthServiceTest {
 
         @Test
         @DisplayName(
-                "성공: deleteUser 실행 시 SavedApprovalLine 삭제가 SavedApprovalLineDetail 삭제 직후에 실행된다 - 호출 순서 검증")
+                "성공: deleteUser 실행 시 SavedApprovalLine 삭제가 SavedApprovalLineDetail 삭제 직후에 실행된다 - 호출"
+                    + " 순서 검증")
         void deleteUser_deletesSavedApprovalLineAfterSavedApprovalLineDetail_orderCheck() {
             // given
             Long userId = 1L;
@@ -1480,7 +1479,8 @@ class AuthServiceTest {
 
         @Test
         @DisplayName(
-                "성공: deleteUser 실행 시 ApprovalDocument 자식 4개 삭제가 SavedApprovalLine 삭제 직후에 실행된다 - 호출 순서 검증")
+                "성공: deleteUser 실행 시 ApprovalDocument 자식 4개 삭제가 SavedApprovalLine 삭제 직후에 실행된다 - 호출"
+                    + " 순서 검증")
         void deleteUser_deletesApprovalDocumentChildrenAfterSavedApprovalLine_orderCheck() {
             // given
             Long userId = 1L;
@@ -1660,8 +1660,7 @@ class AuthServiceTest {
         }
 
         @Test
-        @DisplayName(
-                "성공: deleteUser 실행 시 ApprovalDocumentLine.targetUser NULLIFY UPDATE 쿼리가 실행된다")
+        @DisplayName("성공: deleteUser 실행 시 ApprovalDocumentLine.targetUser NULLIFY UPDATE 쿼리가 실행된다")
         void deleteUser_executesNullifyApprovalDocumentLineTargetUserJpql() {
             // given
             Long userId = 1L;
@@ -1718,14 +1717,13 @@ class AuthServiceTest {
                                                     && jpql.contains(":userId"));
             assertThat(found)
                     .as(
-                            "deleteUser() 실행 시 ApprovalDocumentLine.processedByUser NULLIFY UPDATE JPQL이"
-                                    + " 포함되어야 한다")
+                            "deleteUser() 실행 시 ApprovalDocumentLine.processedByUser NULLIFY UPDATE"
+                                + " JPQL이 포함되어야 한다")
                     .isTrue();
         }
 
         @Test
-        @DisplayName(
-                "성공: deleteUser 실행 시 ApprovalDocumentRead.targetUser NULLIFY UPDATE 쿼리가 실행된다")
+        @DisplayName("성공: deleteUser 실행 시 ApprovalDocumentRead.targetUser NULLIFY UPDATE 쿼리가 실행된다")
         void deleteUser_executesNullifyApprovalDocumentReadTargetUserJpql() {
             // given
             Long userId = 1L;
@@ -1756,8 +1754,7 @@ class AuthServiceTest {
         }
 
         @Test
-        @DisplayName(
-                "성공: deleteUser 실행 시 ApprovalActionHistory.actorUser NULLIFY UPDATE 쿼리가 실행된다")
+        @DisplayName("성공: deleteUser 실행 시 ApprovalActionHistory.actorUser NULLIFY UPDATE 쿼리가 실행된다")
         void deleteUser_executesNullifyApprovalActionHistoryActorUserJpql() {
             // given
             Long userId = 1L;
@@ -1814,14 +1811,15 @@ class AuthServiceTest {
                                                     && jpql.contains(":userId"));
             assertThat(found)
                     .as(
-                            "deleteUser() 실행 시 ApprovalAttachment.uploadedByUser NULLIFY UPDATE JPQL이"
-                                    + " 포함되어야 한다")
+                            "deleteUser() 실행 시 ApprovalAttachment.uploadedByUser NULLIFY UPDATE"
+                                + " JPQL이 포함되어야 한다")
                     .isTrue();
         }
 
         @Test
         @DisplayName(
-                "성공: deleteUser 실행 시 5개의 NULLIFY UPDATE 쿼리가 모두 ApprovalDocument 삭제 이후에 실행된다 - 호출 순서 검증")
+                "성공: deleteUser 실행 시 5개의 NULLIFY UPDATE 쿼리가 모두 ApprovalDocument 삭제 이후에 실행된다 - 호출 순서"
+                    + " 검증")
         void deleteUser_nullifyQueriesExecutedAfterApprovalDocumentDelete_orderCheck() {
             // given
             Long userId = 1L;
@@ -1901,8 +1899,7 @@ class AuthServiceTest {
         }
 
         @Test
-        @DisplayName(
-                "성공: deleteUser 실행 시 ApprovalTemplate.createdBy NULLIFY UPDATE 쿼리가 실행된다")
+        @DisplayName("성공: deleteUser 실행 시 ApprovalTemplate.createdBy NULLIFY UPDATE 쿼리가 실행된다")
         void deleteUser_executesNullifyApprovalTemplateCreatedByJpql() {
             // given
             Long userId = 1L;
@@ -1934,8 +1931,7 @@ class AuthServiceTest {
         }
 
         @Test
-        @DisplayName(
-                "성공: deleteUser 실행 시 ApprovalTemplateLine.targetUser NULLIFY UPDATE 쿼리가 실행된다")
+        @DisplayName("성공: deleteUser 실행 시 ApprovalTemplateLine.targetUser NULLIFY UPDATE 쿼리가 실행된다")
         void deleteUser_executesNullifyApprovalTemplateLineTargetUserJpql() {
             // given
             Long userId = 1L;
@@ -2018,7 +2014,8 @@ class AuthServiceTest {
 
         @Test
         @DisplayName(
-                "성공: deleteUser 실행 시 ApprovalPersonalViewerTarget 삭제가 Notice 삭제 이후에 실행된다 - 호출 순서 검증")
+                "성공: deleteUser 실행 시 ApprovalPersonalViewerTarget 삭제가 Notice 삭제 이후에 실행된다 - 호출 순서"
+                    + " 검증")
         void deleteUser_deletesApprovalPersonalViewerTargetAfterNotice_orderCheck() {
             // given
             Long userId = 1L;
@@ -2046,9 +2043,7 @@ class AuthServiceTest {
                 }
             }
 
-            assertThat(lastNoticeIdx)
-                    .as("Notice 관련 삭제 JPQL이 실행되어야 한다")
-                    .isGreaterThanOrEqualTo(0);
+            assertThat(lastNoticeIdx).as("Notice 관련 삭제 JPQL이 실행되어야 한다").isGreaterThanOrEqualTo(0);
             assertThat(viewerTargetIdx)
                     .as("ApprovalPersonalViewerTarget 삭제 JPQL이 실행되어야 한다")
                     .isGreaterThanOrEqualTo(0);
@@ -2087,7 +2082,8 @@ class AuthServiceTest {
 
         @Test
         @DisplayName(
-                "성공: deleteUser 실행 시 EduReport.createdBy NULLIFY가 EduAttendance 삭제 이후에 실행된다 - 호출 순서 검증")
+                "성공: deleteUser 실행 시 EduReport.createdBy NULLIFY가 EduAttendance 삭제 이후에 실행된다 - 호출 순서"
+                    + " 검증")
         void deleteUser_nullifiesEduReportCreatedByAfterEduAttendanceDelete_orderCheck() {
             // given
             Long userId = 1L;
@@ -2110,7 +2106,9 @@ class AuthServiceTest {
                 if (jpql.contains("EduAttendance") && eduAttendanceIdx == -1) {
                     eduAttendanceIdx = i;
                 }
-                if (jpql.contains("EduReport") && jpql.contains("er.createdBy") && eduReportNullifyIdx == -1) {
+                if (jpql.contains("EduReport")
+                        && jpql.contains("er.createdBy")
+                        && eduReportNullifyIdx == -1) {
                     eduReportNullifyIdx = i;
                 }
             }
@@ -2127,8 +2125,7 @@ class AuthServiceTest {
         }
 
         @Test
-        @DisplayName(
-                "성공: deleteUser 실행 시 RequestHistory.processedBy NULLIFY UPDATE 쿼리가 실행된다")
+        @DisplayName("성공: deleteUser 실행 시 RequestHistory.processedBy NULLIFY UPDATE 쿼리가 실행된다")
         void deleteUser_executesNullifyRequestHistoryProcessedByJpql() {
             // given
             Long userId = 1L;

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
@@ -991,5 +991,1219 @@ class AuthServiceTest {
             inOrder.verify(safetyTrainingSessionRepository).updateInstructorUserToNull(userId);
             inOrder.verify(userRepository).delete(testUser);
         }
+
+        @Test
+        @DisplayName("성공: deleteUser 실행 시 FcmToken JPQL 삭제 쿼리가 실행된다")
+        void deleteUser_executesDeleteFcmTokenJpql() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+            boolean fcmTokenQueryFound =
+                    executedJpqls.stream()
+                            .anyMatch(
+                                    jpql ->
+                                            jpql.contains("FcmToken")
+                                                    && jpql.contains("ft.user.id")
+                                                    && jpql.contains(":userId"));
+            assertThat(fcmTokenQueryFound)
+                    .as("deleteUser() 실행 시 FcmToken 삭제 JPQL이 포함되어야 한다")
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName("성공: deleteUser 실행 시 FcmToken 삭제가 RefreshToken 삭제 직후에 실행된다 - 호출 순서 검증")
+        void deleteUser_deletesFcmTokenAfterRefreshToken_orderCheck() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+
+            int refreshTokenIdx = -1;
+            int fcmTokenIdx = -1;
+            for (int i = 0; i < executedJpqls.size(); i++) {
+                String jpql = executedJpqls.get(i);
+                if (jpql.contains("RefreshToken") && refreshTokenIdx == -1) {
+                    refreshTokenIdx = i;
+                }
+                if (jpql.contains("FcmToken") && fcmTokenIdx == -1) {
+                    fcmTokenIdx = i;
+                }
+            }
+
+            assertThat(fcmTokenIdx)
+                    .as("FcmToken 삭제 JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+            assertThat(refreshTokenIdx)
+                    .as("RefreshToken 삭제 JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+            assertThat(fcmTokenIdx)
+                    .as("FcmToken 삭제는 RefreshToken 삭제 직후(= 그 이후)에 실행되어야 한다")
+                    .isEqualTo(refreshTokenIdx + 1);
+        }
+
+        @Test
+        @DisplayName("성공: deleteUser 실행 시 TopicMember JPQL 삭제 쿼리가 실행된다")
+        void deleteUser_executesDeleteTopicMemberJpql() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+            boolean topicMemberQueryFound =
+                    executedJpqls.stream()
+                            .anyMatch(
+                                    jpql ->
+                                            jpql.contains("TopicMember")
+                                                    && jpql.contains("tm.user.id")
+                                                    && jpql.contains(":userId"));
+            assertThat(topicMemberQueryFound)
+                    .as("deleteUser() 실행 시 TopicMember 삭제 JPQL이 포함되어야 한다")
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName("성공: deleteUser 실행 시 TopicMember 삭제가 FcmToken 삭제 직후에 실행된다 - 호출 순서 검증")
+        void deleteUser_deletesTopicMemberAfterFcmToken_orderCheck() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+
+            int fcmTokenIdx = -1;
+            int topicMemberIdx = -1;
+            for (int i = 0; i < executedJpqls.size(); i++) {
+                String jpql = executedJpqls.get(i);
+                if (jpql.contains("FcmToken") && fcmTokenIdx == -1) {
+                    fcmTokenIdx = i;
+                }
+                if (jpql.contains("TopicMember") && topicMemberIdx == -1) {
+                    topicMemberIdx = i;
+                }
+            }
+
+            assertThat(fcmTokenIdx)
+                    .as("FcmToken 삭제 JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+            assertThat(topicMemberIdx)
+                    .as("TopicMember 삭제 JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+            assertThat(topicMemberIdx)
+                    .as("TopicMember 삭제는 FcmToken 삭제 직후(= 그 이후)에 실행되어야 한다")
+                    .isEqualTo(fcmTokenIdx + 1);
+        }
+
+        @Test
+        @DisplayName("성공: deleteUser 실행 시 ApprovalPersonalViewerTarget JPQL 삭제 쿼리가 실행된다")
+        void deleteUser_executesDeleteApprovalPersonalViewerTargetJpql() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+            boolean viewerTargetQueryFound =
+                    executedJpqls.stream()
+                            .anyMatch(
+                                    jpql ->
+                                            jpql.contains("ApprovalPersonalViewerTarget")
+                                                    && jpql.contains("vt.setting.user.id")
+                                                    && jpql.contains(":userId"));
+            assertThat(viewerTargetQueryFound)
+                    .as("deleteUser() 실행 시 ApprovalPersonalViewerTarget 삭제 JPQL이 포함되어야 한다")
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName("성공: deleteUser 실행 시 ApprovalPersonalSetting JPQL 삭제 쿼리가 실행된다")
+        void deleteUser_executesDeleteApprovalPersonalSettingJpql() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+            boolean settingQueryFound =
+                    executedJpqls.stream()
+                            .anyMatch(
+                                    jpql ->
+                                            jpql.contains("ApprovalPersonalSetting")
+                                                    && jpql.contains("aps.user.id")
+                                                    && jpql.contains(":userId"));
+            assertThat(settingQueryFound)
+                    .as("deleteUser() 실행 시 ApprovalPersonalSetting 삭제 JPQL이 포함되어야 한다")
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName(
+                "성공: deleteUser 실행 시 ApprovalPersonalSetting 삭제가 ApprovalPersonalViewerTarget 삭제 직후에 실행된다 - 호출 순서 검증")
+        void deleteUser_deletesApprovalPersonalSettingAfterViewerTarget_orderCheck() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+
+            int viewerTargetIdx = -1;
+            int settingIdx = -1;
+            for (int i = 0; i < executedJpqls.size(); i++) {
+                String jpql = executedJpqls.get(i);
+                if (jpql.contains("ApprovalPersonalViewerTarget") && viewerTargetIdx == -1) {
+                    viewerTargetIdx = i;
+                }
+                if (jpql.contains("ApprovalPersonalSetting") && settingIdx == -1) {
+                    settingIdx = i;
+                }
+            }
+
+            assertThat(viewerTargetIdx)
+                    .as("ApprovalPersonalViewerTarget 삭제 JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+            assertThat(settingIdx)
+                    .as("ApprovalPersonalSetting 삭제 JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+            assertThat(settingIdx)
+                    .as("ApprovalPersonalSetting 삭제는 ApprovalPersonalViewerTarget 삭제 직후에 실행되어야 한다")
+                    .isEqualTo(viewerTargetIdx + 1);
+        }
+
+        @Test
+        @DisplayName("성공: deleteUser 실행 시 SavedApprovalLineDetail JPQL 삭제 쿼리가 실행된다")
+        void deleteUser_executesDeleteSavedApprovalLineDetailJpql() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+            boolean savedLineDetailQueryFound =
+                    executedJpqls.stream()
+                            .anyMatch(
+                                    jpql ->
+                                            jpql.contains("SavedApprovalLineDetail")
+                                                    && jpql.contains("d.savedLine.ownerUser.id")
+                                                    && jpql.contains(":userId"));
+            assertThat(savedLineDetailQueryFound)
+                    .as("deleteUser() 실행 시 SavedApprovalLineDetail 삭제 JPQL이 포함되어야 한다")
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName(
+                "성공: deleteUser 실행 시 SavedApprovalLineDetail 삭제가 ApprovalPersonalSetting 삭제 직후에 실행된다 - 호출 순서 검증")
+        void deleteUser_deletesSavedApprovalLineDetailAfterApprovalPersonalSetting_orderCheck() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+
+            int settingIdx = -1;
+            int savedLineDetailIdx = -1;
+            for (int i = 0; i < executedJpqls.size(); i++) {
+                String jpql = executedJpqls.get(i);
+                if (jpql.contains("ApprovalPersonalSetting") && settingIdx == -1) {
+                    settingIdx = i;
+                }
+                if (jpql.contains("SavedApprovalLineDetail") && savedLineDetailIdx == -1) {
+                    savedLineDetailIdx = i;
+                }
+            }
+
+            assertThat(settingIdx)
+                    .as("ApprovalPersonalSetting 삭제 JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+            assertThat(savedLineDetailIdx)
+                    .as("SavedApprovalLineDetail 삭제 JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+            assertThat(savedLineDetailIdx)
+                    .as("SavedApprovalLineDetail 삭제는 ApprovalPersonalSetting 삭제 직후에 실행되어야 한다")
+                    .isEqualTo(settingIdx + 1);
+        }
+
+        @Test
+        @DisplayName("성공: deleteUser 실행 시 SavedApprovalLine JPQL 삭제 쿼리가 실행된다")
+        void deleteUser_executesDeleteSavedApprovalLineJpql() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+            boolean savedApprovalLineQueryFound =
+                    executedJpqls.stream()
+                            .anyMatch(
+                                    jpql ->
+                                            jpql.contains("SavedApprovalLine")
+                                                    && !jpql.contains("SavedApprovalLineDetail")
+                                                    && jpql.contains("sal.ownerUser.id")
+                                                    && jpql.contains(":userId"));
+            assertThat(savedApprovalLineQueryFound)
+                    .as("deleteUser() 실행 시 SavedApprovalLine 삭제 JPQL이 포함되어야 한다")
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName(
+                "성공: deleteUser 실행 시 SavedApprovalLine 삭제가 SavedApprovalLineDetail 삭제 직후에 실행된다 - 호출 순서 검증")
+        void deleteUser_deletesSavedApprovalLineAfterSavedApprovalLineDetail_orderCheck() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+
+            int savedLineDetailIdx = -1;
+            int savedLineIdx = -1;
+            for (int i = 0; i < executedJpqls.size(); i++) {
+                String jpql = executedJpqls.get(i);
+                if (jpql.contains("SavedApprovalLineDetail") && savedLineDetailIdx == -1) {
+                    savedLineDetailIdx = i;
+                }
+                if (jpql.contains("SavedApprovalLine")
+                        && !jpql.contains("SavedApprovalLineDetail")
+                        && savedLineIdx == -1) {
+                    savedLineIdx = i;
+                }
+            }
+
+            assertThat(savedLineDetailIdx)
+                    .as("SavedApprovalLineDetail 삭제 JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+            assertThat(savedLineIdx)
+                    .as("SavedApprovalLine 삭제 JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+            assertThat(savedLineIdx)
+                    .as("SavedApprovalLine 삭제는 SavedApprovalLineDetail 삭제 직후(= 그 이후)에 실행되어야 한다")
+                    .isEqualTo(savedLineDetailIdx + 1);
+        }
+
+        @Test
+        @DisplayName("성공: deleteUser 실행 시 ApprovalActionHistory JPQL 삭제 쿼리가 실행된다")
+        void deleteUser_executesDeleteApprovalActionHistoryJpql() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+            boolean actionHistoryQueryFound =
+                    executedJpqls.stream()
+                            .anyMatch(
+                                    jpql ->
+                                            jpql.contains("ApprovalActionHistory")
+                                                    && jpql.contains("ah.document.drafterUser.id")
+                                                    && jpql.contains(":userId"));
+            assertThat(actionHistoryQueryFound)
+                    .as("deleteUser() 실행 시 ApprovalActionHistory 삭제 JPQL이 포함되어야 한다")
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName("성공: deleteUser 실행 시 ApprovalDocumentLine JPQL 삭제 쿼리가 실행된다")
+        void deleteUser_executesDeleteApprovalDocumentLineJpql() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+            boolean documentLineQueryFound =
+                    executedJpqls.stream()
+                            .anyMatch(
+                                    jpql ->
+                                            jpql.contains("ApprovalDocumentLine")
+                                                    && jpql.contains("dl.document.drafterUser.id")
+                                                    && jpql.contains(":userId"));
+            assertThat(documentLineQueryFound)
+                    .as("deleteUser() 실행 시 ApprovalDocumentLine 삭제 JPQL이 포함되어야 한다")
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName("성공: deleteUser 실행 시 ApprovalDocumentRead JPQL 삭제 쿼리가 실행된다")
+        void deleteUser_executesDeleteApprovalDocumentReadJpql() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+            boolean documentReadQueryFound =
+                    executedJpqls.stream()
+                            .anyMatch(
+                                    jpql ->
+                                            jpql.contains("ApprovalDocumentRead")
+                                                    && jpql.contains("dr.document.drafterUser.id")
+                                                    && jpql.contains(":userId"));
+            assertThat(documentReadQueryFound)
+                    .as("deleteUser() 실행 시 ApprovalDocumentRead 삭제 JPQL이 포함되어야 한다")
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName("성공: deleteUser 실행 시 ApprovalAttachment JPQL 삭제 쿼리가 실행된다")
+        void deleteUser_executesDeleteApprovalAttachmentJpql() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+            boolean attachmentQueryFound =
+                    executedJpqls.stream()
+                            .anyMatch(
+                                    jpql ->
+                                            jpql.contains("ApprovalAttachment")
+                                                    && jpql.contains("aa.document.drafterUser.id")
+                                                    && jpql.contains(":userId"));
+            assertThat(attachmentQueryFound)
+                    .as("deleteUser() 실행 시 ApprovalAttachment 삭제 JPQL이 포함되어야 한다")
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName(
+                "성공: deleteUser 실행 시 ApprovalDocument 자식 4개 삭제가 SavedApprovalLine 삭제 직후에 실행된다 - 호출 순서 검증")
+        void deleteUser_deletesApprovalDocumentChildrenAfterSavedApprovalLine_orderCheck() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+
+            int savedApprovalLineIdx = -1;
+            int actionHistoryIdx = -1;
+            int documentLineIdx = -1;
+            int documentReadIdx = -1;
+            int attachmentIdx = -1;
+            for (int i = 0; i < executedJpqls.size(); i++) {
+                String jpql = executedJpqls.get(i);
+                if (jpql.contains("SavedApprovalLine")
+                        && !jpql.contains("SavedApprovalLineDetail")
+                        && savedApprovalLineIdx == -1) {
+                    savedApprovalLineIdx = i;
+                }
+                if (jpql.contains("ApprovalActionHistory") && actionHistoryIdx == -1) {
+                    actionHistoryIdx = i;
+                }
+                if (jpql.contains("ApprovalDocumentLine") && documentLineIdx == -1) {
+                    documentLineIdx = i;
+                }
+                if (jpql.contains("ApprovalDocumentRead") && documentReadIdx == -1) {
+                    documentReadIdx = i;
+                }
+                if (jpql.contains("ApprovalAttachment") && attachmentIdx == -1) {
+                    attachmentIdx = i;
+                }
+            }
+
+            assertThat(savedApprovalLineIdx)
+                    .as("SavedApprovalLine 삭제 JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+            assertThat(actionHistoryIdx)
+                    .as("ApprovalActionHistory 삭제 JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+            assertThat(documentLineIdx)
+                    .as("ApprovalDocumentLine 삭제 JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+            assertThat(documentReadIdx)
+                    .as("ApprovalDocumentRead 삭제 JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+            assertThat(attachmentIdx)
+                    .as("ApprovalAttachment 삭제 JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+
+            assertThat(actionHistoryIdx)
+                    .as("ApprovalActionHistory 삭제는 SavedApprovalLine 삭제 이후에 실행되어야 한다")
+                    .isGreaterThan(savedApprovalLineIdx);
+            assertThat(documentLineIdx)
+                    .as("ApprovalDocumentLine 삭제는 SavedApprovalLine 삭제 이후에 실행되어야 한다")
+                    .isGreaterThan(savedApprovalLineIdx);
+            assertThat(documentReadIdx)
+                    .as("ApprovalDocumentRead 삭제는 SavedApprovalLine 삭제 이후에 실행되어야 한다")
+                    .isGreaterThan(savedApprovalLineIdx);
+            assertThat(attachmentIdx)
+                    .as("ApprovalAttachment 삭제는 SavedApprovalLine 삭제 이후에 실행되어야 한다")
+                    .isGreaterThan(savedApprovalLineIdx);
+        }
+
+        @Test
+        @DisplayName("성공: deleteUser 실행 시 ApprovalDocument JPQL 삭제 쿼리가 실행된다")
+        void deleteUser_executesDeleteApprovalDocumentJpql() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+            boolean approvalDocumentQueryFound =
+                    executedJpqls.stream()
+                            .anyMatch(
+                                    jpql ->
+                                            jpql.contains("ApprovalDocument")
+                                                    && !jpql.contains("ApprovalDocumentLine")
+                                                    && !jpql.contains("ApprovalDocumentRead")
+                                                    && jpql.contains("ad.drafterUser.id")
+                                                    && jpql.contains(":userId"));
+            assertThat(approvalDocumentQueryFound)
+                    .as("deleteUser() 실행 시 ApprovalDocument 삭제 JPQL이 포함되어야 한다")
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName(
+                "성공: deleteUser 실행 시 ApprovalDocument 삭제가 자식 4종(ApprovalActionHistory,"
+                        + " ApprovalDocumentLine, ApprovalDocumentRead, ApprovalAttachment) 삭제 직후에"
+                        + " 실행된다 - 호출 순서 검증")
+        void deleteUser_deletesApprovalDocumentAfterChildren_orderCheck() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+
+            int actionHistoryIdx = -1;
+            int documentLineIdx = -1;
+            int documentReadIdx = -1;
+            int attachmentIdx = -1;
+            int approvalDocumentIdx = -1;
+            for (int i = 0; i < executedJpqls.size(); i++) {
+                String jpql = executedJpqls.get(i);
+                if (jpql.contains("ApprovalActionHistory") && actionHistoryIdx == -1) {
+                    actionHistoryIdx = i;
+                }
+                if (jpql.contains("ApprovalDocumentLine") && documentLineIdx == -1) {
+                    documentLineIdx = i;
+                }
+                if (jpql.contains("ApprovalDocumentRead") && documentReadIdx == -1) {
+                    documentReadIdx = i;
+                }
+                if (jpql.contains("ApprovalAttachment") && attachmentIdx == -1) {
+                    attachmentIdx = i;
+                }
+                if (jpql.contains("ApprovalDocument")
+                        && !jpql.contains("ApprovalDocumentLine")
+                        && !jpql.contains("ApprovalDocumentRead")
+                        && approvalDocumentIdx == -1) {
+                    approvalDocumentIdx = i;
+                }
+            }
+
+            assertThat(approvalDocumentIdx)
+                    .as("ApprovalDocument 삭제 JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+            assertThat(actionHistoryIdx)
+                    .as("ApprovalActionHistory 삭제 JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+            assertThat(documentLineIdx)
+                    .as("ApprovalDocumentLine 삭제 JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+            assertThat(documentReadIdx)
+                    .as("ApprovalDocumentRead 삭제 JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+            assertThat(attachmentIdx)
+                    .as("ApprovalAttachment 삭제 JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+
+            assertThat(approvalDocumentIdx)
+                    .as("ApprovalDocument 삭제는 ApprovalActionHistory 삭제 이후에 실행되어야 한다")
+                    .isGreaterThan(actionHistoryIdx);
+            assertThat(approvalDocumentIdx)
+                    .as("ApprovalDocument 삭제는 ApprovalDocumentLine 삭제 이후에 실행되어야 한다")
+                    .isGreaterThan(documentLineIdx);
+            assertThat(approvalDocumentIdx)
+                    .as("ApprovalDocument 삭제는 ApprovalDocumentRead 삭제 이후에 실행되어야 한다")
+                    .isGreaterThan(documentReadIdx);
+            assertThat(approvalDocumentIdx)
+                    .as("ApprovalDocument 삭제는 ApprovalAttachment 삭제 이후에 실행되어야 한다")
+                    .isGreaterThan(attachmentIdx);
+        }
+
+        @Test
+        @DisplayName(
+                "성공: deleteUser 실행 시 ApprovalDocumentLine.targetUser NULLIFY UPDATE 쿼리가 실행된다")
+        void deleteUser_executesNullifyApprovalDocumentLineTargetUserJpql() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+            boolean found =
+                    executedJpqls.stream()
+                            .anyMatch(
+                                    jpql ->
+                                            jpql.contains("ApprovalDocumentLine")
+                                                    && jpql.contains("dl.targetUser")
+                                                    && jpql.contains("dl.targetUser.id")
+                                                    && jpql.contains(":userId"));
+            assertThat(found)
+                    .as(
+                            "deleteUser() 실행 시 ApprovalDocumentLine.targetUser NULLIFY UPDATE JPQL이"
+                                    + " 포함되어야 한다")
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName(
+                "성공: deleteUser 실행 시 ApprovalDocumentLine.processedByUser NULLIFY UPDATE 쿼리가 실행된다")
+        void deleteUser_executesNullifyApprovalDocumentLineProcessedByUserJpql() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+            boolean found =
+                    executedJpqls.stream()
+                            .anyMatch(
+                                    jpql ->
+                                            jpql.contains("ApprovalDocumentLine")
+                                                    && jpql.contains("dl.processedByUser")
+                                                    && jpql.contains("dl.processedByUser.id")
+                                                    && jpql.contains(":userId"));
+            assertThat(found)
+                    .as(
+                            "deleteUser() 실행 시 ApprovalDocumentLine.processedByUser NULLIFY UPDATE JPQL이"
+                                    + " 포함되어야 한다")
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName(
+                "성공: deleteUser 실행 시 ApprovalDocumentRead.targetUser NULLIFY UPDATE 쿼리가 실행된다")
+        void deleteUser_executesNullifyApprovalDocumentReadTargetUserJpql() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+            boolean found =
+                    executedJpqls.stream()
+                            .anyMatch(
+                                    jpql ->
+                                            jpql.contains("ApprovalDocumentRead")
+                                                    && jpql.contains("dr.targetUser")
+                                                    && jpql.contains("dr.targetUser.id")
+                                                    && jpql.contains(":userId"));
+            assertThat(found)
+                    .as(
+                            "deleteUser() 실행 시 ApprovalDocumentRead.targetUser NULLIFY UPDATE JPQL이"
+                                    + " 포함되어야 한다")
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName(
+                "성공: deleteUser 실행 시 ApprovalActionHistory.actorUser NULLIFY UPDATE 쿼리가 실행된다")
+        void deleteUser_executesNullifyApprovalActionHistoryActorUserJpql() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+            boolean found =
+                    executedJpqls.stream()
+                            .anyMatch(
+                                    jpql ->
+                                            jpql.contains("ApprovalActionHistory")
+                                                    && jpql.contains("ah.actorUser")
+                                                    && jpql.contains("ah.actorUser.id")
+                                                    && jpql.contains(":userId"));
+            assertThat(found)
+                    .as(
+                            "deleteUser() 실행 시 ApprovalActionHistory.actorUser NULLIFY UPDATE JPQL이"
+                                    + " 포함되어야 한다")
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName(
+                "성공: deleteUser 실행 시 ApprovalAttachment.uploadedByUser NULLIFY UPDATE 쿼리가 실행된다")
+        void deleteUser_executesNullifyApprovalAttachmentUploadedByUserJpql() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+            boolean found =
+                    executedJpqls.stream()
+                            .anyMatch(
+                                    jpql ->
+                                            jpql.contains("ApprovalAttachment")
+                                                    && jpql.contains("aa.uploadedByUser")
+                                                    && jpql.contains("aa.uploadedByUser.id")
+                                                    && jpql.contains(":userId"));
+            assertThat(found)
+                    .as(
+                            "deleteUser() 실행 시 ApprovalAttachment.uploadedByUser NULLIFY UPDATE JPQL이"
+                                    + " 포함되어야 한다")
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName(
+                "성공: deleteUser 실행 시 5개의 NULLIFY UPDATE 쿼리가 모두 ApprovalDocument 삭제 이후에 실행된다 - 호출 순서 검증")
+        void deleteUser_nullifyQueriesExecutedAfterApprovalDocumentDelete_orderCheck() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+
+            int approvalDocumentDeleteIdx = -1;
+            int nullifyDocumentLineTargetUserIdx = -1;
+            int nullifyDocumentLineProcessedByUserIdx = -1;
+            int nullifyDocumentReadTargetUserIdx = -1;
+            int nullifyActionHistoryActorUserIdx = -1;
+            int nullifyAttachmentUploadedByUserIdx = -1;
+
+            for (int i = 0; i < executedJpqls.size(); i++) {
+                String jpql = executedJpqls.get(i);
+                if (jpql.contains("ApprovalDocument")
+                        && !jpql.contains("ApprovalDocumentLine")
+                        && !jpql.contains("ApprovalDocumentRead")
+                        && jpql.contains("ad.drafterUser.id")
+                        && approvalDocumentDeleteIdx == -1) {
+                    approvalDocumentDeleteIdx = i;
+                }
+                if (jpql.contains("ApprovalDocumentLine")
+                        && jpql.contains("dl.targetUser")
+                        && nullifyDocumentLineTargetUserIdx == -1) {
+                    nullifyDocumentLineTargetUserIdx = i;
+                }
+                if (jpql.contains("ApprovalDocumentLine")
+                        && jpql.contains("dl.processedByUser")
+                        && nullifyDocumentLineProcessedByUserIdx == -1) {
+                    nullifyDocumentLineProcessedByUserIdx = i;
+                }
+                if (jpql.contains("ApprovalDocumentRead")
+                        && jpql.contains("dr.targetUser")
+                        && nullifyDocumentReadTargetUserIdx == -1) {
+                    nullifyDocumentReadTargetUserIdx = i;
+                }
+                if (jpql.contains("ApprovalActionHistory")
+                        && jpql.contains("ah.actorUser")
+                        && nullifyActionHistoryActorUserIdx == -1) {
+                    nullifyActionHistoryActorUserIdx = i;
+                }
+                if (jpql.contains("ApprovalAttachment")
+                        && jpql.contains("aa.uploadedByUser")
+                        && nullifyAttachmentUploadedByUserIdx == -1) {
+                    nullifyAttachmentUploadedByUserIdx = i;
+                }
+            }
+
+            assertThat(approvalDocumentDeleteIdx)
+                    .as("ApprovalDocument 삭제 JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+            assertThat(nullifyDocumentLineTargetUserIdx)
+                    .as("ApprovalDocumentLine.targetUser NULLIFY JPQL이 실행되어야 한다")
+                    .isGreaterThan(approvalDocumentDeleteIdx);
+            assertThat(nullifyDocumentLineProcessedByUserIdx)
+                    .as("ApprovalDocumentLine.processedByUser NULLIFY JPQL이 실행되어야 한다")
+                    .isGreaterThan(approvalDocumentDeleteIdx);
+            assertThat(nullifyDocumentReadTargetUserIdx)
+                    .as("ApprovalDocumentRead.targetUser NULLIFY JPQL이 실행되어야 한다")
+                    .isGreaterThan(approvalDocumentDeleteIdx);
+            assertThat(nullifyActionHistoryActorUserIdx)
+                    .as("ApprovalActionHistory.actorUser NULLIFY JPQL이 실행되어야 한다")
+                    .isGreaterThan(approvalDocumentDeleteIdx);
+            assertThat(nullifyAttachmentUploadedByUserIdx)
+                    .as("ApprovalAttachment.uploadedByUser NULLIFY JPQL이 실행되어야 한다")
+                    .isGreaterThan(approvalDocumentDeleteIdx);
+        }
+
+        @Test
+        @DisplayName(
+                "성공: deleteUser 실행 시 ApprovalTemplate.createdBy NULLIFY UPDATE 쿼리가 실행된다")
+        void deleteUser_executesNullifyApprovalTemplateCreatedByJpql() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+            boolean found =
+                    executedJpqls.stream()
+                            .anyMatch(
+                                    jpql ->
+                                            jpql.contains("ApprovalTemplate")
+                                                    && !jpql.contains("ApprovalTemplateLine")
+                                                    && jpql.contains("at.createdBy")
+                                                    && jpql.contains("at.createdBy.id")
+                                                    && jpql.contains(":userId"));
+            assertThat(found)
+                    .as(
+                            "deleteUser() 실행 시 ApprovalTemplate.createdBy NULLIFY UPDATE JPQL이"
+                                    + " 포함되어야 한다")
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName(
+                "성공: deleteUser 실행 시 ApprovalTemplateLine.targetUser NULLIFY UPDATE 쿼리가 실행된다")
+        void deleteUser_executesNullifyApprovalTemplateLineTargetUserJpql() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+            boolean found =
+                    executedJpqls.stream()
+                            .anyMatch(
+                                    jpql ->
+                                            jpql.contains("ApprovalTemplateLine")
+                                                    && jpql.contains("atl.targetUser")
+                                                    && jpql.contains("atl.targetUser.id")
+                                                    && jpql.contains(":userId"));
+            assertThat(found)
+                    .as(
+                            "deleteUser() 실행 시 ApprovalTemplateLine.targetUser NULLIFY UPDATE JPQL이"
+                                    + " 포함되어야 한다")
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName(
+                "성공: deleteUser 실행 시 ApprovalTemplate/ApprovalTemplateLine NULLIFY 쿼리 2개가"
+                        + " SafetyTrainingSessionAttendee 삭제 이후에 실행된다 - 호출 순서 검증")
+        void deleteUser_nullifyApprovalTemplateQueriesAfterAttendeeDelete_orderCheck() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+
+            int attendeeDeleteIdx = -1;
+            int nullifyTemplateCreatedByIdx = -1;
+            int nullifyTemplateLineTargetUserIdx = -1;
+            for (int i = 0; i < executedJpqls.size(); i++) {
+                String jpql = executedJpqls.get(i);
+                if (jpql.contains("SafetyTrainingSessionAttendee") && attendeeDeleteIdx == -1) {
+                    attendeeDeleteIdx = i;
+                }
+                if (jpql.contains("ApprovalTemplate")
+                        && !jpql.contains("ApprovalTemplateLine")
+                        && jpql.contains("at.createdBy")
+                        && nullifyTemplateCreatedByIdx == -1) {
+                    nullifyTemplateCreatedByIdx = i;
+                }
+                if (jpql.contains("ApprovalTemplateLine")
+                        && jpql.contains("atl.targetUser")
+                        && nullifyTemplateLineTargetUserIdx == -1) {
+                    nullifyTemplateLineTargetUserIdx = i;
+                }
+            }
+
+            assertThat(attendeeDeleteIdx)
+                    .as("SafetyTrainingSessionAttendee 삭제 JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+            assertThat(nullifyTemplateCreatedByIdx)
+                    .as("ApprovalTemplate.createdBy NULLIFY JPQL이 실행되어야 한다")
+                    .isGreaterThan(attendeeDeleteIdx);
+            assertThat(nullifyTemplateLineTargetUserIdx)
+                    .as("ApprovalTemplateLine.targetUser NULLIFY JPQL이 실행되어야 한다")
+                    .isGreaterThan(attendeeDeleteIdx);
+        }
+
+        @Test
+        @DisplayName(
+                "성공: deleteUser 실행 시 ApprovalPersonalViewerTarget 삭제가 Notice 삭제 이후에 실행된다 - 호출 순서 검증")
+        void deleteUser_deletesApprovalPersonalViewerTargetAfterNotice_orderCheck() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+
+            int lastNoticeIdx = -1;
+            int viewerTargetIdx = -1;
+            for (int i = 0; i < executedJpqls.size(); i++) {
+                String jpql = executedJpqls.get(i);
+                if (jpql.contains("Notice")) {
+                    lastNoticeIdx = i;
+                }
+                if (jpql.contains("ApprovalPersonalViewerTarget") && viewerTargetIdx == -1) {
+                    viewerTargetIdx = i;
+                }
+            }
+
+            assertThat(lastNoticeIdx)
+                    .as("Notice 관련 삭제 JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+            assertThat(viewerTargetIdx)
+                    .as("ApprovalPersonalViewerTarget 삭제 JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+            assertThat(viewerTargetIdx)
+                    .as("ApprovalPersonalViewerTarget 삭제는 Notice 관련 삭제 이후에 실행되어야 한다")
+                    .isGreaterThan(lastNoticeIdx);
+        }
+
+        @Test
+        @DisplayName("성공: deleteUser 실행 시 EduReport.createdBy NULLIFY JPQL 쿼리가 실행된다")
+        void deleteUser_executesNullifyEduReportCreatedByJpql() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+            boolean eduReportNullifyFound =
+                    executedJpqls.stream()
+                            .anyMatch(
+                                    jpql ->
+                                            jpql.contains("EduReport")
+                                                    && jpql.contains("er.createdBy")
+                                                    && jpql.contains(":userId"));
+            assertThat(eduReportNullifyFound)
+                    .as("deleteUser() 실행 시 EduReport.createdBy NULLIFY JPQL이 포함되어야 한다")
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName(
+                "성공: deleteUser 실행 시 EduReport.createdBy NULLIFY가 EduAttendance 삭제 이후에 실행된다 - 호출 순서 검증")
+        void deleteUser_nullifiesEduReportCreatedByAfterEduAttendanceDelete_orderCheck() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+
+            int eduAttendanceIdx = -1;
+            int eduReportNullifyIdx = -1;
+            for (int i = 0; i < executedJpqls.size(); i++) {
+                String jpql = executedJpqls.get(i);
+                if (jpql.contains("EduAttendance") && eduAttendanceIdx == -1) {
+                    eduAttendanceIdx = i;
+                }
+                if (jpql.contains("EduReport") && jpql.contains("er.createdBy") && eduReportNullifyIdx == -1) {
+                    eduReportNullifyIdx = i;
+                }
+            }
+
+            assertThat(eduAttendanceIdx)
+                    .as("EduAttendance 삭제 JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+            assertThat(eduReportNullifyIdx)
+                    .as("EduReport.createdBy NULLIFY JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+            assertThat(eduReportNullifyIdx)
+                    .as("EduReport.createdBy NULLIFY는 EduAttendance 삭제 이후에 실행되어야 한다")
+                    .isGreaterThan(eduAttendanceIdx);
+        }
+
+        @Test
+        @DisplayName(
+                "성공: deleteUser 실행 시 RequestHistory.processedBy NULLIFY UPDATE 쿼리가 실행된다")
+        void deleteUser_executesNullifyRequestHistoryProcessedByJpql() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+            boolean found =
+                    executedJpqls.stream()
+                            .anyMatch(
+                                    jpql ->
+                                            jpql.contains("RequestHistory")
+                                                    && jpql.contains("rh.processedBy")
+                                                    && jpql.contains("rh.processedBy.id")
+                                                    && jpql.contains(":userId"));
+            assertThat(found)
+                    .as(
+                            "deleteUser() 실행 시 RequestHistory.processedBy NULLIFY UPDATE JPQL이"
+                                    + " 포함되어야 한다")
+                    .isTrue();
+        }
+
+        @Test
+        @DisplayName(
+                "성공: deleteUser 실행 시 RequestHistory.processedBy NULLIFY가"
+                        + " RequestHistory 삭제(rh.user.id) 직전에 실행된다 - 호출 순서 검증")
+        void deleteUser_nullifyRequestHistoryProcessedByBeforeRequestHistoryDelete_orderCheck() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when
+            authService.deleteUser(userId);
+
+            // then
+            ArgumentCaptor<String> jpqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(entityManager, org.mockito.Mockito.atLeastOnce())
+                    .createQuery(jpqlCaptor.capture());
+
+            List<String> executedJpqls = jpqlCaptor.getAllValues();
+
+            int nullifyProcessedByIdx = -1;
+            int deleteRequestHistoryIdx = -1;
+            for (int i = 0; i < executedJpqls.size(); i++) {
+                String jpql = executedJpqls.get(i);
+                if (jpql.contains("RequestHistory")
+                        && jpql.contains("rh.processedBy")
+                        && nullifyProcessedByIdx == -1) {
+                    nullifyProcessedByIdx = i;
+                }
+                if (jpql.contains("RequestHistory")
+                        && jpql.contains("rh.user.id")
+                        && deleteRequestHistoryIdx == -1) {
+                    deleteRequestHistoryIdx = i;
+                }
+            }
+
+            assertThat(nullifyProcessedByIdx)
+                    .as("RequestHistory.processedBy NULLIFY JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+            assertThat(deleteRequestHistoryIdx)
+                    .as("RequestHistory 삭제(rh.user.id) JPQL이 실행되어야 한다")
+                    .isGreaterThanOrEqualTo(0);
+            assertThat(nullifyProcessedByIdx)
+                    .as(
+                            "RequestHistory.processedBy NULLIFY는 RequestHistory 삭제(rh.user.id) 직전에"
+                                    + " 실행되어야 한다")
+                    .isEqualTo(deleteRequestHistoryIdx - 1);
+        }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #357

## 📝작업 내용

- FCM: 사용자 삭제 시 FcmToken, TopicMember 선행 삭제
- Request: RequestHistory.processedBy NULLIFY (삭제 전 선행)
- Education: EduReport.createdBy NULLIFY
- Approval (개인 설정): ApprovalPersonalViewerTarget → ApprovalPersonalSetting 순서로 삭제
- Approval (저장 결재선): SavedApprovalLineDetail → SavedApprovalLine 순서로 삭제
    - SavedApprovalLine.createdByUser NULLIFY 추가 (코드 리뷰 중 FK 누락 발견)
- Approval (기안 문서): 자식 4종(ActionHistory/DocumentLine/DocumentRead/Attachment) → ApprovalDocument 순서로 삭제
- Approval (참여 이력): DocumentLine/Read/ActionHistory/Attachment 5종 NULLIFY
- Approval (템플릿): ApprovalTemplate.createdBy, ApprovalTemplateLine.targetUser NULLIFY

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)

- `deleteByQuery` 헬퍼가 UPDATE JPQL도 처리하므로 별도 `updateByQuery` 추가 없이 재사용
- API 테스트는 로컬 알림톡 발송 불가로 단위 테스트(`AuthServiceTest.DeleteUserTest`)로 대체