### PR TITLE
refactor(363): 알림 completion 정합화 및 내방객 권한 정책 개선

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
@@ -275,17 +275,6 @@ public class AdminController {
                                                           "message": "전화번호 인증이 필요합니다.",
                                                           "result": null
                                                         }
-                                                        """),
-                                            @ExampleObject(
-                                                    name = "잘못된 직무/역할 조합",
-                                                    value =
-                                                            """
-                                                        {
-                                                          "isSuccess": false,
-                                                          "code": "INVALID_JOB_TYPE_FOR_ADMIN_ROLE",
-                                                          "message": "현장직은 관리자 권한을 가질 수 없습니다.",
-                                                          "result": null
-                                                        }
                                                         """)
                                         })),
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
@@ -127,10 +127,6 @@ public class AdminService {
         user.setWorkLocation(requestDto.getWorkLocation());
         user.setDepartment(department);
         user.setJobType(requestDto.getJobType());
-
-        if (requestDto.getJobType() == JobType.FIELD && requestDto.getRole() == Role.ADMIN) {
-            throw new CustomException(ErrorCode.INVALID_JOB_TYPE_FOR_ADMIN_ROLE);
-        }
         if (requestDto.getRole() != null) {
             user.setRole(requestDto.getRole());
         }
@@ -307,12 +303,6 @@ public class AdminService {
         }
         if (requestDto.getRole() != null) {
             user.setRole(requestDto.getRole());
-        }
-
-        JobType finalJobType = user.getJobType();
-        Role finalRole = user.getRole();
-        if (finalJobType == JobType.FIELD && finalRole == Role.ADMIN) {
-            throw new CustomException(ErrorCode.INVALID_JOB_TYPE_FOR_ADMIN_ROLE);
         }
 
         if (requestDto.getAuthorities() != null) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
@@ -159,6 +159,9 @@ public class AdminService {
             }
         }
         userRepository.save(user);
+
+        // 회원가입 승인 처리 완료 시 관리자 승인대기 알림 해제
+        notificationService.resolveRequiresApproval(NotificationDomainType.AUTH, user.getId());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
@@ -112,10 +112,10 @@ public class AuthService {
         phoneAuthService.clearVerification(joinDto.getPhoneNumber());
 
         // 10. Admin 유저에게 신규 가입 알림 전송 (FCM + Notification DB)
-        notificationService.sendAlertToAdmins(
+        notificationService.sendAlertToAdminsRequiringApproval(
                 NotificationMessage.SIGNUP_ADMIN_ALERT,
                 NotificationDomainType.AUTH,
-                null,
+                savedUser.getId(),
                 Map.of("targetId", savedUser.getId()),
                 savedUser.getDisplayName());
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/dto/response/NotificationResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/dto/response/NotificationResponseDto.java
@@ -47,7 +47,7 @@ public class NotificationResponseDto {
     @Schema(description = "알림 메시지 유형", example = "VISIT_CHECK_IN")
     private final NotificationMessage messageType;
 
-    @Schema(description = "승인/반려 완료 알림 여부 (예: 내정보수정 승인·반려 완료, 장기방문 승인요청 처리 완료)", example = "false")
+    @Schema(description = "승인 요청형 알림의 처리 완료 여부 (예: 회원가입 승인 요청, 내정보수정 승인 요청, 장기방문 승인 요청)", example = "false")
     private final boolean approvalOrRejectionCompleted;
 
     private NotificationResponseDto(Notification notification) {
@@ -72,11 +72,6 @@ public class NotificationResponseDto {
         NotificationMessage messageType = notification.getMessageType();
         if (messageType == null) {
             return false;
-        }
-
-        if (messageType == NotificationMessage.MY_INFO_UPDATE_APPROVED
-                || messageType == NotificationMessage.MY_INFO_UPDATE_REJECTED) {
-            return true;
         }
 
         // 승인 요청형 알림은 requiresApproval 해제 시점(승인/반려 처리 완료)을 완료로 간주

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/dto/response/NotificationResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/dto/response/NotificationResponseDto.java
@@ -81,7 +81,8 @@ public class NotificationResponseDto {
 
         // 승인 요청형 알림은 requiresApproval 해제 시점(승인/반려 처리 완료)을 완료로 간주
         if (messageType == NotificationMessage.VISIT_LONG_TERM_PRE
-                || messageType == NotificationMessage.SIGNUP_ADMIN_ALERT) {
+                || messageType == NotificationMessage.SIGNUP_ADMIN_ALERT
+                || messageType == NotificationMessage.MY_INFO_UPDATE_REQUEST_ADMIN) {
             return !notification.isRequiresApproval();
         }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/dto/response/NotificationResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/dto/response/NotificationResponseDto.java
@@ -79,8 +79,9 @@ public class NotificationResponseDto {
             return true;
         }
 
-        // 장기 방문 승인요청 알림은 requiresApproval 해제 시점(승인/반려 처리 완료)을 완료로 간주
-        if (messageType == NotificationMessage.VISIT_LONG_TERM_PRE) {
+        // 승인 요청형 알림은 requiresApproval 해제 시점(승인/반려 처리 완료)을 완료로 간주
+        if (messageType == NotificationMessage.VISIT_LONG_TERM_PRE
+                || messageType == NotificationMessage.SIGNUP_ADMIN_ALERT) {
             return !notification.isRequiresApproval();
         }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/dto/response/NotificationResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/dto/response/NotificationResponseDto.java
@@ -47,7 +47,9 @@ public class NotificationResponseDto {
     @Schema(description = "알림 메시지 유형", example = "VISIT_CHECK_IN")
     private final NotificationMessage messageType;
 
-    @Schema(description = "승인 요청형 알림의 처리 완료 여부 (예: 회원가입 승인 요청, 내정보수정 승인 요청, 장기방문 승인 요청)", example = "false")
+    @Schema(
+            description = "승인 요청형 알림의 처리 완료 여부 (예: 회원가입 승인 요청, 내정보수정 승인 요청, 장기방문 승인 요청)",
+            example = "false")
     private final boolean approvalOrRejectionCompleted;
 
     private NotificationResponseDto(Notification notification) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/controller/VisitController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/controller/VisitController.java
@@ -170,7 +170,9 @@ public class VisitController {
         return ResponseEntity.ok(ApiResponse.onSuccess(visitId));
     }
 
-    @Operation(summary = "방문자 퇴실 처리", description = "입실 중인 내방객의 퇴실 시간을 기록하고 방문 상태를 업데이트합니다.")
+    @Operation(
+            summary = "방문자 퇴실 처리",
+            description = "MANAGE_VISITOR 권한을 가진 담당 부서 직원이 내방객의 퇴실 시간을 기록하고 방문 상태를 업데이트합니다.")
     @PatchMapping("/check-out")
     public ResponseEntity<ApiResponse<Long>> checkOut(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -214,7 +216,7 @@ public class VisitController {
 
     @Operation(
             summary = "직원용 내방객 목록 조회",
-            description = "관리 직군이 전체 내방객 목록을 조회합니다. 부서 및 상태별 필터링과 페이징이 가능합니다.")
+            description = "직원 계정으로 전체 내방객 목록을 조회합니다. 부서 및 상태별 필터링과 페이징이 가능합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",
@@ -277,7 +279,7 @@ public class VisitController {
 
     @Operation(
             summary = "직원용 내방객 상세 조회",
-            description = "관리 직군이 특정 내방객의 상세 정보, 서명 이미지 및 모든 입퇴실 기록을 조회합니다.")
+            description = "직원 계정으로 특정 내방객의 상세 정보, 서명 이미지 및 모든 입퇴실 기록을 조회합니다.")
     @GetMapping("/admin/{visitId}")
     public ResponseEntity<ApiResponse<MyVisitDetailResponseDto>> getAdminVisitDetail(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -288,7 +290,9 @@ public class VisitController {
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
-    @Operation(summary = "장기 방문 신청 처리", description = "관리 직군이 PENDING 상태인 장기 방문 신청을 승인 혹은 반려합니다.")
+    @Operation(
+            summary = "장기 방문 신청 처리",
+            description = "MANAGE_VISITOR 권한을 가진 담당 부서 직원이 PENDING 상태인 장기 방문 신청을 승인 혹은 반려합니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
@@ -8,7 +8,6 @@ import kr.co.awesomelead.groupware_backend.domain.notification.enums.Notificatio
 import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Authority;
-import kr.co.awesomelead.groupware_backend.domain.user.enums.JobType;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.request.CheckInRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.request.CheckOutRequestDto;
@@ -274,12 +273,12 @@ public class VisitService {
 
     @Transactional
     public Long checkOut(Long userId, CheckOutRequestDto dto) {
-        validateAdminAuthority(userId);
-
         Visit visit =
                 visitRepository
                         .findById(dto.getVisitId())
                         .orElseThrow(() -> new CustomException(ErrorCode.VISIT_NOT_FOUND));
+        User manager = validateVisitorManageAuthority(userId);
+        validateManagedDepartmentAccess(manager, visit);
 
         VisitRecord record =
                 visit.getRecords().stream()
@@ -439,7 +438,7 @@ public class VisitService {
             LocalDate startDate,
             LocalDate endDate,
             Pageable pageable) {
-        validateAdminAuthority(userId);
+        validateEmployeeAccess(userId);
 
         return visitQueryRepository
                 .findVisitsForAdmin(departmentId, status, startDate, endDate, pageable)
@@ -449,8 +448,7 @@ public class VisitService {
     // 직원용 방문 상세 조회
     @Transactional(readOnly = true)
     public MyVisitDetailResponseDto getVisitDetailForAdmin(Long userId, Long visitId) {
-
-        validateAdminAuthority(userId);
+        validateEmployeeAccess(userId);
 
         Visit visit =
                 visitRepository
@@ -474,15 +472,35 @@ public class VisitService {
         return responseDto;
     }
 
-    private void validateAdminAuthority(Long userId) {
+    private void validateEmployeeAccess(Long userId) {
+        userRepository
+                .findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private User validateVisitorManageAuthority(Long userId) {
         User user =
                 userRepository
                         .findById(userId)
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        // MANAGEMENT 직군이고 방문 관리 권한이 있는지 확인
-        if (user.getJobType() != JobType.MANAGEMENT
-                || !user.hasAuthority(Authority.MANAGE_VISITOR)) {
+        if (!user.hasAuthority(Authority.MANAGE_VISITOR)) {
+            throw new CustomException(ErrorCode.VISIT_ACCESS_DENIED);
+        }
+        return user;
+    }
+
+    private void validateManagedDepartmentAccess(User manager, Visit visit) {
+        Long managerDepartmentId =
+                manager.getDepartment() != null ? manager.getDepartment().getId() : null;
+        Long hostDepartmentId =
+                visit.getUser() != null && visit.getUser().getDepartment() != null
+                        ? visit.getUser().getDepartment().getId()
+                        : null;
+
+        if (managerDepartmentId == null
+                || hostDepartmentId == null
+                || !managerDepartmentId.equals(hostDepartmentId)) {
             throw new CustomException(ErrorCode.VISIT_ACCESS_DENIED);
         }
     }
@@ -490,14 +508,13 @@ public class VisitService {
     // 직원용 사전 장기방문 승인 및 반려
     @Transactional
     public void processVisit(Long userId, Long visitId, VisitProcessRequestDto dto) {
-        // 1. 관리 권한 확인 (MANAGEMENT 직군 & MANAGE_VISITOR 권한)
-        validateAdminAuthority(userId);
-
         // 2. 방문 신청 건 조회
         Visit visit =
                 visitRepository
                         .findById(visitId)
                         .orElseThrow(() -> new CustomException(ErrorCode.VISIT_NOT_FOUND));
+        User manager = validateVisitorManageAuthority(userId);
+        validateManagedDepartmentAccess(manager, visit);
 
         // 3. 승인 가능한 상태인지 검증
         // - 장기 방문이어야 함


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #363 

## 📝작업 내용
- 회원가입 승인 알림 흐름에서 completion 플래그/승인대기 해제 로직을 정리했습니다.
- 내정보수정 승인요청 알림 completion 계산 로직을 보완했습니다.
- `approvalOrRejectionCompleted`를 승인요청형 알림에서만 노출되도록 변경했습니다.
  - 비승인 알림(예: 입실 알림)에서는 해당 필드 미노출
- 내방객 권한 정책을 다음처럼 변경했습니다.
  - 조회(목록/상세): 전체 직원 가능
  - 처리(장기 방문 승인/반려, 퇴실): `MANAGE_VISITOR` 권한 + 담당부서 일치 필요
- 현장직 사용자도 관리자 역할을 할당할 수 있도록 기존 제한 검증을 제거했습니다.
- 관련 스웨거 설명/예시를 변경사항에 맞게 동기화했습니다.

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
x