### PR TITLE
feat(368): 교육/안전보건 리마인드 알림 API 추가

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
@@ -52,21 +52,49 @@ import java.util.List;
 @RequestMapping("/api/educations")
 public class EduReportController {
 
-        private final EduReportService eduReportService;
+    private final EduReportService eduReportService;
 
-        @Operation(tags = {
-                        "부서교육" }, summary = "부서 교육 게시물 생성", description = """
+    @Operation(
+            tags = {"부서교육"},
+            summary = "부서 교육 게시물 생성",
+            description =
+                    """
                                         `multipart/form-data`로 부서 교육 게시물을 생성합니다.
 
                                         - `requestDto`(JSON 파트)는 필수입니다.
                                         - `files`(파일 파트)는 선택입니다.
                                         - 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 있어야 생성할 수 있습니다.
-                                        """, requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE, schema = @Schema(implementation = DepartmentEduReportCreateMultipartRequestDoc.class), encoding = {
-                                        @Encoding(name = "requestDto", contentType = MediaType.APPLICATION_JSON_VALUE),
-                                        @Encoding(name = "files", contentType = "*/*")
-                        })))
-        @ApiResponses({
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "생성 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class), examples = @ExampleObject(value = """
+                                        """,
+            requestBody =
+                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                                            schema =
+                                                    @Schema(
+                                                            implementation =
+                                                                    DepartmentEduReportCreateMultipartRequestDoc
+                                                                            .class),
+                                            encoding = {
+                                                @Encoding(
+                                                        name = "requestDto",
+                                                        contentType =
+                                                                MediaType.APPLICATION_JSON_VALUE),
+                                                @Encoding(name = "files", contentType = "*/*")
+                                            })))
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "201",
+                description = "생성 성공",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                schema = @Schema(implementation = ApiResponse.class),
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                                         {
                                           "isSuccess": true,
                                           "code": "COMMON201",
@@ -74,7 +102,16 @@ public class EduReportController {
                                           "result": 1
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "권한 없음",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                                         {
                                           "isSuccess": false,
                                           "code": "NO_AUTHORITY_FOR_EDU_REPORT",
@@ -82,7 +119,16 @@ public class EduReportController {
                                           "result": null
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "리소스 없음",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                                         {
                                           "isSuccess": false,
                                           "code": "DEPARTMENT_NOT_FOUND",
@@ -90,26 +136,35 @@ public class EduReportController {
                                           "result": null
                                         }
                                         """)))
-        })
-        @PostMapping(value = "/department", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-        public ResponseEntity<ApiResponse<Long>> createDepartmentEduReport(
-                        @Parameter(description = "부서 교육 게시물 생성 정보(JSON)", required = true) @RequestPart("requestDto") @Valid DepartmentEduReportCreateRequestDto requestDto,
-                        @Parameter(description = "첨부 파일 목록(선택)") @RequestPart(value = "files", required = false) List<MultipartFile> files,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
-                        throws IOException {
+    })
+    @PostMapping(value = "/department", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Long>> createDepartmentEduReport(
+            @Parameter(description = "부서 교육 게시물 생성 정보(JSON)", required = true)
+                    @RequestPart("requestDto")
+                    @Valid
+                    DepartmentEduReportCreateRequestDto requestDto,
+            @Parameter(description = "첨부 파일 목록(선택)") @RequestPart(value = "files", required = false)
+                    List<MultipartFile> files,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
+            throws IOException {
 
-                Long reportId = eduReportService.createDepartmentEduReport(requestDto, files, userDetails.getId());
+        Long reportId =
+                eduReportService.createDepartmentEduReport(requestDto, files, userDetails.getId());
 
-                URI location = ServletUriComponentsBuilder.fromCurrentContextPath()
-                                .path("/api/educations/department/{id}")
-                                .buildAndExpand(reportId)
-                                .toUri();
+        URI location =
+                ServletUriComponentsBuilder.fromCurrentContextPath()
+                        .path("/api/educations/department/{id}")
+                        .buildAndExpand(reportId)
+                        .toUri();
 
-                return ResponseEntity.created(location).body(ApiResponse.onCreated(reportId));
-        }
+        return ResponseEntity.created(location).body(ApiResponse.onCreated(reportId));
+    }
 
-        @Operation(tags = {
-                        "PSM" }, summary = "PSM 게시물 생성", description = """
+    @Operation(
+            tags = {"PSM"},
+            summary = "PSM 게시물 생성",
+            description =
+                    """
                                         `multipart/form-data`로 PSM 게시물을 생성합니다.
 
                                         - `requestDto`(JSON 파트)는 필수입니다.
@@ -118,12 +173,36 @@ public class EduReportController {
                                         - `companyScope`는 회사 목록 배열입니다.
                                         - `[AWESOME]`처럼 1개를 보내면 해당 회사 게시물로 생성됩니다.
                                         - `[AWESOME, MARUI]`, `null`, `[]`는 모든 회사 공통 게시물로 생성됩니다.
-                                        """, requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE, schema = @Schema(implementation = PsmEduReportCreateMultipartRequestDoc.class), encoding = {
-                                        @Encoding(name = "requestDto", contentType = MediaType.APPLICATION_JSON_VALUE),
-                                        @Encoding(name = "files", contentType = "*/*")
-                        })))
-        @ApiResponses({
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "생성 성공", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                                        """,
+            requestBody =
+                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                                            schema =
+                                                    @Schema(
+                                                            implementation =
+                                                                    PsmEduReportCreateMultipartRequestDoc
+                                                                            .class),
+                                            encoding = {
+                                                @Encoding(
+                                                        name = "requestDto",
+                                                        contentType =
+                                                                MediaType.APPLICATION_JSON_VALUE),
+                                                @Encoding(name = "files", contentType = "*/*")
+                                            })))
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "201",
+                description = "생성 성공",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                                         {
                                           "isSuccess": true,
                                           "code": "COMMON201",
@@ -131,7 +210,16 @@ public class EduReportController {
                                           "result": 2
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "권한 없음",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                                         {
                                           "isSuccess": false,
                                           "code": "NO_AUTHORITY_FOR_PSM_MANAGE",
@@ -139,7 +227,16 @@ public class EduReportController {
                                           "result": null
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "리소스 없음",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                                         {
                                           "isSuccess": false,
                                           "code": "EDUCATION_CATEGORY_NOT_FOUND",
@@ -147,26 +244,34 @@ public class EduReportController {
                                           "result": null
                                         }
                                         """)))
-        })
-        @PostMapping(value = "/psm", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-        public ResponseEntity<ApiResponse<Long>> createPsmEduReport(
-                        @Parameter(description = "PSM 게시물 생성 정보(JSON)", required = true) @RequestPart("requestDto") @Valid PsmEduReportCreateRequestDto requestDto,
-                        @Parameter(description = "첨부 파일 목록(선택)") @RequestPart(value = "files", required = false) List<MultipartFile> files,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
-                        throws IOException {
+    })
+    @PostMapping(value = "/psm", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Long>> createPsmEduReport(
+            @Parameter(description = "PSM 게시물 생성 정보(JSON)", required = true)
+                    @RequestPart("requestDto")
+                    @Valid
+                    PsmEduReportCreateRequestDto requestDto,
+            @Parameter(description = "첨부 파일 목록(선택)") @RequestPart(value = "files", required = false)
+                    List<MultipartFile> files,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
+            throws IOException {
 
-                Long reportId = eduReportService.createPsmEduReport(requestDto, files, userDetails.getId());
+        Long reportId = eduReportService.createPsmEduReport(requestDto, files, userDetails.getId());
 
-                URI location = ServletUriComponentsBuilder.fromCurrentContextPath()
-                                .path("/api/educations/psm/{id}")
-                                .buildAndExpand(reportId)
-                                .toUri();
+        URI location =
+                ServletUriComponentsBuilder.fromCurrentContextPath()
+                        .path("/api/educations/psm/{id}")
+                        .buildAndExpand(reportId)
+                        .toUri();
 
-                return ResponseEntity.created(location).body(ApiResponse.onCreated(reportId));
-        }
+        return ResponseEntity.created(location).body(ApiResponse.onCreated(reportId));
+    }
 
-        @Operation(tags = {
-                        "안전보건" }, summary = "안전 보건 게시물 생성", description = """
+    @Operation(
+            tags = {"안전보건"},
+            summary = "안전 보건 게시물 생성",
+            description =
+                    """
                                         `multipart/form-data`로 안전 보건 게시물을 생성합니다.
 
                                         - `requestDto`(JSON 파트)는 필수입니다.
@@ -175,12 +280,36 @@ public class EduReportController {
                                         - `companyScope`는 회사 목록 배열입니다.
                                         - `[AWESOME]`처럼 1개를 보내면 해당 회사 게시물로 생성됩니다.
                                         - `[AWESOME, MARUI]`, `null`, `[]`는 모든 회사 공통 게시물로 생성됩니다.
-                                        """, requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE, schema = @Schema(implementation = SafetyEduReportCreateMultipartRequestDoc.class), encoding = {
-                                        @Encoding(name = "requestDto", contentType = MediaType.APPLICATION_JSON_VALUE),
-                                        @Encoding(name = "files", contentType = "*/*")
-                        })))
-        @ApiResponses({
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "생성 성공", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                                        """,
+            requestBody =
+                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                                            schema =
+                                                    @Schema(
+                                                            implementation =
+                                                                    SafetyEduReportCreateMultipartRequestDoc
+                                                                            .class),
+                                            encoding = {
+                                                @Encoding(
+                                                        name = "requestDto",
+                                                        contentType =
+                                                                MediaType.APPLICATION_JSON_VALUE),
+                                                @Encoding(name = "files", contentType = "*/*")
+                                            })))
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "201",
+                description = "생성 성공",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                                         {
                                           "isSuccess": true,
                                           "code": "COMMON201",
@@ -188,7 +317,16 @@ public class EduReportController {
                                           "result": 3
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "권한 없음",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                                         {
                                           "isSuccess": false,
                                           "code": "NO_AUTHORITY_FOR_SAFETY_WRITE",
@@ -196,7 +334,16 @@ public class EduReportController {
                                           "result": null
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "리소스 없음",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                                         {
                                           "isSuccess": false,
                                           "code": "EDUCATION_CATEGORY_NOT_FOUND",
@@ -204,66 +351,83 @@ public class EduReportController {
                                           "result": null
                                         }
                                         """)))
-        })
-        @PostMapping(value = "/safety", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-        public ResponseEntity<ApiResponse<Long>> createSafetyEduReport(
-                        @Parameter(description = "안전 보건 게시물 생성 정보(JSON)", required = true) @RequestPart("requestDto") @Valid SafetyEduReportCreateRequestDto requestDto,
-                        @Parameter(description = "첨부 파일 목록(선택)") @RequestPart(value = "files", required = false) List<MultipartFile> files,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
-                        throws IOException {
+    })
+    @PostMapping(value = "/safety", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Long>> createSafetyEduReport(
+            @Parameter(description = "안전 보건 게시물 생성 정보(JSON)", required = true)
+                    @RequestPart("requestDto")
+                    @Valid
+                    SafetyEduReportCreateRequestDto requestDto,
+            @Parameter(description = "첨부 파일 목록(선택)") @RequestPart(value = "files", required = false)
+                    List<MultipartFile> files,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
+            throws IOException {
 
-                Long reportId = eduReportService.createSafetyEduReport(requestDto, files, userDetails.getId());
+        Long reportId =
+                eduReportService.createSafetyEduReport(requestDto, files, userDetails.getId());
 
-                URI location = ServletUriComponentsBuilder.fromCurrentContextPath()
-                                .path("/api/educations/safety/{id}")
-                                .buildAndExpand(reportId)
-                                .toUri();
+        URI location =
+                ServletUriComponentsBuilder.fromCurrentContextPath()
+                        .path("/api/educations/safety/{id}")
+                        .buildAndExpand(reportId)
+                        .toUri();
 
-                return ResponseEntity.created(location).body(ApiResponse.onCreated(reportId));
-        }
+        return ResponseEntity.created(location).body(ApiResponse.onCreated(reportId));
+    }
 
-        @Schema(name = "DepartmentEduReportCreateMultipartRequestDoc", description = "부서 교육 게시물 생성 multipart 요청")
-        static class DepartmentEduReportCreateMultipartRequestDoc {
+    @Schema(
+            name = "DepartmentEduReportCreateMultipartRequestDoc",
+            description = "부서 교육 게시물 생성 multipart 요청")
+    static class DepartmentEduReportCreateMultipartRequestDoc {
 
-                @Schema(description = "부서 교육 게시물 생성 정보(JSON 파트)", requiredMode = Schema.RequiredMode.REQUIRED)
-                public DepartmentEduReportCreateRequestDto requestDto;
+        @Schema(
+                description = "부서 교육 게시물 생성 정보(JSON 파트)",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        public DepartmentEduReportCreateRequestDto requestDto;
 
-                @ArraySchema(schema = @Schema(type = "string", format = "binary"))
-                public List<String> files;
-        }
+        @ArraySchema(schema = @Schema(type = "string", format = "binary"))
+        public List<String> files;
+    }
 
-        @Schema(name = "PsmEduReportCreateMultipartRequestDoc", description = "PSM 게시물 생성 multipart 요청")
-        static class PsmEduReportCreateMultipartRequestDoc {
+    @Schema(name = "PsmEduReportCreateMultipartRequestDoc", description = "PSM 게시물 생성 multipart 요청")
+    static class PsmEduReportCreateMultipartRequestDoc {
 
-                @Schema(description = "PSM 게시물 생성 정보(JSON 파트)", requiredMode = Schema.RequiredMode.REQUIRED)
-                public PsmEduReportCreateRequestDto requestDto;
+        @Schema(description = "PSM 게시물 생성 정보(JSON 파트)", requiredMode = Schema.RequiredMode.REQUIRED)
+        public PsmEduReportCreateRequestDto requestDto;
 
-                @ArraySchema(schema = @Schema(type = "string", format = "binary"))
-                public List<String> files;
-        }
+        @ArraySchema(schema = @Schema(type = "string", format = "binary"))
+        public List<String> files;
+    }
 
-        @Schema(name = "SafetyEduReportCreateMultipartRequestDoc", description = "안전 보건 게시물 생성 multipart 요청")
-        static class SafetyEduReportCreateMultipartRequestDoc {
+    @Schema(
+            name = "SafetyEduReportCreateMultipartRequestDoc",
+            description = "안전 보건 게시물 생성 multipart 요청")
+    static class SafetyEduReportCreateMultipartRequestDoc {
 
-                @Schema(description = "안전 보건 게시물 생성 정보(JSON 파트)", requiredMode = Schema.RequiredMode.REQUIRED)
-                public SafetyEduReportCreateRequestDto requestDto;
+        @Schema(
+                description = "안전 보건 게시물 생성 정보(JSON 파트)",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        public SafetyEduReportCreateRequestDto requestDto;
 
-                @ArraySchema(schema = @Schema(type = "string", format = "binary"))
-                public List<String> files;
-        }
+        @ArraySchema(schema = @Schema(type = "string", format = "binary"))
+        public List<String> files;
+    }
 
-        @Schema(name = "EduReportUpdateMultipartRequestDoc", description = "교육 수정 multipart 요청")
-        static class EduReportUpdateMultipartRequestDoc {
+    @Schema(name = "EduReportUpdateMultipartRequestDoc", description = "교육 수정 multipart 요청")
+    static class EduReportUpdateMultipartRequestDoc {
 
-                @Schema(description = "교육 수정 정보(JSON 파트)", requiredMode = Schema.RequiredMode.REQUIRED)
-                public EduReportUpdateRequestDto requestDto;
+        @Schema(description = "교육 수정 정보(JSON 파트)", requiredMode = Schema.RequiredMode.REQUIRED)
+        public EduReportUpdateRequestDto requestDto;
 
-                @ArraySchema(schema = @Schema(type = "string", format = "binary"))
-                public List<String> files;
-        }
+        @ArraySchema(schema = @Schema(type = "string", format = "binary"))
+        public List<String> files;
+    }
 
-        @Operation(tags = {
-                        "부서교육" }, summary = "부서 교육 게시물 목록 조회", description = """
+    @Operation(
+            tags = {"부서교육"},
+            summary = "부서 교육 게시물 목록 조회",
+            description =
+                    """
                                         부서 교육 게시물 목록을 조회합니다.
 
                                         - `MANAGE_DEPARTMENT_EDUCATION` 권한 사용자는 `departmentName`으로 전체 부서 대상 필터 조회가 가능합니다.
@@ -272,8 +436,17 @@ public class EduReportController {
                                         - `mySigned`, `myCompletionStatus`는 부서교육 + 본인 소속 부서 게시물일 때만 값이 채워집니다.
                                         - `myCompletionStatus`는 `signatureRequired=false`이면 항상 `COMPLETED`이며, `signatureRequired=true`이면 내 서명 여부에 따라 `COMPLETED/INCOMPLETE`로 계산됩니다.
                                         """)
-        @ApiResponses({
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "조회 성공",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                                         {
                                           "isSuccess": true,
                                           "code": "COMMON200",
@@ -298,8 +471,17 @@ public class EduReportController {
                                           ]
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음", content = @Content(mediaType = "application/json", examples = {
-                                        @ExampleObject(name = "사용자 없음", value = """
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "리소스 없음",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples = {
+                                    @ExampleObject(
+                                            name = "사용자 없음",
+                                            value =
+                                                    """
                                                         {
                                                           "isSuccess": false,
                                                           "code": "USER_NOT_FOUND",
@@ -307,7 +489,10 @@ public class EduReportController {
                                                           "result": null
                                                         }
                                                         """),
-                                        @ExampleObject(name = "부서 없음", value = """
+                                    @ExampleObject(
+                                            name = "부서 없음",
+                                            value =
+                                                    """
                                                         {
                                                           "isSuccess": false,
                                                           "code": "DEPARTMENT_NOT_FOUND",
@@ -315,19 +500,28 @@ public class EduReportController {
                                                           "result": null
                                                         }
                                                         """)
-                        }))
-        })
-        @GetMapping("/department")
-        public ResponseEntity<ApiResponse<List<EduReportSummaryDto>>> getDepartmentEduReports(
-                        @Parameter(description = "부서명 필터(권한 사용자 전용)", example = "SALES_DEPT") @RequestParam(required = false) DepartmentName departmentName,
-                        @Parameter(description = "제목 검색 키워드 (FULLTEXT 검색)", example = "안전교육") @RequestParam(required = false) String title,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-                List<EduReportSummaryDto> reports = eduReportService.getDepartmentEduReports(
-                                departmentName, userDetails.getId(), title);
-                return ResponseEntity.ok(ApiResponse.onSuccess(reports));
-        }
+                                }))
+    })
+    @GetMapping("/department")
+    public ResponseEntity<ApiResponse<List<EduReportSummaryDto>>> getDepartmentEduReports(
+            @Parameter(description = "부서명 필터(권한 사용자 전용)", example = "SALES_DEPT")
+                    @RequestParam(required = false)
+                    DepartmentName departmentName,
+            @Parameter(description = "제목 검색 키워드 (FULLTEXT 검색)", example = "안전교육")
+                    @RequestParam(required = false)
+                    String title,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<EduReportSummaryDto> reports =
+                eduReportService.getDepartmentEduReports(
+                        departmentName, userDetails.getId(), title);
+        return ResponseEntity.ok(ApiResponse.onSuccess(reports));
+    }
 
-        @Operation(tags = { "PSM" }, summary = "PSM 게시물 목록 조회", description = """
+    @Operation(
+            tags = {"PSM"},
+            summary = "PSM 게시물 목록 조회",
+            description =
+                    """
                         PSM 게시물 목록을 조회합니다.
 
                         - `MANAGE_PSM` 권한 사용자는 모든 회사의 PSM 게시물을 조회할 수 있습니다.
@@ -335,8 +529,17 @@ public class EduReportController {
                         - 응답의 `companyScope`는 대상 회사 목록 배열로 반환됩니다.
                         - 공통 게시물은 `companyScope: ["AWESOME", "MARUI"]`로 응답됩니다.
                         """)
-        @ApiResponses({
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "조회 성공",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                                         {
                                           "isSuccess": true,
                                           "code": "COMMON200",
@@ -360,8 +563,17 @@ public class EduReportController {
                                           ]
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음", content = @Content(mediaType = "application/json", examples = {
-                                        @ExampleObject(name = "사용자 없음", value = """
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "리소스 없음",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples = {
+                                    @ExampleObject(
+                                            name = "사용자 없음",
+                                            value =
+                                                    """
                                                         {
                                                           "isSuccess": false,
                                                           "code": "USER_NOT_FOUND",
@@ -369,19 +581,27 @@ public class EduReportController {
                                                           "result": null
                                                         }
                                                         """)
-                        }))
-        })
-        @GetMapping("/psm")
-        public ResponseEntity<ApiResponse<List<EduReportSummaryDto>>> getPsmEduReports(
-                        @Parameter(description = "카테고리 ID 필터(PSM)", example = "1") @RequestParam(required = false) Long categoryId,
-                        @Parameter(description = "제목 검색 키워드 (FULLTEXT 검색)", example = "변경관리") @RequestParam(required = false) String title,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-                List<EduReportSummaryDto> reports = eduReportService.getPsmEduReports(categoryId, userDetails.getId(),
-                                title);
-                return ResponseEntity.ok(ApiResponse.onSuccess(reports));
-        }
+                                }))
+    })
+    @GetMapping("/psm")
+    public ResponseEntity<ApiResponse<List<EduReportSummaryDto>>> getPsmEduReports(
+            @Parameter(description = "카테고리 ID 필터(PSM)", example = "1")
+                    @RequestParam(required = false)
+                    Long categoryId,
+            @Parameter(description = "제목 검색 키워드 (FULLTEXT 검색)", example = "변경관리")
+                    @RequestParam(required = false)
+                    String title,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<EduReportSummaryDto> reports =
+                eduReportService.getPsmEduReports(categoryId, userDetails.getId(), title);
+        return ResponseEntity.ok(ApiResponse.onSuccess(reports));
+    }
 
-        @Operation(tags = { "안전보건" }, summary = "안전 보건 게시물 목록 조회", description = """
+    @Operation(
+            tags = {"안전보건"},
+            summary = "안전 보건 게시물 목록 조회",
+            description =
+                    """
                         안전 보건 게시물 목록을 조회합니다.
 
                         - `MANAGE_SAFETY` 권한 사용자는 모든 회사의 안전 보건 게시물을 조회할 수 있습니다.
@@ -389,8 +609,17 @@ public class EduReportController {
                         - 응답의 `companyScope`는 대상 회사 목록 배열로 반환됩니다.
                         - 공통 게시물은 `companyScope: ["AWESOME", "MARUI"]`로 응답됩니다.
                         """)
-        @ApiResponses({
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "조회 성공",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                                         {
                                           "isSuccess": true,
                                           "code": "COMMON200",
@@ -414,8 +643,17 @@ public class EduReportController {
                                           ]
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음", content = @Content(mediaType = "application/json", examples = {
-                                        @ExampleObject(name = "사용자 없음", value = """
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "리소스 없음",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples = {
+                                    @ExampleObject(
+                                            name = "사용자 없음",
+                                            value =
+                                                    """
                                                         {
                                                           "isSuccess": false,
                                                           "code": "USER_NOT_FOUND",
@@ -423,20 +661,27 @@ public class EduReportController {
                                                           "result": null
                                                         }
                                                         """)
-                        }))
-        })
-        @GetMapping("/safety")
-        public ResponseEntity<ApiResponse<List<EduReportSummaryDto>>> getSafetyEduReports(
-                        @Parameter(description = "카테고리 ID 필터(안전 보건)", example = "1") @RequestParam(required = false) Long categoryId,
-                        @Parameter(description = "제목 검색 키워드 (FULLTEXT 검색)", example = "정기교육") @RequestParam(required = false) String title,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-                List<EduReportSummaryDto> reports = eduReportService.getSafetyEduReports(categoryId,
-                                userDetails.getId(), title);
-                return ResponseEntity.ok(ApiResponse.onSuccess(reports));
-        }
+                                }))
+    })
+    @GetMapping("/safety")
+    public ResponseEntity<ApiResponse<List<EduReportSummaryDto>>> getSafetyEduReports(
+            @Parameter(description = "카테고리 ID 필터(안전 보건)", example = "1")
+                    @RequestParam(required = false)
+                    Long categoryId,
+            @Parameter(description = "제목 검색 키워드 (FULLTEXT 검색)", example = "정기교육")
+                    @RequestParam(required = false)
+                    String title,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<EduReportSummaryDto> reports =
+                eduReportService.getSafetyEduReports(categoryId, userDetails.getId(), title);
+        return ResponseEntity.ok(ApiResponse.onSuccess(reports));
+    }
 
-        @Operation(tags = {
-                        "부서교육" }, summary = "부서 교육 게시물 상세 조회", description = """
+    @Operation(
+            tags = {"부서교육"},
+            summary = "부서 교육 게시물 상세 조회",
+            description =
+                    """
                                         부서 교육 게시물 상세 정보를 조회합니다.
 
                                         - `MANAGE_DEPARTMENT_EDUCATION` 권한 사용자는 전체 부서의 부서 교육 게시물을 조회할 수 있습니다.
@@ -448,10 +693,21 @@ public class EduReportController {
                                         - `mySigned`, `myCompletionStatus`는 부서교육 + 본인 소속 부서 게시물일 때만 값이 채워집니다.
                                         - `myCompletionStatus`는 `signatureRequired=false`이면 항상 `COMPLETED`이며, `signatureRequired=true`이면 내 서명 여부에 따라 `COMPLETED/INCOMPLETE`로 계산됩니다.
                                         """)
-        @ApiResponses({
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음", content = @Content(mediaType = "application/json", examples = {
-                                        @ExampleObject(name = "게시물 없음", value = """
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "리소스 없음",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples = {
+                                    @ExampleObject(
+                                            name = "게시물 없음",
+                                            value =
+                                                    """
                                                         {
                                                           "isSuccess": false,
                                                           "code": "EDU_REPORT_NOT_FOUND",
@@ -459,7 +715,10 @@ public class EduReportController {
                                                           "result": null
                                                         }
                                                         """),
-                                        @ExampleObject(name = "타 부서 접근", value = """
+                                    @ExampleObject(
+                                            name = "타 부서 접근",
+                                            value =
+                                                    """
                                                         {
                                                           "isSuccess": false,
                                                           "code": "EDU_REPORT_NOT_FOUND",
@@ -467,7 +726,10 @@ public class EduReportController {
                                                           "result": null
                                                         }
                                                         """),
-                                        @ExampleObject(name = "사용자 없음", value = """
+                                    @ExampleObject(
+                                            name = "사용자 없음",
+                                            value =
+                                                    """
                                                         {
                                                           "isSuccess": false,
                                                           "code": "USER_NOT_FOUND",
@@ -475,17 +737,23 @@ public class EduReportController {
                                                           "result": null
                                                         }
                                                         """)
-                        }))
-        })
-        @GetMapping("/department/{educationId}")
-        public ResponseEntity<ApiResponse<EduReportDetailDto>> getDepartmentEduReport(
-                        @Parameter(description = "조회할 부서 교육 게시물 ID", example = "1") @PathVariable Long educationId,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-                EduReportDetailDto report = eduReportService.getDepartmentEduReport(educationId, userDetails.getId());
-                return ResponseEntity.ok(ApiResponse.onSuccess(report));
-        }
+                                }))
+    })
+    @GetMapping("/department/{educationId}")
+    public ResponseEntity<ApiResponse<EduReportDetailDto>> getDepartmentEduReport(
+            @Parameter(description = "조회할 부서 교육 게시물 ID", example = "1") @PathVariable
+                    Long educationId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        EduReportDetailDto report =
+                eduReportService.getDepartmentEduReport(educationId, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(report));
+    }
 
-        @Operation(tags = { "PSM" }, summary = "PSM 게시물 상세 조회", description = """
+    @Operation(
+            tags = {"PSM"},
+            summary = "PSM 게시물 상세 조회",
+            description =
+                    """
                         PSM 게시물 상세 정보를 조회합니다.
 
                         - `MANAGE_PSM` 권한 사용자는 모든 회사의 PSM 게시물을 조회할 수 있습니다.
@@ -494,10 +762,21 @@ public class EduReportController {
                         - 응답의 `companyScope`는 회사 목록 배열로 반환됩니다.
                         - 공통 게시물은 `companyScope: ["AWESOME", "MARUI"]`로 응답됩니다.
                         """)
-        @ApiResponses({
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음", content = @Content(mediaType = "application/json", examples = {
-                                        @ExampleObject(name = "게시물 없음", value = """
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "리소스 없음",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples = {
+                                    @ExampleObject(
+                                            name = "게시물 없음",
+                                            value =
+                                                    """
                                                         {
                                                           "isSuccess": false,
                                                           "code": "EDU_REPORT_NOT_FOUND",
@@ -505,7 +784,10 @@ public class EduReportController {
                                                           "result": null
                                                         }
                                                         """),
-                                        @ExampleObject(name = "타 회사 접근", value = """
+                                    @ExampleObject(
+                                            name = "타 회사 접근",
+                                            value =
+                                                    """
                                                         {
                                                           "isSuccess": false,
                                                           "code": "EDU_REPORT_NOT_FOUND",
@@ -513,7 +795,10 @@ public class EduReportController {
                                                           "result": null
                                                         }
                                                         """),
-                                        @ExampleObject(name = "사용자 없음", value = """
+                                    @ExampleObject(
+                                            name = "사용자 없음",
+                                            value =
+                                                    """
                                                         {
                                                           "isSuccess": false,
                                                           "code": "USER_NOT_FOUND",
@@ -521,17 +806,23 @@ public class EduReportController {
                                                           "result": null
                                                         }
                                                         """)
-                        }))
-        })
-        @GetMapping("/psm/{educationId}")
-        public ResponseEntity<ApiResponse<EduReportDetailDto>> getPsmEduReport(
-                        @Parameter(description = "조회할 PSM 게시물 ID", example = "1") @PathVariable Long educationId,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-                EduReportDetailDto report = eduReportService.getPsmEduReport(educationId, userDetails.getId());
-                return ResponseEntity.ok(ApiResponse.onSuccess(report));
-        }
+                                }))
+    })
+    @GetMapping("/psm/{educationId}")
+    public ResponseEntity<ApiResponse<EduReportDetailDto>> getPsmEduReport(
+            @Parameter(description = "조회할 PSM 게시물 ID", example = "1") @PathVariable
+                    Long educationId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        EduReportDetailDto report =
+                eduReportService.getPsmEduReport(educationId, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(report));
+    }
 
-        @Operation(tags = { "안전보건" }, summary = "안전 보건 게시물 상세 조회", description = """
+    @Operation(
+            tags = {"안전보건"},
+            summary = "안전 보건 게시물 상세 조회",
+            description =
+                    """
                         안전 보건 게시물 상세 정보를 조회합니다.
 
                         - `MANAGE_SAFETY` 권한 사용자는 모든 회사의 안전 보건 게시물을 조회할 수 있습니다.
@@ -540,10 +831,21 @@ public class EduReportController {
                         - 응답의 `companyScope`는 회사 목록 배열로 반환됩니다.
                         - 공통 게시물은 `companyScope: ["AWESOME", "MARUI"]`로 응답됩니다.
                         """)
-        @ApiResponses({
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음", content = @Content(mediaType = "application/json", examples = {
-                                        @ExampleObject(name = "게시물 없음", value = """
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "리소스 없음",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples = {
+                                    @ExampleObject(
+                                            name = "게시물 없음",
+                                            value =
+                                                    """
                                                         {
                                                           "isSuccess": false,
                                                           "code": "EDU_REPORT_NOT_FOUND",
@@ -551,7 +853,10 @@ public class EduReportController {
                                                           "result": null
                                                         }
                                                         """),
-                                        @ExampleObject(name = "타 회사 접근", value = """
+                                    @ExampleObject(
+                                            name = "타 회사 접근",
+                                            value =
+                                                    """
                                                         {
                                                           "isSuccess": false,
                                                           "code": "EDU_REPORT_NOT_FOUND",
@@ -559,7 +864,10 @@ public class EduReportController {
                                                           "result": null
                                                         }
                                                         """),
-                                        @ExampleObject(name = "사용자 없음", value = """
+                                    @ExampleObject(
+                                            name = "사용자 없음",
+                                            value =
+                                                    """
                                                         {
                                                           "isSuccess": false,
                                                           "code": "USER_NOT_FOUND",
@@ -567,18 +875,23 @@ public class EduReportController {
                                                           "result": null
                                                         }
                                                         """)
-                        }))
-        })
-        @GetMapping("/safety/{educationId}")
-        public ResponseEntity<ApiResponse<EduReportDetailDto>> getSafetyEduReport(
-                        @Parameter(description = "조회할 안전 보건 게시물 ID", example = "1") @PathVariable Long educationId,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-                EduReportDetailDto report = eduReportService.getSafetyEduReport(educationId, userDetails.getId());
-                return ResponseEntity.ok(ApiResponse.onSuccess(report));
-        }
+                                }))
+    })
+    @GetMapping("/safety/{educationId}")
+    public ResponseEntity<ApiResponse<EduReportDetailDto>> getSafetyEduReport(
+            @Parameter(description = "조회할 안전 보건 게시물 ID", example = "1") @PathVariable
+                    Long educationId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        EduReportDetailDto report =
+                eduReportService.getSafetyEduReport(educationId, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(report));
+    }
 
-        @Operation(tags = {
-                        "부서교육" }, summary = "부서 교육 게시물 수정", description = """
+    @Operation(
+            tags = {"부서교육"},
+            summary = "부서 교육 게시물 수정",
+            description =
+                    """
                                         `multipart/form-data`로 부서 교육 게시물을 수정합니다.
 
                                         - 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 필요합니다.
@@ -586,40 +899,76 @@ public class EduReportController {
                                         - 출석 완료자가 1명이라도 있으면 수정할 수 없습니다.
                                         - `requestDto`(JSON 파트)는 필수이며, `files`(파일 파트)는 선택입니다.
                                         - `requestDto.deleteAttachmentIds`로 기존 첨부파일 삭제가 가능합니다.
-                                        """, requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE, schema = @Schema(implementation = EduReportUpdateMultipartRequestDoc.class), encoding = {
-                                        @Encoding(name = "requestDto", contentType = MediaType.APPLICATION_JSON_VALUE),
-                                        @Encoding(name = "files", contentType = "*/*")
-                        })))
-        @ApiResponses({
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음")
-        })
-        @PatchMapping(value = "/department/{educationId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-        public ResponseEntity<ApiResponse<Long>> updateDepartmentEducation(
-                        @Parameter(description = "수정할 부서 교육 게시물 ID", example = "1") @PathVariable Long educationId,
-                        @Parameter(description = "부서 교육 수정 정보(JSON)", required = true) @RequestPart("requestDto") @Valid EduReportUpdateRequestDto requestDto,
-                        @Parameter(description = "추가할 첨부 파일 목록(선택)") @RequestPart(value = "files", required = false) List<MultipartFile> files,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-                Long updatedId = eduReportService.updateDepartmentEduReport(
-                                educationId, requestDto, files, userDetails.getId());
-                return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
-        }
+                                        """,
+            requestBody =
+                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                                            schema =
+                                                    @Schema(
+                                                            implementation =
+                                                                    EduReportUpdateMultipartRequestDoc
+                                                                            .class),
+                                            encoding = {
+                                                @Encoding(
+                                                        name = "requestDto",
+                                                        contentType =
+                                                                MediaType.APPLICATION_JSON_VALUE),
+                                                @Encoding(name = "files", contentType = "*/*")
+                                            })))
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "수정 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "권한 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "리소스 없음")
+    })
+    @PatchMapping(
+            value = "/department/{educationId}",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Long>> updateDepartmentEducation(
+            @Parameter(description = "수정할 부서 교육 게시물 ID", example = "1") @PathVariable
+                    Long educationId,
+            @Parameter(description = "부서 교육 수정 정보(JSON)", required = true)
+                    @RequestPart("requestDto")
+                    @Valid
+                    EduReportUpdateRequestDto requestDto,
+            @Parameter(description = "추가할 첨부 파일 목록(선택)")
+                    @RequestPart(value = "files", required = false)
+                    List<MultipartFile> files,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long updatedId =
+                eduReportService.updateDepartmentEduReport(
+                        educationId, requestDto, files, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
+    }
 
-        @Hidden
-        @PatchMapping(value = "/department/{educationId}", consumes = MediaType.APPLICATION_JSON_VALUE)
-        public ResponseEntity<ApiResponse<Long>> updateDepartmentEducationJsonFallback(
-                        @PathVariable Long educationId,
-                        @Valid @RequestBody EduReportUpdateRequestDto requestDto,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-                Long updatedId = eduReportService.updateDepartmentEduReport(
-                                educationId, requestDto, userDetails.getId());
-                return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
-        }
+    @Hidden
+    @PatchMapping(value = "/department/{educationId}", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ApiResponse<Long>> updateDepartmentEducationJsonFallback(
+            @PathVariable Long educationId,
+            @Valid @RequestBody EduReportUpdateRequestDto requestDto,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long updatedId =
+                eduReportService.updateDepartmentEduReport(
+                        educationId, requestDto, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
+    }
 
-        @Operation(tags = {
-                        "PSM" }, summary = "PSM 게시물 수정", description = """
+    @Operation(
+            tags = {"PSM"},
+            summary = "PSM 게시물 수정",
+            description =
+                    """
                                         `multipart/form-data`로 PSM 게시물을 수정합니다.
 
                                         - PSM 관리 권한(`MANAGE_PSM`)이 필요합니다.
@@ -627,39 +976,73 @@ public class EduReportController {
                                         - 출석 완료자가 1명이라도 있으면 수정할 수 없습니다.
                                         - `requestDto`(JSON 파트)는 필수이며, `files`(파일 파트)는 선택입니다.
                                         - `requestDto.deleteAttachmentIds`로 기존 첨부파일 삭제가 가능합니다.
-                                        """, requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE, schema = @Schema(implementation = EduReportUpdateMultipartRequestDoc.class), encoding = {
-                                        @Encoding(name = "requestDto", contentType = MediaType.APPLICATION_JSON_VALUE),
-                                        @Encoding(name = "files", contentType = "*/*")
-                        })))
-        @ApiResponses({
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음")
-        })
-        @PatchMapping(value = "/psm/{educationId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-        public ResponseEntity<ApiResponse<Long>> updatePsmEducation(
-                        @Parameter(description = "수정할 PSM 게시물 ID", example = "1") @PathVariable Long educationId,
-                        @Parameter(description = "PSM 수정 정보(JSON)", required = true) @RequestPart("requestDto") @Valid EduReportUpdateRequestDto requestDto,
-                        @Parameter(description = "추가할 첨부 파일 목록(선택)") @RequestPart(value = "files", required = false) List<MultipartFile> files,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-                Long updatedId = eduReportService.updatePsmEduReport(
-                                educationId, requestDto, files, userDetails.getId());
-                return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
-        }
+                                        """,
+            requestBody =
+                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                                            schema =
+                                                    @Schema(
+                                                            implementation =
+                                                                    EduReportUpdateMultipartRequestDoc
+                                                                            .class),
+                                            encoding = {
+                                                @Encoding(
+                                                        name = "requestDto",
+                                                        contentType =
+                                                                MediaType.APPLICATION_JSON_VALUE),
+                                                @Encoding(name = "files", contentType = "*/*")
+                                            })))
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "수정 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "권한 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "리소스 없음")
+    })
+    @PatchMapping(value = "/psm/{educationId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Long>> updatePsmEducation(
+            @Parameter(description = "수정할 PSM 게시물 ID", example = "1") @PathVariable
+                    Long educationId,
+            @Parameter(description = "PSM 수정 정보(JSON)", required = true)
+                    @RequestPart("requestDto")
+                    @Valid
+                    EduReportUpdateRequestDto requestDto,
+            @Parameter(description = "추가할 첨부 파일 목록(선택)")
+                    @RequestPart(value = "files", required = false)
+                    List<MultipartFile> files,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long updatedId =
+                eduReportService.updatePsmEduReport(
+                        educationId, requestDto, files, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
+    }
 
-        @Hidden
-        @PatchMapping(value = "/psm/{educationId}", consumes = MediaType.APPLICATION_JSON_VALUE)
-        public ResponseEntity<ApiResponse<Long>> updatePsmEducationJsonFallback(
-                        @PathVariable Long educationId,
-                        @Valid @RequestBody EduReportUpdateRequestDto requestDto,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-                Long updatedId = eduReportService.updatePsmEduReport(educationId, requestDto, userDetails.getId());
-                return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
-        }
+    @Hidden
+    @PatchMapping(value = "/psm/{educationId}", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ApiResponse<Long>> updatePsmEducationJsonFallback(
+            @PathVariable Long educationId,
+            @Valid @RequestBody EduReportUpdateRequestDto requestDto,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long updatedId =
+                eduReportService.updatePsmEduReport(educationId, requestDto, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
+    }
 
-        @Operation(tags = {
-                        "안전보건" }, summary = "안전 보건 게시물 수정", description = """
+    @Operation(
+            tags = {"안전보건"},
+            summary = "안전 보건 게시물 수정",
+            description =
+                    """
                                         `multipart/form-data`로 안전 보건 게시물을 수정합니다.
 
                                         - 안전 보건 관리 권한(`MANAGE_SAFETY`)이 필요합니다.
@@ -667,199 +1050,355 @@ public class EduReportController {
                                         - 출석 완료자가 1명이라도 있으면 수정할 수 없습니다.
                                         - `requestDto`(JSON 파트)는 필수이며, `files`(파일 파트)는 선택입니다.
                                         - `requestDto.deleteAttachmentIds`로 기존 첨부파일 삭제가 가능합니다.
-                                        """, requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE, schema = @Schema(implementation = EduReportUpdateMultipartRequestDoc.class), encoding = {
-                                        @Encoding(name = "requestDto", contentType = MediaType.APPLICATION_JSON_VALUE),
-                                        @Encoding(name = "files", contentType = "*/*")
-                        })))
-        @ApiResponses({
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음")
-        })
-        @PatchMapping(value = "/safety/{educationId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-        public ResponseEntity<ApiResponse<Long>> updateSafetyEducation(
-                        @Parameter(description = "수정할 안전 보건 게시물 ID", example = "1") @PathVariable Long educationId,
-                        @Parameter(description = "안전 보건 수정 정보(JSON)", required = true) @RequestPart("requestDto") @Valid EduReportUpdateRequestDto requestDto,
-                        @Parameter(description = "추가할 첨부 파일 목록(선택)") @RequestPart(value = "files", required = false) List<MultipartFile> files,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-                Long updatedId = eduReportService.updateSafetyEduReport(
-                                educationId, requestDto, files, userDetails.getId());
-                return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
-        }
+                                        """,
+            requestBody =
+                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                                            schema =
+                                                    @Schema(
+                                                            implementation =
+                                                                    EduReportUpdateMultipartRequestDoc
+                                                                            .class),
+                                            encoding = {
+                                                @Encoding(
+                                                        name = "requestDto",
+                                                        contentType =
+                                                                MediaType.APPLICATION_JSON_VALUE),
+                                                @Encoding(name = "files", contentType = "*/*")
+                                            })))
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "수정 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "권한 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "리소스 없음")
+    })
+    @PatchMapping(value = "/safety/{educationId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Long>> updateSafetyEducation(
+            @Parameter(description = "수정할 안전 보건 게시물 ID", example = "1") @PathVariable
+                    Long educationId,
+            @Parameter(description = "안전 보건 수정 정보(JSON)", required = true)
+                    @RequestPart("requestDto")
+                    @Valid
+                    EduReportUpdateRequestDto requestDto,
+            @Parameter(description = "추가할 첨부 파일 목록(선택)")
+                    @RequestPart(value = "files", required = false)
+                    List<MultipartFile> files,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long updatedId =
+                eduReportService.updateSafetyEduReport(
+                        educationId, requestDto, files, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
+    }
 
-        @Hidden
-        @PatchMapping(value = "/safety/{educationId}", consumes = MediaType.APPLICATION_JSON_VALUE)
-        public ResponseEntity<ApiResponse<Long>> updateSafetyEducationJsonFallback(
-                        @PathVariable Long educationId,
-                        @Valid @RequestBody EduReportUpdateRequestDto requestDto,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-                Long updatedId = eduReportService.updateSafetyEduReport(
-                                educationId, requestDto, userDetails.getId());
-                return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
-        }
+    @Hidden
+    @PatchMapping(value = "/safety/{educationId}", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ApiResponse<Long>> updateSafetyEducationJsonFallback(
+            @PathVariable Long educationId,
+            @Valid @RequestBody EduReportUpdateRequestDto requestDto,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long updatedId =
+                eduReportService.updateSafetyEduReport(
+                        educationId, requestDto, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
+    }
 
-        @Operation(tags = { "부서교육" }, summary = "부서 교육 게시물 상태 변경", description = """
+    @Operation(
+            tags = {"부서교육"},
+            summary = "부서 교육 게시물 상태 변경",
+            description =
+                    """
                         부서 교육 게시물 상태를 `OPEN`/`CLOSED`로 변경합니다.
 
                         - 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 필요합니다.
                         """)
-        @ApiResponses({
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "상태 변경 성공"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음")
-        })
-        @PatchMapping("/department/{educationId}/status")
-        public ResponseEntity<ApiResponse<Long>> updateDepartmentEducationStatus(
-                        @Parameter(description = "상태 변경할 부서 교육 게시물 ID", example = "1") @PathVariable Long educationId,
-                        @Valid @RequestBody EduReportStatusUpdateRequestDto requestDto,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-                Long updatedId = eduReportService.updateDepartmentEduReportStatus(
-                                educationId, requestDto, userDetails.getId());
-                return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
-        }
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "상태 변경 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "권한 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "리소스 없음")
+    })
+    @PatchMapping("/department/{educationId}/status")
+    public ResponseEntity<ApiResponse<Long>> updateDepartmentEducationStatus(
+            @Parameter(description = "상태 변경할 부서 교육 게시물 ID", example = "1") @PathVariable
+                    Long educationId,
+            @Valid @RequestBody EduReportStatusUpdateRequestDto requestDto,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long updatedId =
+                eduReportService.updateDepartmentEduReportStatus(
+                        educationId, requestDto, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
+    }
 
-        @Operation(tags = { "PSM" }, summary = "PSM 게시물 상태 변경", description = """
+    @Operation(
+            tags = {"PSM"},
+            summary = "PSM 게시물 상태 변경",
+            description =
+                    """
                         PSM 게시물 상태를 `OPEN`/`CLOSED`로 변경합니다.
 
                         - PSM 관리 권한(`MANAGE_PSM`)이 필요합니다.
                         """)
-        @ApiResponses({
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "상태 변경 성공"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음")
-        })
-        @PatchMapping("/psm/{educationId}/status")
-        public ResponseEntity<ApiResponse<Long>> updatePsmEducationStatus(
-                        @Parameter(description = "상태 변경할 PSM 게시물 ID", example = "1") @PathVariable Long educationId,
-                        @Valid @RequestBody EduReportStatusUpdateRequestDto requestDto,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-                Long updatedId = eduReportService.updatePsmEduReportStatus(
-                                educationId, requestDto, userDetails.getId());
-                return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
-        }
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "상태 변경 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "권한 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "리소스 없음")
+    })
+    @PatchMapping("/psm/{educationId}/status")
+    public ResponseEntity<ApiResponse<Long>> updatePsmEducationStatus(
+            @Parameter(description = "상태 변경할 PSM 게시물 ID", example = "1") @PathVariable
+                    Long educationId,
+            @Valid @RequestBody EduReportStatusUpdateRequestDto requestDto,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long updatedId =
+                eduReportService.updatePsmEduReportStatus(
+                        educationId, requestDto, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
+    }
 
-        @Operation(tags = { "안전보건" }, summary = "안전 보건 게시물 상태 변경", description = """
+    @Operation(
+            tags = {"안전보건"},
+            summary = "안전 보건 게시물 상태 변경",
+            description =
+                    """
                         안전 보건 게시물 상태를 `OPEN`/`CLOSED`로 변경합니다.
 
                         - 안전 보건 관리 권한(`MANAGE_SAFETY`)이 필요합니다.
                         """)
-        @ApiResponses({
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "상태 변경 성공"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음")
-        })
-        @PatchMapping("/safety/{educationId}/status")
-        public ResponseEntity<ApiResponse<Long>> updateSafetyEducationStatus(
-                        @Parameter(description = "상태 변경할 안전 보건 게시물 ID", example = "1") @PathVariable Long educationId,
-                        @Valid @RequestBody EduReportStatusUpdateRequestDto requestDto,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-                Long updatedId = eduReportService.updateSafetyEduReportStatus(
-                                educationId, requestDto, userDetails.getId());
-                return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
-        }
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "상태 변경 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "권한 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "리소스 없음")
+    })
+    @PatchMapping("/safety/{educationId}/status")
+    public ResponseEntity<ApiResponse<Long>> updateSafetyEducationStatus(
+            @Parameter(description = "상태 변경할 안전 보건 게시물 ID", example = "1") @PathVariable
+                    Long educationId,
+            @Valid @RequestBody EduReportStatusUpdateRequestDto requestDto,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long updatedId =
+                eduReportService.updateSafetyEduReportStatus(
+                        educationId, requestDto, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
+    }
 
-        @Operation(tags = {
-                        "부서교육" }, summary = "부서 교육 게시물 삭제", description = "부서 교육 게시물을 삭제합니다. 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 필요합니다.")
-        @ApiResponses({
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "삭제 성공"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음")
-        })
-        @DeleteMapping("/department/{educationId}")
-        public ResponseEntity<ApiResponse<Void>> deleteDepartmentEduReport(
-                        @Parameter(description = "삭제할 부서 교육 게시물 ID", example = "1") @PathVariable Long educationId,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-                eduReportService.deleteDepartmentEduReport(educationId, userDetails.getId());
-                return ResponseEntity.ok().body(ApiResponse.onNoContent());
-        }
+    @Operation(
+            tags = {"부서교육"},
+            summary = "부서 교육 게시물 삭제",
+            description = "부서 교육 게시물을 삭제합니다. 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 필요합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "삭제 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "권한 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "리소스 없음")
+    })
+    @DeleteMapping("/department/{educationId}")
+    public ResponseEntity<ApiResponse<Void>> deleteDepartmentEduReport(
+            @Parameter(description = "삭제할 부서 교육 게시물 ID", example = "1") @PathVariable
+                    Long educationId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        eduReportService.deleteDepartmentEduReport(educationId, userDetails.getId());
+        return ResponseEntity.ok().body(ApiResponse.onNoContent());
+    }
 
-        @Operation(tags = {
-                        "PSM" }, summary = "PSM 게시물 삭제", description = "PSM 게시물을 삭제합니다. PSM 관리 권한(`MANAGE_PSM`)이 필요합니다.")
-        @ApiResponses({
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "삭제 성공"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음")
-        })
-        @DeleteMapping("/psm/{educationId}")
-        public ResponseEntity<ApiResponse<Void>> deletePsmEduReport(
-                        @Parameter(description = "삭제할 PSM 게시물 ID", example = "1") @PathVariable Long educationId,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-                eduReportService.deletePsmEduReport(educationId, userDetails.getId());
-                return ResponseEntity.ok().body(ApiResponse.onNoContent());
-        }
+    @Operation(
+            tags = {"PSM"},
+            summary = "PSM 게시물 삭제",
+            description = "PSM 게시물을 삭제합니다. PSM 관리 권한(`MANAGE_PSM`)이 필요합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "삭제 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "권한 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "리소스 없음")
+    })
+    @DeleteMapping("/psm/{educationId}")
+    public ResponseEntity<ApiResponse<Void>> deletePsmEduReport(
+            @Parameter(description = "삭제할 PSM 게시물 ID", example = "1") @PathVariable
+                    Long educationId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        eduReportService.deletePsmEduReport(educationId, userDetails.getId());
+        return ResponseEntity.ok().body(ApiResponse.onNoContent());
+    }
 
-        @Operation(tags = {
-                        "안전보건" }, summary = "안전 보건 게시물 삭제", description = "안전 보건 게시물을 삭제합니다. 안전 보건 관리 권한(`MANAGE_SAFETY`)이 필요합니다.")
-        @ApiResponses({
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "삭제 성공"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음")
-        })
-        @DeleteMapping("/safety/{educationId}")
-        public ResponseEntity<ApiResponse<Void>> deleteSafetyEduReport(
-                        @Parameter(description = "삭제할 안전 보건 게시물 ID", example = "1") @PathVariable Long educationId,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-                eduReportService.deleteSafetyEduReport(educationId, userDetails.getId());
-                return ResponseEntity.ok().body(ApiResponse.onNoContent());
-        }
+    @Operation(
+            tags = {"안전보건"},
+            summary = "안전 보건 게시물 삭제",
+            description = "안전 보건 게시물을 삭제합니다. 안전 보건 관리 권한(`MANAGE_SAFETY`)이 필요합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "삭제 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "권한 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "리소스 없음")
+    })
+    @DeleteMapping("/safety/{educationId}")
+    public ResponseEntity<ApiResponse<Void>> deleteSafetyEduReport(
+            @Parameter(description = "삭제할 안전 보건 게시물 ID", example = "1") @PathVariable
+                    Long educationId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        eduReportService.deleteSafetyEduReport(educationId, userDetails.getId());
+        return ResponseEntity.ok().body(ApiResponse.onNoContent());
+    }
 
-        @Operation(tags = {
-                        "부서교육" }, summary = "부서 교육 게시물 출석(서명) 처리", description = """
+    @Operation(
+            tags = {"부서교육"},
+            summary = "부서 교육 게시물 출석(서명) 처리",
+            description =
+                    """
                                         부서 교육 게시물 출석을 처리합니다.
 
                                         - `signatureRequired=true` 게시물은 PNG 서명 파일(`signature`)이 필수입니다.
                                         - `signatureRequired=false` 게시물은 파일 없이도 출석 처리됩니다.
                                         - 동일 사용자 중복 출석은 허용되지 않습니다.
-                                        """, requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(required = false, content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE, schema = @Schema(implementation = EduReportAttendanceMultipartRequestDoc.class), encoding = @Encoding(name = "signature", contentType = "image/png"))))
-        @ApiResponses(value = {
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "출석 처리 성공"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음")
-        })
-        @PostMapping(value = "/department/{educationId}/attendance", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-        public ResponseEntity<ApiResponse<Void>> markDepartmentAttendance(
-                        @Parameter(description = "부서 교육 게시물 ID", example = "1") @PathVariable Long educationId,
-                        @Parameter(description = "서명 PNG 파일(signatureRequired=true인 경우 필수)") @RequestPart(value = "signature", required = false) MultipartFile signature,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
-                        throws IOException {
-                eduReportService.markDepartmentAttendance(educationId, signature, userDetails.getId());
-                return ResponseEntity.ok(ApiResponse.onNoContent());
-        }
+                                        """,
+            requestBody =
+                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            required = false,
+                            content =
+                                    @Content(
+                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                                            schema =
+                                                    @Schema(
+                                                            implementation =
+                                                                    EduReportAttendanceMultipartRequestDoc
+                                                                            .class),
+                                            encoding =
+                                                    @Encoding(
+                                                            name = "signature",
+                                                            contentType = "image/png"))))
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "출석 처리 성공"),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "400",
+                        description = "잘못된 요청"),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "404",
+                        description = "리소스 없음")
+            })
+    @PostMapping(
+            value = "/department/{educationId}/attendance",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Void>> markDepartmentAttendance(
+            @Parameter(description = "부서 교육 게시물 ID", example = "1") @PathVariable Long educationId,
+            @Parameter(description = "서명 PNG 파일(signatureRequired=true인 경우 필수)")
+                    @RequestPart(value = "signature", required = false)
+                    MultipartFile signature,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
+            throws IOException {
+        eduReportService.markDepartmentAttendance(educationId, signature, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onNoContent());
+    }
 
-        @Operation(tags = { "부서교육" }, summary = "부서 교육 서명 현황 목록 조회", description = """
+    @Operation(
+            tags = {"부서교육"},
+            summary = "부서 교육 서명 현황 목록 조회",
+            description =
+                    """
                         부서 교육 게시물의 대상 직원별 서명 현황을 조회합니다.
 
                         - `MANAGE_DEPARTMENT_EDUCATION` 권한이 필요합니다.
                         - `name` 파라미터로 한글명(nameKor) 또는 영문명(nameEng)에 대한 부분 일치 검색이 가능합니다.
                         """)
-        @ApiResponses({
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음")
-        })
-        @GetMapping("/{educationId}/signatures")
-        public ResponseEntity<ApiResponse<List<EduReportSignatureStatusDto>>> getSignatureStatuses(
-                        @Parameter(description = "교육 보고서 ID", example = "1") @PathVariable Long educationId,
-                        @Parameter(description = "직원명 검색 필터 (한글명/영문명 부분 일치)", example = "홍") @RequestParam(required = false) String name,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-                List<EduReportSignatureStatusDto> result = eduReportService.getSignatureStatuses(educationId, name,
-                                userDetails.getId());
-                return ResponseEntity.ok(ApiResponse.onSuccess(result));
-        }
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "권한 없음"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "리소스 없음")
+    })
+    @GetMapping("/{educationId}/signatures")
+    public ResponseEntity<ApiResponse<List<EduReportSignatureStatusDto>>> getSignatureStatuses(
+            @Parameter(description = "교육 보고서 ID", example = "1") @PathVariable Long educationId,
+            @Parameter(description = "직원명 검색 필터 (한글명/영문명 부분 일치)", example = "홍")
+                    @RequestParam(required = false)
+                    String name,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<EduReportSignatureStatusDto> result =
+                eduReportService.getSignatureStatuses(educationId, name, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
+    }
 
-        @Operation(tags = { "교육 (공통)" }, summary = "교육 리마인드 알림 전송", description = """
+    @Operation(
+            tags = {"교육 (공통)"},
+            summary = "교육 리마인드 알림 전송",
+            description =
+                    """
                         교육 생성자(createdBy)만 요청 가능합니다.
 
                         - 생성 시와 동일한 대상자에게 title에 `[리마인드]` prefix를 붙여 알림을 재전송합니다.
                         - 부서교육 / PSM / 안전보건 모든 타입에 사용 가능합니다.
                         """)
-        @ApiResponses({
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "전송 성공"),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음 (교육 생성자가 아님)", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "전송 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "권한 없음 (교육 생성자가 아님)",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                                         {
                                           "isSuccess": false,
                                           "code": "NO_AUTHORITY_FOR_EDU_REPORT",
@@ -867,7 +1406,16 @@ public class EduReportController {
                                           "result": null
                                         }
                                         """))),
-                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "교육 게시물 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "교육 게시물 없음",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                                         {
                                           "isSuccess": false,
                                           "code": "EDU_REPORT_NOT_FOUND",
@@ -875,19 +1423,23 @@ public class EduReportController {
                                           "result": null
                                         }
                                         """)))
-        })
-        @PostMapping("/{educationId}/remind")
-        public ResponseEntity<ApiResponse<Void>> remindEduReport(
-                        @Parameter(description = "리마인드 알림을 전송할 교육 게시물 ID", example = "1") @PathVariable Long educationId,
-                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-                eduReportService.remindEduReport(educationId, userDetails.getId());
-                return ResponseEntity.ok(ApiResponse.onNoContent());
-        }
+    })
+    @PostMapping("/{educationId}/remind")
+    public ResponseEntity<ApiResponse<Void>> remindEduReport(
+            @Parameter(description = "리마인드 알림을 전송할 교육 게시물 ID", example = "1") @PathVariable
+                    Long educationId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        eduReportService.remindEduReport(educationId, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onNoContent());
+    }
 
-        @Schema(name = "EduReportAttendanceMultipartRequestDoc", description = "출석(서명) multipart 요청")
-        static class EduReportAttendanceMultipartRequestDoc {
+    @Schema(name = "EduReportAttendanceMultipartRequestDoc", description = "출석(서명) multipart 요청")
+    static class EduReportAttendanceMultipartRequestDoc {
 
-                @Schema(description = "서명 PNG 파일(signatureRequired=true인 경우 필수)", type = "string", format = "binary")
-                public String signature;
-        }
+        @Schema(
+                description = "서명 PNG 파일(signatureRequired=true인 경우 필수)",
+                type = "string",
+                format = "binary")
+        public String signature;
+    }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
@@ -52,1336 +52,842 @@ import java.util.List;
 @RequestMapping("/api/educations")
 public class EduReportController {
 
-    private final EduReportService eduReportService;
+        private final EduReportService eduReportService;
 
-    @Operation(
-            tags = {"부서교육"},
-            summary = "부서 교육 게시물 생성",
-            description =
-                    """
-                `multipart/form-data`로 부서 교육 게시물을 생성합니다.
+        @Operation(tags = {
+                        "부서교육" }, summary = "부서 교육 게시물 생성", description = """
+                                        `multipart/form-data`로 부서 교육 게시물을 생성합니다.
 
-                - `requestDto`(JSON 파트)는 필수입니다.
-                - `files`(파일 파트)는 선택입니다.
-                - 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 있어야 생성할 수 있습니다.
-                """,
-            requestBody =
-                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                            required = true,
-                            content =
-                                    @Content(
-                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-                                            schema =
-                                                    @Schema(
-                                                            implementation =
-                                                                    DepartmentEduReportCreateMultipartRequestDoc
-                                                                            .class),
-                                            encoding = {
-                                                @Encoding(
-                                                        name = "requestDto",
-                                                        contentType =
-                                                                MediaType.APPLICATION_JSON_VALUE),
-                                                @Encoding(name = "files", contentType = "*/*")
-                                            })))
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "201",
-                description = "생성 성공",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                schema = @Schema(implementation = ApiResponse.class),
-                                examples =
-                                        @ExampleObject(
-                                                value =
-                                                        """
-                            {
-                              "isSuccess": true,
-                              "code": "COMMON201",
-                              "message": "성공적으로 생성되었습니다.",
-                              "result": 1
-                            }
-                            """))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "403",
-                description = "권한 없음",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples =
-                                        @ExampleObject(
-                                                value =
-                                                        """
-                            {
-                              "isSuccess": false,
-                              "code": "NO_AUTHORITY_FOR_EDU_REPORT",
-                              "message": "교육 게시물 관리 권한이 없습니다.",
-                              "result": null
-                            }
-                            """))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples =
-                                        @ExampleObject(
-                                                value =
-                                                        """
-                            {
-                              "isSuccess": false,
-                              "code": "DEPARTMENT_NOT_FOUND",
-                              "message": "해당 부서를 찾을 수 없습니다.",
-                              "result": null
-                            }
-                            """)))
-    })
-    @PostMapping(value = "/department", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<Long>> createDepartmentEduReport(
-            @Parameter(description = "부서 교육 게시물 생성 정보(JSON)", required = true)
-                    @RequestPart("requestDto")
-                    @Valid
-                    DepartmentEduReportCreateRequestDto requestDto,
-            @Parameter(description = "첨부 파일 목록(선택)") @RequestPart(value = "files", required = false)
-                    List<MultipartFile> files,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
-            throws IOException {
+                                        - `requestDto`(JSON 파트)는 필수입니다.
+                                        - `files`(파일 파트)는 선택입니다.
+                                        - 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 있어야 생성할 수 있습니다.
+                                        """, requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE, schema = @Schema(implementation = DepartmentEduReportCreateMultipartRequestDoc.class), encoding = {
+                                        @Encoding(name = "requestDto", contentType = MediaType.APPLICATION_JSON_VALUE),
+                                        @Encoding(name = "files", contentType = "*/*")
+                        })))
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "생성 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ApiResponse.class), examples = @ExampleObject(value = """
+                                        {
+                                          "isSuccess": true,
+                                          "code": "COMMON201",
+                                          "message": "성공적으로 생성되었습니다.",
+                                          "result": 1
+                                        }
+                                        """))),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                                        {
+                                          "isSuccess": false,
+                                          "code": "NO_AUTHORITY_FOR_EDU_REPORT",
+                                          "message": "교육 게시물 관리 권한이 없습니다.",
+                                          "result": null
+                                        }
+                                        """))),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                                        {
+                                          "isSuccess": false,
+                                          "code": "DEPARTMENT_NOT_FOUND",
+                                          "message": "해당 부서를 찾을 수 없습니다.",
+                                          "result": null
+                                        }
+                                        """)))
+        })
+        @PostMapping(value = "/department", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+        public ResponseEntity<ApiResponse<Long>> createDepartmentEduReport(
+                        @Parameter(description = "부서 교육 게시물 생성 정보(JSON)", required = true) @RequestPart("requestDto") @Valid DepartmentEduReportCreateRequestDto requestDto,
+                        @Parameter(description = "첨부 파일 목록(선택)") @RequestPart(value = "files", required = false) List<MultipartFile> files,
+                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
+                        throws IOException {
 
-        Long reportId =
-                eduReportService.createDepartmentEduReport(requestDto, files, userDetails.getId());
+                Long reportId = eduReportService.createDepartmentEduReport(requestDto, files, userDetails.getId());
 
-        URI location =
-                ServletUriComponentsBuilder.fromCurrentContextPath()
-                        .path("/api/educations/department/{id}")
-                        .buildAndExpand(reportId)
-                        .toUri();
+                URI location = ServletUriComponentsBuilder.fromCurrentContextPath()
+                                .path("/api/educations/department/{id}")
+                                .buildAndExpand(reportId)
+                                .toUri();
 
-        return ResponseEntity.created(location).body(ApiResponse.onCreated(reportId));
-    }
+                return ResponseEntity.created(location).body(ApiResponse.onCreated(reportId));
+        }
 
-    @Operation(
-            tags = {"PSM"},
-            summary = "PSM 게시물 생성",
-            description =
-                    """
-                `multipart/form-data`로 PSM 게시물을 생성합니다.
+        @Operation(tags = {
+                        "PSM" }, summary = "PSM 게시물 생성", description = """
+                                        `multipart/form-data`로 PSM 게시물을 생성합니다.
 
-                - `requestDto`(JSON 파트)는 필수입니다.
-                - `files`(파일 파트)는 선택입니다.
-                - PSM 관리 권한(`MANAGE_PSM`)이 있어야 생성할 수 있습니다.
-                - `companyScope`는 회사 목록 배열입니다.
-                - `[AWESOME]`처럼 1개를 보내면 해당 회사 게시물로 생성됩니다.
-                - `[AWESOME, MARUI]`, `null`, `[]`는 모든 회사 공통 게시물로 생성됩니다.
-                """,
-            requestBody =
-                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                            required = true,
-                            content =
-                                    @Content(
-                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-                                            schema =
-                                                    @Schema(
-                                                            implementation =
-                                                                    PsmEduReportCreateMultipartRequestDoc
-                                                                            .class),
-                                            encoding = {
-                                                @Encoding(
-                                                        name = "requestDto",
-                                                        contentType =
-                                                                MediaType.APPLICATION_JSON_VALUE),
-                                                @Encoding(name = "files", contentType = "*/*")
-                                            })))
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "201",
-                description = "생성 성공",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples =
-                                        @ExampleObject(
-                                                value =
-                                                        """
-                            {
-                              "isSuccess": true,
-                              "code": "COMMON201",
-                              "message": "성공적으로 생성되었습니다.",
-                              "result": 2
-                            }
-                            """))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "403",
-                description = "권한 없음",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples =
-                                        @ExampleObject(
-                                                value =
-                                                        """
-                            {
-                              "isSuccess": false,
-                              "code": "NO_AUTHORITY_FOR_PSM_MANAGE",
-                              "message": "PSM 관리 권한이 없습니다.",
-                              "result": null
-                            }
-                            """))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples =
-                                        @ExampleObject(
-                                                value =
-                                                        """
-                            {
-                              "isSuccess": false,
-                              "code": "EDUCATION_CATEGORY_NOT_FOUND",
-                              "message": "해당 교육 카테고리를 찾을 수 없습니다.",
-                              "result": null
-                            }
-                            """)))
-    })
-    @PostMapping(value = "/psm", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<Long>> createPsmEduReport(
-            @Parameter(description = "PSM 게시물 생성 정보(JSON)", required = true)
-                    @RequestPart("requestDto")
-                    @Valid
-                    PsmEduReportCreateRequestDto requestDto,
-            @Parameter(description = "첨부 파일 목록(선택)") @RequestPart(value = "files", required = false)
-                    List<MultipartFile> files,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
-            throws IOException {
+                                        - `requestDto`(JSON 파트)는 필수입니다.
+                                        - `files`(파일 파트)는 선택입니다.
+                                        - PSM 관리 권한(`MANAGE_PSM`)이 있어야 생성할 수 있습니다.
+                                        - `companyScope`는 회사 목록 배열입니다.
+                                        - `[AWESOME]`처럼 1개를 보내면 해당 회사 게시물로 생성됩니다.
+                                        - `[AWESOME, MARUI]`, `null`, `[]`는 모든 회사 공통 게시물로 생성됩니다.
+                                        """, requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE, schema = @Schema(implementation = PsmEduReportCreateMultipartRequestDoc.class), encoding = {
+                                        @Encoding(name = "requestDto", contentType = MediaType.APPLICATION_JSON_VALUE),
+                                        @Encoding(name = "files", contentType = "*/*")
+                        })))
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "생성 성공", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                                        {
+                                          "isSuccess": true,
+                                          "code": "COMMON201",
+                                          "message": "성공적으로 생성되었습니다.",
+                                          "result": 2
+                                        }
+                                        """))),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                                        {
+                                          "isSuccess": false,
+                                          "code": "NO_AUTHORITY_FOR_PSM_MANAGE",
+                                          "message": "PSM 관리 권한이 없습니다.",
+                                          "result": null
+                                        }
+                                        """))),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                                        {
+                                          "isSuccess": false,
+                                          "code": "EDUCATION_CATEGORY_NOT_FOUND",
+                                          "message": "해당 교육 카테고리를 찾을 수 없습니다.",
+                                          "result": null
+                                        }
+                                        """)))
+        })
+        @PostMapping(value = "/psm", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+        public ResponseEntity<ApiResponse<Long>> createPsmEduReport(
+                        @Parameter(description = "PSM 게시물 생성 정보(JSON)", required = true) @RequestPart("requestDto") @Valid PsmEduReportCreateRequestDto requestDto,
+                        @Parameter(description = "첨부 파일 목록(선택)") @RequestPart(value = "files", required = false) List<MultipartFile> files,
+                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
+                        throws IOException {
 
-        Long reportId = eduReportService.createPsmEduReport(requestDto, files, userDetails.getId());
+                Long reportId = eduReportService.createPsmEduReport(requestDto, files, userDetails.getId());
 
-        URI location =
-                ServletUriComponentsBuilder.fromCurrentContextPath()
-                        .path("/api/educations/psm/{id}")
-                        .buildAndExpand(reportId)
-                        .toUri();
+                URI location = ServletUriComponentsBuilder.fromCurrentContextPath()
+                                .path("/api/educations/psm/{id}")
+                                .buildAndExpand(reportId)
+                                .toUri();
 
-        return ResponseEntity.created(location).body(ApiResponse.onCreated(reportId));
-    }
+                return ResponseEntity.created(location).body(ApiResponse.onCreated(reportId));
+        }
 
-    @Operation(
-            tags = {"안전보건"},
-            summary = "안전 보건 게시물 생성",
-            description =
-                    """
-                `multipart/form-data`로 안전 보건 게시물을 생성합니다.
+        @Operation(tags = {
+                        "안전보건" }, summary = "안전 보건 게시물 생성", description = """
+                                        `multipart/form-data`로 안전 보건 게시물을 생성합니다.
 
-                - `requestDto`(JSON 파트)는 필수입니다.
-                - `files`(파일 파트)는 선택입니다.
-                - 안전 보건 관리 권한(`MANAGE_SAFETY`)이 있어야 생성할 수 있습니다.
-                - `companyScope`는 회사 목록 배열입니다.
-                - `[AWESOME]`처럼 1개를 보내면 해당 회사 게시물로 생성됩니다.
-                - `[AWESOME, MARUI]`, `null`, `[]`는 모든 회사 공통 게시물로 생성됩니다.
-                """,
-            requestBody =
-                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                            required = true,
-                            content =
-                                    @Content(
-                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-                                            schema =
-                                                    @Schema(
-                                                            implementation =
-                                                                    SafetyEduReportCreateMultipartRequestDoc
-                                                                            .class),
-                                            encoding = {
-                                                @Encoding(
-                                                        name = "requestDto",
-                                                        contentType =
-                                                                MediaType.APPLICATION_JSON_VALUE),
-                                                @Encoding(name = "files", contentType = "*/*")
-                                            })))
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "201",
-                description = "생성 성공",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples =
-                                        @ExampleObject(
-                                                value =
-                                                        """
-                            {
-                              "isSuccess": true,
-                              "code": "COMMON201",
-                              "message": "성공적으로 생성되었습니다.",
-                              "result": 3
-                            }
-                            """))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "403",
-                description = "권한 없음",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples =
-                                        @ExampleObject(
-                                                value =
-                                                        """
-                            {
-                              "isSuccess": false,
-                              "code": "NO_AUTHORITY_FOR_SAFETY_WRITE",
-                              "message": "안전 보건 관리 권한이 없습니다.",
-                              "result": null
-                            }
-                            """))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples =
-                                        @ExampleObject(
-                                                value =
-                                                        """
-                            {
-                              "isSuccess": false,
-                              "code": "EDUCATION_CATEGORY_NOT_FOUND",
-                              "message": "해당 교육 카테고리를 찾을 수 없습니다.",
-                              "result": null
-                            }
-                            """)))
-    })
-    @PostMapping(value = "/safety", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<Long>> createSafetyEduReport(
-            @Parameter(description = "안전 보건 게시물 생성 정보(JSON)", required = true)
-                    @RequestPart("requestDto")
-                    @Valid
-                    SafetyEduReportCreateRequestDto requestDto,
-            @Parameter(description = "첨부 파일 목록(선택)") @RequestPart(value = "files", required = false)
-                    List<MultipartFile> files,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
-            throws IOException {
+                                        - `requestDto`(JSON 파트)는 필수입니다.
+                                        - `files`(파일 파트)는 선택입니다.
+                                        - 안전 보건 관리 권한(`MANAGE_SAFETY`)이 있어야 생성할 수 있습니다.
+                                        - `companyScope`는 회사 목록 배열입니다.
+                                        - `[AWESOME]`처럼 1개를 보내면 해당 회사 게시물로 생성됩니다.
+                                        - `[AWESOME, MARUI]`, `null`, `[]`는 모든 회사 공통 게시물로 생성됩니다.
+                                        """, requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE, schema = @Schema(implementation = SafetyEduReportCreateMultipartRequestDoc.class), encoding = {
+                                        @Encoding(name = "requestDto", contentType = MediaType.APPLICATION_JSON_VALUE),
+                                        @Encoding(name = "files", contentType = "*/*")
+                        })))
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "생성 성공", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                                        {
+                                          "isSuccess": true,
+                                          "code": "COMMON201",
+                                          "message": "성공적으로 생성되었습니다.",
+                                          "result": 3
+                                        }
+                                        """))),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                                        {
+                                          "isSuccess": false,
+                                          "code": "NO_AUTHORITY_FOR_SAFETY_WRITE",
+                                          "message": "안전 보건 관리 권한이 없습니다.",
+                                          "result": null
+                                        }
+                                        """))),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                                        {
+                                          "isSuccess": false,
+                                          "code": "EDUCATION_CATEGORY_NOT_FOUND",
+                                          "message": "해당 교육 카테고리를 찾을 수 없습니다.",
+                                          "result": null
+                                        }
+                                        """)))
+        })
+        @PostMapping(value = "/safety", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+        public ResponseEntity<ApiResponse<Long>> createSafetyEduReport(
+                        @Parameter(description = "안전 보건 게시물 생성 정보(JSON)", required = true) @RequestPart("requestDto") @Valid SafetyEduReportCreateRequestDto requestDto,
+                        @Parameter(description = "첨부 파일 목록(선택)") @RequestPart(value = "files", required = false) List<MultipartFile> files,
+                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
+                        throws IOException {
 
-        Long reportId =
-                eduReportService.createSafetyEduReport(requestDto, files, userDetails.getId());
+                Long reportId = eduReportService.createSafetyEduReport(requestDto, files, userDetails.getId());
 
-        URI location =
-                ServletUriComponentsBuilder.fromCurrentContextPath()
-                        .path("/api/educations/safety/{id}")
-                        .buildAndExpand(reportId)
-                        .toUri();
+                URI location = ServletUriComponentsBuilder.fromCurrentContextPath()
+                                .path("/api/educations/safety/{id}")
+                                .buildAndExpand(reportId)
+                                .toUri();
 
-        return ResponseEntity.created(location).body(ApiResponse.onCreated(reportId));
-    }
+                return ResponseEntity.created(location).body(ApiResponse.onCreated(reportId));
+        }
 
-    @Schema(
-            name = "DepartmentEduReportCreateMultipartRequestDoc",
-            description = "부서 교육 게시물 생성 multipart 요청")
-    static class DepartmentEduReportCreateMultipartRequestDoc {
+        @Schema(name = "DepartmentEduReportCreateMultipartRequestDoc", description = "부서 교육 게시물 생성 multipart 요청")
+        static class DepartmentEduReportCreateMultipartRequestDoc {
 
-        @Schema(
-                description = "부서 교육 게시물 생성 정보(JSON 파트)",
-                requiredMode = Schema.RequiredMode.REQUIRED)
-        public DepartmentEduReportCreateRequestDto requestDto;
+                @Schema(description = "부서 교육 게시물 생성 정보(JSON 파트)", requiredMode = Schema.RequiredMode.REQUIRED)
+                public DepartmentEduReportCreateRequestDto requestDto;
 
-        @ArraySchema(schema = @Schema(type = "string", format = "binary"))
-        public List<String> files;
-    }
+                @ArraySchema(schema = @Schema(type = "string", format = "binary"))
+                public List<String> files;
+        }
 
-    @Schema(name = "PsmEduReportCreateMultipartRequestDoc", description = "PSM 게시물 생성 multipart 요청")
-    static class PsmEduReportCreateMultipartRequestDoc {
+        @Schema(name = "PsmEduReportCreateMultipartRequestDoc", description = "PSM 게시물 생성 multipart 요청")
+        static class PsmEduReportCreateMultipartRequestDoc {
 
-        @Schema(description = "PSM 게시물 생성 정보(JSON 파트)", requiredMode = Schema.RequiredMode.REQUIRED)
-        public PsmEduReportCreateRequestDto requestDto;
+                @Schema(description = "PSM 게시물 생성 정보(JSON 파트)", requiredMode = Schema.RequiredMode.REQUIRED)
+                public PsmEduReportCreateRequestDto requestDto;
 
-        @ArraySchema(schema = @Schema(type = "string", format = "binary"))
-        public List<String> files;
-    }
+                @ArraySchema(schema = @Schema(type = "string", format = "binary"))
+                public List<String> files;
+        }
 
-    @Schema(
-            name = "SafetyEduReportCreateMultipartRequestDoc",
-            description = "안전 보건 게시물 생성 multipart 요청")
-    static class SafetyEduReportCreateMultipartRequestDoc {
+        @Schema(name = "SafetyEduReportCreateMultipartRequestDoc", description = "안전 보건 게시물 생성 multipart 요청")
+        static class SafetyEduReportCreateMultipartRequestDoc {
 
-        @Schema(
-                description = "안전 보건 게시물 생성 정보(JSON 파트)",
-                requiredMode = Schema.RequiredMode.REQUIRED)
-        public SafetyEduReportCreateRequestDto requestDto;
+                @Schema(description = "안전 보건 게시물 생성 정보(JSON 파트)", requiredMode = Schema.RequiredMode.REQUIRED)
+                public SafetyEduReportCreateRequestDto requestDto;
 
-        @ArraySchema(schema = @Schema(type = "string", format = "binary"))
-        public List<String> files;
-    }
+                @ArraySchema(schema = @Schema(type = "string", format = "binary"))
+                public List<String> files;
+        }
 
-    @Schema(name = "EduReportUpdateMultipartRequestDoc", description = "교육 수정 multipart 요청")
-    static class EduReportUpdateMultipartRequestDoc {
+        @Schema(name = "EduReportUpdateMultipartRequestDoc", description = "교육 수정 multipart 요청")
+        static class EduReportUpdateMultipartRequestDoc {
 
-        @Schema(description = "교육 수정 정보(JSON 파트)", requiredMode = Schema.RequiredMode.REQUIRED)
-        public EduReportUpdateRequestDto requestDto;
+                @Schema(description = "교육 수정 정보(JSON 파트)", requiredMode = Schema.RequiredMode.REQUIRED)
+                public EduReportUpdateRequestDto requestDto;
 
-        @ArraySchema(schema = @Schema(type = "string", format = "binary"))
-        public List<String> files;
-    }
+                @ArraySchema(schema = @Schema(type = "string", format = "binary"))
+                public List<String> files;
+        }
 
-    @Operation(
-            tags = {"부서교육"},
-            summary = "부서 교육 게시물 목록 조회",
-            description =
-                    """
-                부서 교육 게시물 목록을 조회합니다.
+        @Operation(tags = {
+                        "부서교육" }, summary = "부서 교육 게시물 목록 조회", description = """
+                                        부서 교육 게시물 목록을 조회합니다.
 
-                - `MANAGE_DEPARTMENT_EDUCATION` 권한 사용자는 `departmentName`으로 전체 부서 대상 필터 조회가 가능합니다.
-                - `MANAGE_DEPARTMENT_EDUCATION` 권한이 없는 사용자는 본인 소속 부서 게시물만 조회됩니다.
-                - `canSign`은 목록 기준 서명 가능 여부이며, `signatureRequired=true` + `OPEN` 상태 + 미서명 + 본인 소속 부서 게시물일 때 `true`입니다.
-                - `mySigned`, `myCompletionStatus`는 부서교육 + 본인 소속 부서 게시물일 때만 값이 채워집니다.
-                - `myCompletionStatus`는 `signatureRequired=false`이면 항상 `COMPLETED`이며, `signatureRequired=true`이면 내 서명 여부에 따라 `COMPLETED/INCOMPLETE`로 계산됩니다.
-                """)
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "조회 성공",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples =
-                                        @ExampleObject(
-                                                value =
-                                                        """
-                            {
-                              "isSuccess": true,
-                              "code": "COMMON200",
-                              "message": "요청에 성공했습니다.",
-                              "result": [
-                                {
-                                  "id": 202,
-                                  "title": "경영지원부 교육",
-                                  "eduType": "부서 교육",
-                                  "eduDate": "2026-03-16",
-                                  "content": "부서교육 게시글입니다.",
-                                  "attendance": false,
-                                  "mySigned": false,
-                                  "myCompletionStatus": "INCOMPLETE",
-                                  "canSign": true,
-                                  "pinned": false,
-                                  "signatureRequired": true,
-                                  "status": "OPEN",
-                                  "categoryId": null,
-                                  "categoryName": null
-                                }
-                              ]
-                            }
-                            """))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples = {
-                                    @ExampleObject(
-                                            name = "사용자 없음",
-                                            value =
-                                                    """
-                                {
-                                  "isSuccess": false,
-                                  "code": "USER_NOT_FOUND",
-                                  "message": "해당 사용자를 찾을 수 없습니다.",
-                                  "result": null
-                                }
-                                """),
-                                    @ExampleObject(
-                                            name = "부서 없음",
-                                            value =
-                                                    """
-                                {
-                                  "isSuccess": false,
-                                  "code": "DEPARTMENT_NOT_FOUND",
-                                  "message": "해당 부서를 찾을 수 없습니다.",
-                                  "result": null
-                                }
-                                """)
-                                }))
-    })
-    @GetMapping("/department")
-    public ResponseEntity<ApiResponse<List<EduReportSummaryDto>>> getDepartmentEduReports(
-            @Parameter(description = "부서명 필터(권한 사용자 전용)", example = "SALES_DEPT")
-                    @RequestParam(required = false)
-                    DepartmentName departmentName,
-            @Parameter(description = "제목 검색 키워드 (FULLTEXT 검색)", example = "안전교육")
-                    @RequestParam(required = false)
-                    String title,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-        List<EduReportSummaryDto> reports =
-                eduReportService.getDepartmentEduReports(
-                        departmentName, userDetails.getId(), title);
-        return ResponseEntity.ok(ApiResponse.onSuccess(reports));
-    }
+                                        - `MANAGE_DEPARTMENT_EDUCATION` 권한 사용자는 `departmentName`으로 전체 부서 대상 필터 조회가 가능합니다.
+                                        - `MANAGE_DEPARTMENT_EDUCATION` 권한이 없는 사용자는 본인 소속 부서 게시물만 조회됩니다.
+                                        - `canSign`은 목록 기준 서명 가능 여부이며, `signatureRequired=true` + `OPEN` 상태 + 미서명 + 본인 소속 부서 게시물일 때 `true`입니다.
+                                        - `mySigned`, `myCompletionStatus`는 부서교육 + 본인 소속 부서 게시물일 때만 값이 채워집니다.
+                                        - `myCompletionStatus`는 `signatureRequired=false`이면 항상 `COMPLETED`이며, `signatureRequired=true`이면 내 서명 여부에 따라 `COMPLETED/INCOMPLETE`로 계산됩니다.
+                                        """)
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                                        {
+                                          "isSuccess": true,
+                                          "code": "COMMON200",
+                                          "message": "요청에 성공했습니다.",
+                                          "result": [
+                                            {
+                                              "id": 202,
+                                              "title": "경영지원부 교육",
+                                              "eduType": "부서 교육",
+                                              "eduDate": "2026-03-16",
+                                              "content": "부서교육 게시글입니다.",
+                                              "attendance": false,
+                                              "mySigned": false,
+                                              "myCompletionStatus": "INCOMPLETE",
+                                              "canSign": true,
+                                              "pinned": false,
+                                              "signatureRequired": true,
+                                              "status": "OPEN",
+                                              "categoryId": null,
+                                              "categoryName": null
+                                            }
+                                          ]
+                                        }
+                                        """))),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음", content = @Content(mediaType = "application/json", examples = {
+                                        @ExampleObject(name = "사용자 없음", value = """
+                                                        {
+                                                          "isSuccess": false,
+                                                          "code": "USER_NOT_FOUND",
+                                                          "message": "해당 사용자를 찾을 수 없습니다.",
+                                                          "result": null
+                                                        }
+                                                        """),
+                                        @ExampleObject(name = "부서 없음", value = """
+                                                        {
+                                                          "isSuccess": false,
+                                                          "code": "DEPARTMENT_NOT_FOUND",
+                                                          "message": "해당 부서를 찾을 수 없습니다.",
+                                                          "result": null
+                                                        }
+                                                        """)
+                        }))
+        })
+        @GetMapping("/department")
+        public ResponseEntity<ApiResponse<List<EduReportSummaryDto>>> getDepartmentEduReports(
+                        @Parameter(description = "부서명 필터(권한 사용자 전용)", example = "SALES_DEPT") @RequestParam(required = false) DepartmentName departmentName,
+                        @Parameter(description = "제목 검색 키워드 (FULLTEXT 검색)", example = "안전교육") @RequestParam(required = false) String title,
+                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+                List<EduReportSummaryDto> reports = eduReportService.getDepartmentEduReports(
+                                departmentName, userDetails.getId(), title);
+                return ResponseEntity.ok(ApiResponse.onSuccess(reports));
+        }
 
-    @Operation(
-            tags = {"PSM"},
-            summary = "PSM 게시물 목록 조회",
-            description =
-                    """
-                PSM 게시물 목록을 조회합니다.
+        @Operation(tags = { "PSM" }, summary = "PSM 게시물 목록 조회", description = """
+                        PSM 게시물 목록을 조회합니다.
 
-                - `MANAGE_PSM` 권한 사용자는 모든 회사의 PSM 게시물을 조회할 수 있습니다.
-                - `MANAGE_PSM` 권한이 없는 사용자는 본인 소속 회사의 PSM 게시물만 조회됩니다.
-                - 응답의 `companyScope`는 대상 회사 목록 배열로 반환됩니다.
-                - 공통 게시물은 `companyScope: ["AWESOME", "MARUI"]`로 응답됩니다.
-                """)
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "조회 성공",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples =
-                                        @ExampleObject(
-                                                value =
-                                                        """
-                            {
-                              "isSuccess": true,
-                              "code": "COMMON200",
-                              "message": "요청에 성공했습니다.",
-                              "result": [
-                                {
-                                  "id": 301,
-                                  "title": "PSM 변경관리 교육",
-                                  "eduType": "PSM",
-                                  "eduDate": "2026-04-14",
-                                  "content": "PSM 교육 게시글입니다.",
-                                  "attendance": false,
-                                  "canSign": false,
-                                  "pinned": false,
-                                  "signatureRequired": false,
-                                  "status": "OPEN",
-                                  "categoryId": 2,
-                                  "categoryName": "변경관리",
-                                  "companyScope": ["AWESOME", "MARUI"]
-                                }
-                              ]
-                            }
-                            """))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples = {
-                                    @ExampleObject(
-                                            name = "사용자 없음",
-                                            value =
-                                                    """
-                                {
-                                  "isSuccess": false,
-                                  "code": "USER_NOT_FOUND",
-                                  "message": "해당 사용자를 찾을 수 없습니다.",
-                                  "result": null
-                                }
-                                """)
-                                }))
-    })
-    @GetMapping("/psm")
-    public ResponseEntity<ApiResponse<List<EduReportSummaryDto>>> getPsmEduReports(
-            @Parameter(description = "카테고리 ID 필터(PSM)", example = "1")
-                    @RequestParam(required = false)
-                    Long categoryId,
-            @Parameter(description = "제목 검색 키워드 (FULLTEXT 검색)", example = "변경관리")
-                    @RequestParam(required = false)
-                    String title,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-        List<EduReportSummaryDto> reports =
-                eduReportService.getPsmEduReports(categoryId, userDetails.getId(), title);
-        return ResponseEntity.ok(ApiResponse.onSuccess(reports));
-    }
+                        - `MANAGE_PSM` 권한 사용자는 모든 회사의 PSM 게시물을 조회할 수 있습니다.
+                        - `MANAGE_PSM` 권한이 없는 사용자는 본인 소속 회사의 PSM 게시물만 조회됩니다.
+                        - 응답의 `companyScope`는 대상 회사 목록 배열로 반환됩니다.
+                        - 공통 게시물은 `companyScope: ["AWESOME", "MARUI"]`로 응답됩니다.
+                        """)
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                                        {
+                                          "isSuccess": true,
+                                          "code": "COMMON200",
+                                          "message": "요청에 성공했습니다.",
+                                          "result": [
+                                            {
+                                              "id": 301,
+                                              "title": "PSM 변경관리 교육",
+                                              "eduType": "PSM",
+                                              "eduDate": "2026-04-14",
+                                              "content": "PSM 교육 게시글입니다.",
+                                              "attendance": false,
+                                              "canSign": false,
+                                              "pinned": false,
+                                              "signatureRequired": false,
+                                              "status": "OPEN",
+                                              "categoryId": 2,
+                                              "categoryName": "변경관리",
+                                              "companyScope": ["AWESOME", "MARUI"]
+                                            }
+                                          ]
+                                        }
+                                        """))),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음", content = @Content(mediaType = "application/json", examples = {
+                                        @ExampleObject(name = "사용자 없음", value = """
+                                                        {
+                                                          "isSuccess": false,
+                                                          "code": "USER_NOT_FOUND",
+                                                          "message": "해당 사용자를 찾을 수 없습니다.",
+                                                          "result": null
+                                                        }
+                                                        """)
+                        }))
+        })
+        @GetMapping("/psm")
+        public ResponseEntity<ApiResponse<List<EduReportSummaryDto>>> getPsmEduReports(
+                        @Parameter(description = "카테고리 ID 필터(PSM)", example = "1") @RequestParam(required = false) Long categoryId,
+                        @Parameter(description = "제목 검색 키워드 (FULLTEXT 검색)", example = "변경관리") @RequestParam(required = false) String title,
+                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+                List<EduReportSummaryDto> reports = eduReportService.getPsmEduReports(categoryId, userDetails.getId(),
+                                title);
+                return ResponseEntity.ok(ApiResponse.onSuccess(reports));
+        }
 
-    @Operation(
-            tags = {"안전보건"},
-            summary = "안전 보건 게시물 목록 조회",
-            description =
-                    """
-                안전 보건 게시물 목록을 조회합니다.
+        @Operation(tags = { "안전보건" }, summary = "안전 보건 게시물 목록 조회", description = """
+                        안전 보건 게시물 목록을 조회합니다.
 
-                - `MANAGE_SAFETY` 권한 사용자는 모든 회사의 안전 보건 게시물을 조회할 수 있습니다.
-                - `MANAGE_SAFETY` 권한이 없는 사용자는 본인 소속 회사의 안전 보건 게시물만 조회됩니다.
-                - 응답의 `companyScope`는 대상 회사 목록 배열로 반환됩니다.
-                - 공통 게시물은 `companyScope: ["AWESOME", "MARUI"]`로 응답됩니다.
-                """)
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "조회 성공",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples =
-                                        @ExampleObject(
-                                                value =
-                                                        """
-                            {
-                              "isSuccess": true,
-                              "code": "COMMON200",
-                              "message": "요청에 성공했습니다.",
-                              "result": [
-                                {
-                                  "id": 401,
-                                  "title": "안전 보건 정기교육",
-                                  "eduType": "안전 보건",
-                                  "eduDate": "2026-04-14",
-                                  "content": "안전 보건 교육 게시글입니다.",
-                                  "attendance": false,
-                                  "canSign": false,
-                                  "pinned": false,
-                                  "signatureRequired": true,
-                                  "status": "OPEN",
-                                  "categoryId": 3,
-                                  "categoryName": "정기교육",
-                                  "companyScope": ["AWESOME"]
-                                }
-                              ]
-                            }
-                            """))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples = {
-                                    @ExampleObject(
-                                            name = "사용자 없음",
-                                            value =
-                                                    """
-                                {
-                                  "isSuccess": false,
-                                  "code": "USER_NOT_FOUND",
-                                  "message": "해당 사용자를 찾을 수 없습니다.",
-                                  "result": null
-                                }
-                                """)
-                                }))
-    })
-    @GetMapping("/safety")
-    public ResponseEntity<ApiResponse<List<EduReportSummaryDto>>> getSafetyEduReports(
-            @Parameter(description = "카테고리 ID 필터(안전 보건)", example = "1")
-                    @RequestParam(required = false)
-                    Long categoryId,
-            @Parameter(description = "제목 검색 키워드 (FULLTEXT 검색)", example = "정기교육")
-                    @RequestParam(required = false)
-                    String title,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-        List<EduReportSummaryDto> reports =
-                eduReportService.getSafetyEduReports(categoryId, userDetails.getId(), title);
-        return ResponseEntity.ok(ApiResponse.onSuccess(reports));
-    }
+                        - `MANAGE_SAFETY` 권한 사용자는 모든 회사의 안전 보건 게시물을 조회할 수 있습니다.
+                        - `MANAGE_SAFETY` 권한이 없는 사용자는 본인 소속 회사의 안전 보건 게시물만 조회됩니다.
+                        - 응답의 `companyScope`는 대상 회사 목록 배열로 반환됩니다.
+                        - 공통 게시물은 `companyScope: ["AWESOME", "MARUI"]`로 응답됩니다.
+                        """)
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                                        {
+                                          "isSuccess": true,
+                                          "code": "COMMON200",
+                                          "message": "요청에 성공했습니다.",
+                                          "result": [
+                                            {
+                                              "id": 401,
+                                              "title": "안전 보건 정기교육",
+                                              "eduType": "안전 보건",
+                                              "eduDate": "2026-04-14",
+                                              "content": "안전 보건 교육 게시글입니다.",
+                                              "attendance": false,
+                                              "canSign": false,
+                                              "pinned": false,
+                                              "signatureRequired": true,
+                                              "status": "OPEN",
+                                              "categoryId": 3,
+                                              "categoryName": "정기교육",
+                                              "companyScope": ["AWESOME"]
+                                            }
+                                          ]
+                                        }
+                                        """))),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음", content = @Content(mediaType = "application/json", examples = {
+                                        @ExampleObject(name = "사용자 없음", value = """
+                                                        {
+                                                          "isSuccess": false,
+                                                          "code": "USER_NOT_FOUND",
+                                                          "message": "해당 사용자를 찾을 수 없습니다.",
+                                                          "result": null
+                                                        }
+                                                        """)
+                        }))
+        })
+        @GetMapping("/safety")
+        public ResponseEntity<ApiResponse<List<EduReportSummaryDto>>> getSafetyEduReports(
+                        @Parameter(description = "카테고리 ID 필터(안전 보건)", example = "1") @RequestParam(required = false) Long categoryId,
+                        @Parameter(description = "제목 검색 키워드 (FULLTEXT 검색)", example = "정기교육") @RequestParam(required = false) String title,
+                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+                List<EduReportSummaryDto> reports = eduReportService.getSafetyEduReports(categoryId,
+                                userDetails.getId(), title);
+                return ResponseEntity.ok(ApiResponse.onSuccess(reports));
+        }
 
-    @Operation(
-            tags = {"부서교육"},
-            summary = "부서 교육 게시물 상세 조회",
-            description =
-                    """
-                부서 교육 게시물 상세 정보를 조회합니다.
+        @Operation(tags = {
+                        "부서교육" }, summary = "부서 교육 게시물 상세 조회", description = """
+                                        부서 교육 게시물 상세 정보를 조회합니다.
 
-                - `MANAGE_DEPARTMENT_EDUCATION` 권한 사용자는 전체 부서의 부서 교육 게시물을 조회할 수 있습니다.
-                - 권한이 없는 사용자는 본인 소속 부서의 게시물만 조회할 수 있습니다.
-                - 권한이 없는 사용자가 타 부서 게시물을 조회하면 `EDU_REPORT_NOT_FOUND(404)`가 반환됩니다.
-                - `MANAGE_DEPARTMENT_EDUCATION` 권한 사용자는 `attendees`, `numberOfPeople`, `numberOfAttendees`를 조회할 수 있으며, 권한이 없는 사용자는 위 필드가 `null`로 반환됩니다.
-                - `targetCount`, `signedCount`, `unsignedCount`는 부서 교육 상세에서 공통으로 제공됩니다.
-                - `canSign`은 현재 사용자의 서명 가능 여부를 의미하며, `signatureRequired=true` + `OPEN` 상태 + 미서명 + 본인 소속 부서 게시물인 경우 `true`입니다.
-                - `mySigned`, `myCompletionStatus`는 부서교육 + 본인 소속 부서 게시물일 때만 값이 채워집니다.
-                - `myCompletionStatus`는 `signatureRequired=false`이면 항상 `COMPLETED`이며, `signatureRequired=true`이면 내 서명 여부에 따라 `COMPLETED/INCOMPLETE`로 계산됩니다.
-                """)
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "조회 성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples = {
-                                    @ExampleObject(
-                                            name = "게시물 없음",
-                                            value =
-                                                    """
-                                {
-                                  "isSuccess": false,
-                                  "code": "EDU_REPORT_NOT_FOUND",
-                                  "message": "해당 교육 게시물을 찾을 수 없습니다.",
-                                  "result": null
-                                }
-                                """),
-                                    @ExampleObject(
-                                            name = "타 부서 접근",
-                                            value =
-                                                    """
-                                {
-                                  "isSuccess": false,
-                                  "code": "EDU_REPORT_NOT_FOUND",
-                                  "message": "해당 교육 게시물을 찾을 수 없습니다.",
-                                  "result": null
-                                }
-                                """),
-                                    @ExampleObject(
-                                            name = "사용자 없음",
-                                            value =
-                                                    """
-                                {
-                                  "isSuccess": false,
-                                  "code": "USER_NOT_FOUND",
-                                  "message": "해당 사용자를 찾을 수 없습니다.",
-                                  "result": null
-                                }
-                                """)
-                                }))
-    })
-    @GetMapping("/department/{educationId}")
-    public ResponseEntity<ApiResponse<EduReportDetailDto>> getDepartmentEduReport(
-            @Parameter(description = "조회할 부서 교육 게시물 ID", example = "1") @PathVariable
-                    Long educationId,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-        EduReportDetailDto report =
-                eduReportService.getDepartmentEduReport(educationId, userDetails.getId());
-        return ResponseEntity.ok(ApiResponse.onSuccess(report));
-    }
+                                        - `MANAGE_DEPARTMENT_EDUCATION` 권한 사용자는 전체 부서의 부서 교육 게시물을 조회할 수 있습니다.
+                                        - 권한이 없는 사용자는 본인 소속 부서의 게시물만 조회할 수 있습니다.
+                                        - 권한이 없는 사용자가 타 부서 게시물을 조회하면 `EDU_REPORT_NOT_FOUND(404)`가 반환됩니다.
+                                        - `MANAGE_DEPARTMENT_EDUCATION` 권한 사용자는 `attendees`, `numberOfPeople`, `numberOfAttendees`를 조회할 수 있으며, 권한이 없는 사용자는 위 필드가 `null`로 반환됩니다.
+                                        - `targetCount`, `signedCount`, `unsignedCount`는 부서 교육 상세에서 공통으로 제공됩니다.
+                                        - `canSign`은 현재 사용자의 서명 가능 여부를 의미하며, `signatureRequired=true` + `OPEN` 상태 + 미서명 + 본인 소속 부서 게시물인 경우 `true`입니다.
+                                        - `mySigned`, `myCompletionStatus`는 부서교육 + 본인 소속 부서 게시물일 때만 값이 채워집니다.
+                                        - `myCompletionStatus`는 `signatureRequired=false`이면 항상 `COMPLETED`이며, `signatureRequired=true`이면 내 서명 여부에 따라 `COMPLETED/INCOMPLETE`로 계산됩니다.
+                                        """)
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음", content = @Content(mediaType = "application/json", examples = {
+                                        @ExampleObject(name = "게시물 없음", value = """
+                                                        {
+                                                          "isSuccess": false,
+                                                          "code": "EDU_REPORT_NOT_FOUND",
+                                                          "message": "해당 교육 게시물을 찾을 수 없습니다.",
+                                                          "result": null
+                                                        }
+                                                        """),
+                                        @ExampleObject(name = "타 부서 접근", value = """
+                                                        {
+                                                          "isSuccess": false,
+                                                          "code": "EDU_REPORT_NOT_FOUND",
+                                                          "message": "해당 교육 게시물을 찾을 수 없습니다.",
+                                                          "result": null
+                                                        }
+                                                        """),
+                                        @ExampleObject(name = "사용자 없음", value = """
+                                                        {
+                                                          "isSuccess": false,
+                                                          "code": "USER_NOT_FOUND",
+                                                          "message": "해당 사용자를 찾을 수 없습니다.",
+                                                          "result": null
+                                                        }
+                                                        """)
+                        }))
+        })
+        @GetMapping("/department/{educationId}")
+        public ResponseEntity<ApiResponse<EduReportDetailDto>> getDepartmentEduReport(
+                        @Parameter(description = "조회할 부서 교육 게시물 ID", example = "1") @PathVariable Long educationId,
+                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+                EduReportDetailDto report = eduReportService.getDepartmentEduReport(educationId, userDetails.getId());
+                return ResponseEntity.ok(ApiResponse.onSuccess(report));
+        }
 
-    @Operation(
-            tags = {"PSM"},
-            summary = "PSM 게시물 상세 조회",
-            description =
-                    """
-                PSM 게시물 상세 정보를 조회합니다.
+        @Operation(tags = { "PSM" }, summary = "PSM 게시물 상세 조회", description = """
+                        PSM 게시물 상세 정보를 조회합니다.
 
-                - `MANAGE_PSM` 권한 사용자는 모든 회사의 PSM 게시물을 조회할 수 있습니다.
-                - 권한이 없는 사용자는 본인 소속 회사 게시물과 공통 게시물(`company` 컬럼이 null인 게시물)만 조회할 수 있습니다.
-                - 권한이 없는 사용자가 타 회사 게시물을 조회하면 `EDU_REPORT_NOT_FOUND(404)`가 반환됩니다.
-                - 응답의 `companyScope`는 회사 목록 배열로 반환됩니다.
-                - 공통 게시물은 `companyScope: ["AWESOME", "MARUI"]`로 응답됩니다.
-                """)
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "조회 성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples = {
-                                    @ExampleObject(
-                                            name = "게시물 없음",
-                                            value =
-                                                    """
-                                {
-                                  "isSuccess": false,
-                                  "code": "EDU_REPORT_NOT_FOUND",
-                                  "message": "해당 교육 게시물을 찾을 수 없습니다.",
-                                  "result": null
-                                }
-                                """),
-                                    @ExampleObject(
-                                            name = "타 회사 접근",
-                                            value =
-                                                    """
-                                {
-                                  "isSuccess": false,
-                                  "code": "EDU_REPORT_NOT_FOUND",
-                                  "message": "해당 교육 게시물을 찾을 수 없습니다.",
-                                  "result": null
-                                }
-                                """),
-                                    @ExampleObject(
-                                            name = "사용자 없음",
-                                            value =
-                                                    """
-                                {
-                                  "isSuccess": false,
-                                  "code": "USER_NOT_FOUND",
-                                  "message": "해당 사용자를 찾을 수 없습니다.",
-                                  "result": null
-                                }
-                                """)
-                                }))
-    })
-    @GetMapping("/psm/{educationId}")
-    public ResponseEntity<ApiResponse<EduReportDetailDto>> getPsmEduReport(
-            @Parameter(description = "조회할 PSM 게시물 ID", example = "1") @PathVariable
-                    Long educationId,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-        EduReportDetailDto report =
-                eduReportService.getPsmEduReport(educationId, userDetails.getId());
-        return ResponseEntity.ok(ApiResponse.onSuccess(report));
-    }
+                        - `MANAGE_PSM` 권한 사용자는 모든 회사의 PSM 게시물을 조회할 수 있습니다.
+                        - 권한이 없는 사용자는 본인 소속 회사 게시물과 공통 게시물(`company` 컬럼이 null인 게시물)만 조회할 수 있습니다.
+                        - 권한이 없는 사용자가 타 회사 게시물을 조회하면 `EDU_REPORT_NOT_FOUND(404)`가 반환됩니다.
+                        - 응답의 `companyScope`는 회사 목록 배열로 반환됩니다.
+                        - 공통 게시물은 `companyScope: ["AWESOME", "MARUI"]`로 응답됩니다.
+                        """)
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음", content = @Content(mediaType = "application/json", examples = {
+                                        @ExampleObject(name = "게시물 없음", value = """
+                                                        {
+                                                          "isSuccess": false,
+                                                          "code": "EDU_REPORT_NOT_FOUND",
+                                                          "message": "해당 교육 게시물을 찾을 수 없습니다.",
+                                                          "result": null
+                                                        }
+                                                        """),
+                                        @ExampleObject(name = "타 회사 접근", value = """
+                                                        {
+                                                          "isSuccess": false,
+                                                          "code": "EDU_REPORT_NOT_FOUND",
+                                                          "message": "해당 교육 게시물을 찾을 수 없습니다.",
+                                                          "result": null
+                                                        }
+                                                        """),
+                                        @ExampleObject(name = "사용자 없음", value = """
+                                                        {
+                                                          "isSuccess": false,
+                                                          "code": "USER_NOT_FOUND",
+                                                          "message": "해당 사용자를 찾을 수 없습니다.",
+                                                          "result": null
+                                                        }
+                                                        """)
+                        }))
+        })
+        @GetMapping("/psm/{educationId}")
+        public ResponseEntity<ApiResponse<EduReportDetailDto>> getPsmEduReport(
+                        @Parameter(description = "조회할 PSM 게시물 ID", example = "1") @PathVariable Long educationId,
+                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+                EduReportDetailDto report = eduReportService.getPsmEduReport(educationId, userDetails.getId());
+                return ResponseEntity.ok(ApiResponse.onSuccess(report));
+        }
 
-    @Operation(
-            tags = {"안전보건"},
-            summary = "안전 보건 게시물 상세 조회",
-            description =
-                    """
-                안전 보건 게시물 상세 정보를 조회합니다.
+        @Operation(tags = { "안전보건" }, summary = "안전 보건 게시물 상세 조회", description = """
+                        안전 보건 게시물 상세 정보를 조회합니다.
 
-                - `MANAGE_SAFETY` 권한 사용자는 모든 회사의 안전 보건 게시물을 조회할 수 있습니다.
-                - 권한이 없는 사용자는 본인 소속 회사 게시물과 공통 게시물(`company` 컬럼이 null인 게시물)만 조회할 수 있습니다.
-                - 권한이 없는 사용자가 타 회사 게시물을 조회하면 `EDU_REPORT_NOT_FOUND(404)`가 반환됩니다.
-                - 응답의 `companyScope`는 회사 목록 배열로 반환됩니다.
-                - 공통 게시물은 `companyScope: ["AWESOME", "MARUI"]`로 응답됩니다.
-                """)
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "조회 성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음",
-                content =
-                        @Content(
-                                mediaType = "application/json",
-                                examples = {
-                                    @ExampleObject(
-                                            name = "게시물 없음",
-                                            value =
-                                                    """
-                                {
-                                  "isSuccess": false,
-                                  "code": "EDU_REPORT_NOT_FOUND",
-                                  "message": "해당 교육 게시물을 찾을 수 없습니다.",
-                                  "result": null
-                                }
-                                """),
-                                    @ExampleObject(
-                                            name = "타 회사 접근",
-                                            value =
-                                                    """
-                                {
-                                  "isSuccess": false,
-                                  "code": "EDU_REPORT_NOT_FOUND",
-                                  "message": "해당 교육 게시물을 찾을 수 없습니다.",
-                                  "result": null
-                                }
-                                """),
-                                    @ExampleObject(
-                                            name = "사용자 없음",
-                                            value =
-                                                    """
-                                {
-                                  "isSuccess": false,
-                                  "code": "USER_NOT_FOUND",
-                                  "message": "해당 사용자를 찾을 수 없습니다.",
-                                  "result": null
-                                }
-                                """)
-                                }))
-    })
-    @GetMapping("/safety/{educationId}")
-    public ResponseEntity<ApiResponse<EduReportDetailDto>> getSafetyEduReport(
-            @Parameter(description = "조회할 안전 보건 게시물 ID", example = "1") @PathVariable
-                    Long educationId,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-        EduReportDetailDto report =
-                eduReportService.getSafetyEduReport(educationId, userDetails.getId());
-        return ResponseEntity.ok(ApiResponse.onSuccess(report));
-    }
+                        - `MANAGE_SAFETY` 권한 사용자는 모든 회사의 안전 보건 게시물을 조회할 수 있습니다.
+                        - 권한이 없는 사용자는 본인 소속 회사 게시물과 공통 게시물(`company` 컬럼이 null인 게시물)만 조회할 수 있습니다.
+                        - 권한이 없는 사용자가 타 회사 게시물을 조회하면 `EDU_REPORT_NOT_FOUND(404)`가 반환됩니다.
+                        - 응답의 `companyScope`는 회사 목록 배열로 반환됩니다.
+                        - 공통 게시물은 `companyScope: ["AWESOME", "MARUI"]`로 응답됩니다.
+                        """)
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음", content = @Content(mediaType = "application/json", examples = {
+                                        @ExampleObject(name = "게시물 없음", value = """
+                                                        {
+                                                          "isSuccess": false,
+                                                          "code": "EDU_REPORT_NOT_FOUND",
+                                                          "message": "해당 교육 게시물을 찾을 수 없습니다.",
+                                                          "result": null
+                                                        }
+                                                        """),
+                                        @ExampleObject(name = "타 회사 접근", value = """
+                                                        {
+                                                          "isSuccess": false,
+                                                          "code": "EDU_REPORT_NOT_FOUND",
+                                                          "message": "해당 교육 게시물을 찾을 수 없습니다.",
+                                                          "result": null
+                                                        }
+                                                        """),
+                                        @ExampleObject(name = "사용자 없음", value = """
+                                                        {
+                                                          "isSuccess": false,
+                                                          "code": "USER_NOT_FOUND",
+                                                          "message": "해당 사용자를 찾을 수 없습니다.",
+                                                          "result": null
+                                                        }
+                                                        """)
+                        }))
+        })
+        @GetMapping("/safety/{educationId}")
+        public ResponseEntity<ApiResponse<EduReportDetailDto>> getSafetyEduReport(
+                        @Parameter(description = "조회할 안전 보건 게시물 ID", example = "1") @PathVariable Long educationId,
+                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+                EduReportDetailDto report = eduReportService.getSafetyEduReport(educationId, userDetails.getId());
+                return ResponseEntity.ok(ApiResponse.onSuccess(report));
+        }
 
-    @Operation(
-            tags = {"부서교육"},
-            summary = "부서 교육 게시물 수정",
-            description =
-                    """
-                `multipart/form-data`로 부서 교육 게시물을 수정합니다.
+        @Operation(tags = {
+                        "부서교육" }, summary = "부서 교육 게시물 수정", description = """
+                                        `multipart/form-data`로 부서 교육 게시물을 수정합니다.
 
-                - 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 필요합니다.
-                - `OPEN` 상태에서만 수정 가능합니다.
-                - 출석 완료자가 1명이라도 있으면 수정할 수 없습니다.
-                - `requestDto`(JSON 파트)는 필수이며, `files`(파일 파트)는 선택입니다.
-                - `requestDto.deleteAttachmentIds`로 기존 첨부파일 삭제가 가능합니다.
-                """,
-            requestBody =
-                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                            required = true,
-                            content =
-                                    @Content(
-                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-                                            schema =
-                                                    @Schema(
-                                                            implementation =
-                                                                    EduReportUpdateMultipartRequestDoc
-                                                                            .class),
-                                            encoding = {
-                                                @Encoding(
-                                                        name = "requestDto",
-                                                        contentType =
-                                                                MediaType.APPLICATION_JSON_VALUE),
-                                                @Encoding(name = "files", contentType = "*/*")
-                                            })))
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "수정 성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "400",
-                description = "잘못된 요청"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "403",
-                description = "권한 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음")
-    })
-    @PatchMapping(
-            value = "/department/{educationId}",
-            consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<Long>> updateDepartmentEducation(
-            @Parameter(description = "수정할 부서 교육 게시물 ID", example = "1") @PathVariable
-                    Long educationId,
-            @Parameter(description = "부서 교육 수정 정보(JSON)", required = true)
-                    @RequestPart("requestDto")
-                    @Valid
-                    EduReportUpdateRequestDto requestDto,
-            @Parameter(description = "추가할 첨부 파일 목록(선택)")
-                    @RequestPart(value = "files", required = false)
-                    List<MultipartFile> files,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long updatedId =
-                eduReportService.updateDepartmentEduReport(
-                        educationId, requestDto, files, userDetails.getId());
-        return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
-    }
+                                        - 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 필요합니다.
+                                        - `OPEN` 상태에서만 수정 가능합니다.
+                                        - 출석 완료자가 1명이라도 있으면 수정할 수 없습니다.
+                                        - `requestDto`(JSON 파트)는 필수이며, `files`(파일 파트)는 선택입니다.
+                                        - `requestDto.deleteAttachmentIds`로 기존 첨부파일 삭제가 가능합니다.
+                                        """, requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE, schema = @Schema(implementation = EduReportUpdateMultipartRequestDoc.class), encoding = {
+                                        @Encoding(name = "requestDto", contentType = MediaType.APPLICATION_JSON_VALUE),
+                                        @Encoding(name = "files", contentType = "*/*")
+                        })))
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음")
+        })
+        @PatchMapping(value = "/department/{educationId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+        public ResponseEntity<ApiResponse<Long>> updateDepartmentEducation(
+                        @Parameter(description = "수정할 부서 교육 게시물 ID", example = "1") @PathVariable Long educationId,
+                        @Parameter(description = "부서 교육 수정 정보(JSON)", required = true) @RequestPart("requestDto") @Valid EduReportUpdateRequestDto requestDto,
+                        @Parameter(description = "추가할 첨부 파일 목록(선택)") @RequestPart(value = "files", required = false) List<MultipartFile> files,
+                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+                Long updatedId = eduReportService.updateDepartmentEduReport(
+                                educationId, requestDto, files, userDetails.getId());
+                return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
+        }
 
-    @Hidden
-    @PatchMapping(value = "/department/{educationId}", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<ApiResponse<Long>> updateDepartmentEducationJsonFallback(
-            @PathVariable Long educationId,
-            @Valid @RequestBody EduReportUpdateRequestDto requestDto,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long updatedId =
-                eduReportService.updateDepartmentEduReport(
-                        educationId, requestDto, userDetails.getId());
-        return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
-    }
+        @Hidden
+        @PatchMapping(value = "/department/{educationId}", consumes = MediaType.APPLICATION_JSON_VALUE)
+        public ResponseEntity<ApiResponse<Long>> updateDepartmentEducationJsonFallback(
+                        @PathVariable Long educationId,
+                        @Valid @RequestBody EduReportUpdateRequestDto requestDto,
+                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+                Long updatedId = eduReportService.updateDepartmentEduReport(
+                                educationId, requestDto, userDetails.getId());
+                return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
+        }
 
-    @Operation(
-            tags = {"PSM"},
-            summary = "PSM 게시물 수정",
-            description =
-                    """
-                `multipart/form-data`로 PSM 게시물을 수정합니다.
+        @Operation(tags = {
+                        "PSM" }, summary = "PSM 게시물 수정", description = """
+                                        `multipart/form-data`로 PSM 게시물을 수정합니다.
 
-                - PSM 관리 권한(`MANAGE_PSM`)이 필요합니다.
-                - `OPEN` 상태에서만 수정 가능합니다.
-                - 출석 완료자가 1명이라도 있으면 수정할 수 없습니다.
-                - `requestDto`(JSON 파트)는 필수이며, `files`(파일 파트)는 선택입니다.
-                - `requestDto.deleteAttachmentIds`로 기존 첨부파일 삭제가 가능합니다.
-                """,
-            requestBody =
-                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                            required = true,
-                            content =
-                                    @Content(
-                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-                                            schema =
-                                                    @Schema(
-                                                            implementation =
-                                                                    EduReportUpdateMultipartRequestDoc
-                                                                            .class),
-                                            encoding = {
-                                                @Encoding(
-                                                        name = "requestDto",
-                                                        contentType =
-                                                                MediaType.APPLICATION_JSON_VALUE),
-                                                @Encoding(name = "files", contentType = "*/*")
-                                            })))
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "수정 성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "400",
-                description = "잘못된 요청"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "403",
-                description = "권한 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음")
-    })
-    @PatchMapping(value = "/psm/{educationId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<Long>> updatePsmEducation(
-            @Parameter(description = "수정할 PSM 게시물 ID", example = "1") @PathVariable
-                    Long educationId,
-            @Parameter(description = "PSM 수정 정보(JSON)", required = true)
-                    @RequestPart("requestDto")
-                    @Valid
-                    EduReportUpdateRequestDto requestDto,
-            @Parameter(description = "추가할 첨부 파일 목록(선택)")
-                    @RequestPart(value = "files", required = false)
-                    List<MultipartFile> files,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long updatedId =
-                eduReportService.updatePsmEduReport(
-                        educationId, requestDto, files, userDetails.getId());
-        return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
-    }
+                                        - PSM 관리 권한(`MANAGE_PSM`)이 필요합니다.
+                                        - `OPEN` 상태에서만 수정 가능합니다.
+                                        - 출석 완료자가 1명이라도 있으면 수정할 수 없습니다.
+                                        - `requestDto`(JSON 파트)는 필수이며, `files`(파일 파트)는 선택입니다.
+                                        - `requestDto.deleteAttachmentIds`로 기존 첨부파일 삭제가 가능합니다.
+                                        """, requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE, schema = @Schema(implementation = EduReportUpdateMultipartRequestDoc.class), encoding = {
+                                        @Encoding(name = "requestDto", contentType = MediaType.APPLICATION_JSON_VALUE),
+                                        @Encoding(name = "files", contentType = "*/*")
+                        })))
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음")
+        })
+        @PatchMapping(value = "/psm/{educationId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+        public ResponseEntity<ApiResponse<Long>> updatePsmEducation(
+                        @Parameter(description = "수정할 PSM 게시물 ID", example = "1") @PathVariable Long educationId,
+                        @Parameter(description = "PSM 수정 정보(JSON)", required = true) @RequestPart("requestDto") @Valid EduReportUpdateRequestDto requestDto,
+                        @Parameter(description = "추가할 첨부 파일 목록(선택)") @RequestPart(value = "files", required = false) List<MultipartFile> files,
+                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+                Long updatedId = eduReportService.updatePsmEduReport(
+                                educationId, requestDto, files, userDetails.getId());
+                return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
+        }
 
-    @Hidden
-    @PatchMapping(value = "/psm/{educationId}", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<ApiResponse<Long>> updatePsmEducationJsonFallback(
-            @PathVariable Long educationId,
-            @Valid @RequestBody EduReportUpdateRequestDto requestDto,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long updatedId =
-                eduReportService.updatePsmEduReport(educationId, requestDto, userDetails.getId());
-        return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
-    }
+        @Hidden
+        @PatchMapping(value = "/psm/{educationId}", consumes = MediaType.APPLICATION_JSON_VALUE)
+        public ResponseEntity<ApiResponse<Long>> updatePsmEducationJsonFallback(
+                        @PathVariable Long educationId,
+                        @Valid @RequestBody EduReportUpdateRequestDto requestDto,
+                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+                Long updatedId = eduReportService.updatePsmEduReport(educationId, requestDto, userDetails.getId());
+                return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
+        }
 
-    @Operation(
-            tags = {"안전보건"},
-            summary = "안전 보건 게시물 수정",
-            description =
-                    """
-                `multipart/form-data`로 안전 보건 게시물을 수정합니다.
+        @Operation(tags = {
+                        "안전보건" }, summary = "안전 보건 게시물 수정", description = """
+                                        `multipart/form-data`로 안전 보건 게시물을 수정합니다.
 
-                - 안전 보건 관리 권한(`MANAGE_SAFETY`)이 필요합니다.
-                - `OPEN` 상태에서만 수정 가능합니다.
-                - 출석 완료자가 1명이라도 있으면 수정할 수 없습니다.
-                - `requestDto`(JSON 파트)는 필수이며, `files`(파일 파트)는 선택입니다.
-                - `requestDto.deleteAttachmentIds`로 기존 첨부파일 삭제가 가능합니다.
-                """,
-            requestBody =
-                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                            required = true,
-                            content =
-                                    @Content(
-                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-                                            schema =
-                                                    @Schema(
-                                                            implementation =
-                                                                    EduReportUpdateMultipartRequestDoc
-                                                                            .class),
-                                            encoding = {
-                                                @Encoding(
-                                                        name = "requestDto",
-                                                        contentType =
-                                                                MediaType.APPLICATION_JSON_VALUE),
-                                                @Encoding(name = "files", contentType = "*/*")
-                                            })))
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "수정 성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "400",
-                description = "잘못된 요청"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "403",
-                description = "권한 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음")
-    })
-    @PatchMapping(value = "/safety/{educationId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<Long>> updateSafetyEducation(
-            @Parameter(description = "수정할 안전 보건 게시물 ID", example = "1") @PathVariable
-                    Long educationId,
-            @Parameter(description = "안전 보건 수정 정보(JSON)", required = true)
-                    @RequestPart("requestDto")
-                    @Valid
-                    EduReportUpdateRequestDto requestDto,
-            @Parameter(description = "추가할 첨부 파일 목록(선택)")
-                    @RequestPart(value = "files", required = false)
-                    List<MultipartFile> files,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long updatedId =
-                eduReportService.updateSafetyEduReport(
-                        educationId, requestDto, files, userDetails.getId());
-        return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
-    }
+                                        - 안전 보건 관리 권한(`MANAGE_SAFETY`)이 필요합니다.
+                                        - `OPEN` 상태에서만 수정 가능합니다.
+                                        - 출석 완료자가 1명이라도 있으면 수정할 수 없습니다.
+                                        - `requestDto`(JSON 파트)는 필수이며, `files`(파일 파트)는 선택입니다.
+                                        - `requestDto.deleteAttachmentIds`로 기존 첨부파일 삭제가 가능합니다.
+                                        """, requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE, schema = @Schema(implementation = EduReportUpdateMultipartRequestDoc.class), encoding = {
+                                        @Encoding(name = "requestDto", contentType = MediaType.APPLICATION_JSON_VALUE),
+                                        @Encoding(name = "files", contentType = "*/*")
+                        })))
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "수정 성공"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음")
+        })
+        @PatchMapping(value = "/safety/{educationId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+        public ResponseEntity<ApiResponse<Long>> updateSafetyEducation(
+                        @Parameter(description = "수정할 안전 보건 게시물 ID", example = "1") @PathVariable Long educationId,
+                        @Parameter(description = "안전 보건 수정 정보(JSON)", required = true) @RequestPart("requestDto") @Valid EduReportUpdateRequestDto requestDto,
+                        @Parameter(description = "추가할 첨부 파일 목록(선택)") @RequestPart(value = "files", required = false) List<MultipartFile> files,
+                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+                Long updatedId = eduReportService.updateSafetyEduReport(
+                                educationId, requestDto, files, userDetails.getId());
+                return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
+        }
 
-    @Hidden
-    @PatchMapping(value = "/safety/{educationId}", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<ApiResponse<Long>> updateSafetyEducationJsonFallback(
-            @PathVariable Long educationId,
-            @Valid @RequestBody EduReportUpdateRequestDto requestDto,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long updatedId =
-                eduReportService.updateSafetyEduReport(
-                        educationId, requestDto, userDetails.getId());
-        return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
-    }
+        @Hidden
+        @PatchMapping(value = "/safety/{educationId}", consumes = MediaType.APPLICATION_JSON_VALUE)
+        public ResponseEntity<ApiResponse<Long>> updateSafetyEducationJsonFallback(
+                        @PathVariable Long educationId,
+                        @Valid @RequestBody EduReportUpdateRequestDto requestDto,
+                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+                Long updatedId = eduReportService.updateSafetyEduReport(
+                                educationId, requestDto, userDetails.getId());
+                return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
+        }
 
-    @Operation(
-            tags = {"부서교육"},
-            summary = "부서 교육 게시물 상태 변경",
-            description =
-                    """
-                부서 교육 게시물 상태를 `OPEN`/`CLOSED`로 변경합니다.
+        @Operation(tags = { "부서교육" }, summary = "부서 교육 게시물 상태 변경", description = """
+                        부서 교육 게시물 상태를 `OPEN`/`CLOSED`로 변경합니다.
 
-                - 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 필요합니다.
-                """)
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "상태 변경 성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "400",
-                description = "잘못된 요청"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "403",
-                description = "권한 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음")
-    })
-    @PatchMapping("/department/{educationId}/status")
-    public ResponseEntity<ApiResponse<Long>> updateDepartmentEducationStatus(
-            @Parameter(description = "상태 변경할 부서 교육 게시물 ID", example = "1") @PathVariable
-                    Long educationId,
-            @Valid @RequestBody EduReportStatusUpdateRequestDto requestDto,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long updatedId =
-                eduReportService.updateDepartmentEduReportStatus(
-                        educationId, requestDto, userDetails.getId());
-        return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
-    }
+                        - 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 필요합니다.
+                        """)
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "상태 변경 성공"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음")
+        })
+        @PatchMapping("/department/{educationId}/status")
+        public ResponseEntity<ApiResponse<Long>> updateDepartmentEducationStatus(
+                        @Parameter(description = "상태 변경할 부서 교육 게시물 ID", example = "1") @PathVariable Long educationId,
+                        @Valid @RequestBody EduReportStatusUpdateRequestDto requestDto,
+                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+                Long updatedId = eduReportService.updateDepartmentEduReportStatus(
+                                educationId, requestDto, userDetails.getId());
+                return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
+        }
 
-    @Operation(
-            tags = {"PSM"},
-            summary = "PSM 게시물 상태 변경",
-            description =
-                    """
-                PSM 게시물 상태를 `OPEN`/`CLOSED`로 변경합니다.
+        @Operation(tags = { "PSM" }, summary = "PSM 게시물 상태 변경", description = """
+                        PSM 게시물 상태를 `OPEN`/`CLOSED`로 변경합니다.
 
-                - PSM 관리 권한(`MANAGE_PSM`)이 필요합니다.
-                """)
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "상태 변경 성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "400",
-                description = "잘못된 요청"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "403",
-                description = "권한 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음")
-    })
-    @PatchMapping("/psm/{educationId}/status")
-    public ResponseEntity<ApiResponse<Long>> updatePsmEducationStatus(
-            @Parameter(description = "상태 변경할 PSM 게시물 ID", example = "1") @PathVariable
-                    Long educationId,
-            @Valid @RequestBody EduReportStatusUpdateRequestDto requestDto,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long updatedId =
-                eduReportService.updatePsmEduReportStatus(
-                        educationId, requestDto, userDetails.getId());
-        return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
-    }
+                        - PSM 관리 권한(`MANAGE_PSM`)이 필요합니다.
+                        """)
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "상태 변경 성공"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음")
+        })
+        @PatchMapping("/psm/{educationId}/status")
+        public ResponseEntity<ApiResponse<Long>> updatePsmEducationStatus(
+                        @Parameter(description = "상태 변경할 PSM 게시물 ID", example = "1") @PathVariable Long educationId,
+                        @Valid @RequestBody EduReportStatusUpdateRequestDto requestDto,
+                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+                Long updatedId = eduReportService.updatePsmEduReportStatus(
+                                educationId, requestDto, userDetails.getId());
+                return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
+        }
 
-    @Operation(
-            tags = {"안전보건"},
-            summary = "안전 보건 게시물 상태 변경",
-            description =
-                    """
-                안전 보건 게시물 상태를 `OPEN`/`CLOSED`로 변경합니다.
+        @Operation(tags = { "안전보건" }, summary = "안전 보건 게시물 상태 변경", description = """
+                        안전 보건 게시물 상태를 `OPEN`/`CLOSED`로 변경합니다.
 
-                - 안전 보건 관리 권한(`MANAGE_SAFETY`)이 필요합니다.
-                """)
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "상태 변경 성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "400",
-                description = "잘못된 요청"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "403",
-                description = "권한 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음")
-    })
-    @PatchMapping("/safety/{educationId}/status")
-    public ResponseEntity<ApiResponse<Long>> updateSafetyEducationStatus(
-            @Parameter(description = "상태 변경할 안전 보건 게시물 ID", example = "1") @PathVariable
-                    Long educationId,
-            @Valid @RequestBody EduReportStatusUpdateRequestDto requestDto,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long updatedId =
-                eduReportService.updateSafetyEduReportStatus(
-                        educationId, requestDto, userDetails.getId());
-        return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
-    }
+                        - 안전 보건 관리 권한(`MANAGE_SAFETY`)이 필요합니다.
+                        """)
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "상태 변경 성공"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음")
+        })
+        @PatchMapping("/safety/{educationId}/status")
+        public ResponseEntity<ApiResponse<Long>> updateSafetyEducationStatus(
+                        @Parameter(description = "상태 변경할 안전 보건 게시물 ID", example = "1") @PathVariable Long educationId,
+                        @Valid @RequestBody EduReportStatusUpdateRequestDto requestDto,
+                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+                Long updatedId = eduReportService.updateSafetyEduReportStatus(
+                                educationId, requestDto, userDetails.getId());
+                return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
+        }
 
-    @Operation(
-            tags = {"부서교육"},
-            summary = "부서 교육 게시물 삭제",
-            description = "부서 교육 게시물을 삭제합니다. 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 필요합니다.")
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "삭제 성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "403",
-                description = "권한 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음")
-    })
-    @DeleteMapping("/department/{educationId}")
-    public ResponseEntity<ApiResponse<Void>> deleteDepartmentEduReport(
-            @Parameter(description = "삭제할 부서 교육 게시물 ID", example = "1") @PathVariable
-                    Long educationId,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-        eduReportService.deleteDepartmentEduReport(educationId, userDetails.getId());
-        return ResponseEntity.ok().body(ApiResponse.onNoContent());
-    }
+        @Operation(tags = {
+                        "부서교육" }, summary = "부서 교육 게시물 삭제", description = "부서 교육 게시물을 삭제합니다. 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 필요합니다.")
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "삭제 성공"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음")
+        })
+        @DeleteMapping("/department/{educationId}")
+        public ResponseEntity<ApiResponse<Void>> deleteDepartmentEduReport(
+                        @Parameter(description = "삭제할 부서 교육 게시물 ID", example = "1") @PathVariable Long educationId,
+                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+                eduReportService.deleteDepartmentEduReport(educationId, userDetails.getId());
+                return ResponseEntity.ok().body(ApiResponse.onNoContent());
+        }
 
-    @Operation(
-            tags = {"PSM"},
-            summary = "PSM 게시물 삭제",
-            description = "PSM 게시물을 삭제합니다. PSM 관리 권한(`MANAGE_PSM`)이 필요합니다.")
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "삭제 성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "403",
-                description = "권한 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음")
-    })
-    @DeleteMapping("/psm/{educationId}")
-    public ResponseEntity<ApiResponse<Void>> deletePsmEduReport(
-            @Parameter(description = "삭제할 PSM 게시물 ID", example = "1") @PathVariable
-                    Long educationId,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-        eduReportService.deletePsmEduReport(educationId, userDetails.getId());
-        return ResponseEntity.ok().body(ApiResponse.onNoContent());
-    }
+        @Operation(tags = {
+                        "PSM" }, summary = "PSM 게시물 삭제", description = "PSM 게시물을 삭제합니다. PSM 관리 권한(`MANAGE_PSM`)이 필요합니다.")
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "삭제 성공"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음")
+        })
+        @DeleteMapping("/psm/{educationId}")
+        public ResponseEntity<ApiResponse<Void>> deletePsmEduReport(
+                        @Parameter(description = "삭제할 PSM 게시물 ID", example = "1") @PathVariable Long educationId,
+                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+                eduReportService.deletePsmEduReport(educationId, userDetails.getId());
+                return ResponseEntity.ok().body(ApiResponse.onNoContent());
+        }
 
-    @Operation(
-            tags = {"안전보건"},
-            summary = "안전 보건 게시물 삭제",
-            description = "안전 보건 게시물을 삭제합니다. 안전 보건 관리 권한(`MANAGE_SAFETY`)이 필요합니다.")
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "삭제 성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "403",
-                description = "권한 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음")
-    })
-    @DeleteMapping("/safety/{educationId}")
-    public ResponseEntity<ApiResponse<Void>> deleteSafetyEduReport(
-            @Parameter(description = "삭제할 안전 보건 게시물 ID", example = "1") @PathVariable
-                    Long educationId,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-        eduReportService.deleteSafetyEduReport(educationId, userDetails.getId());
-        return ResponseEntity.ok().body(ApiResponse.onNoContent());
-    }
+        @Operation(tags = {
+                        "안전보건" }, summary = "안전 보건 게시물 삭제", description = "안전 보건 게시물을 삭제합니다. 안전 보건 관리 권한(`MANAGE_SAFETY`)이 필요합니다.")
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "삭제 성공"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음")
+        })
+        @DeleteMapping("/safety/{educationId}")
+        public ResponseEntity<ApiResponse<Void>> deleteSafetyEduReport(
+                        @Parameter(description = "삭제할 안전 보건 게시물 ID", example = "1") @PathVariable Long educationId,
+                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+                eduReportService.deleteSafetyEduReport(educationId, userDetails.getId());
+                return ResponseEntity.ok().body(ApiResponse.onNoContent());
+        }
 
-    @Operation(
-            tags = {"부서교육"},
-            summary = "부서 교육 게시물 출석(서명) 처리",
-            description =
-                    """
-                부서 교육 게시물 출석을 처리합니다.
+        @Operation(tags = {
+                        "부서교육" }, summary = "부서 교육 게시물 출석(서명) 처리", description = """
+                                        부서 교육 게시물 출석을 처리합니다.
 
-                - `signatureRequired=true` 게시물은 PNG 서명 파일(`signature`)이 필수입니다.
-                - `signatureRequired=false` 게시물은 파일 없이도 출석 처리됩니다.
-                - 동일 사용자 중복 출석은 허용되지 않습니다.
-                """,
-            requestBody =
-                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                            required = false,
-                            content =
-                                    @Content(
-                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-                                            schema =
-                                                    @Schema(
-                                                            implementation =
-                                                                    EduReportAttendanceMultipartRequestDoc
-                                                                            .class),
-                                            encoding =
-                                                    @Encoding(
-                                                            name = "signature",
-                                                            contentType = "image/png"))))
-    @ApiResponses(
-            value = {
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "200",
-                        description = "출석 처리 성공"),
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "400",
-                        description = "잘못된 요청"),
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "404",
-                        description = "리소스 없음")
-            })
-    @PostMapping(
-            value = "/department/{educationId}/attendance",
-            consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<Void>> markDepartmentAttendance(
-            @Parameter(description = "부서 교육 게시물 ID", example = "1") @PathVariable Long educationId,
-            @Parameter(description = "서명 PNG 파일(signatureRequired=true인 경우 필수)")
-                    @RequestPart(value = "signature", required = false)
-                    MultipartFile signature,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
-            throws IOException {
-        eduReportService.markDepartmentAttendance(educationId, signature, userDetails.getId());
-        return ResponseEntity.ok(ApiResponse.onNoContent());
-    }
+                                        - `signatureRequired=true` 게시물은 PNG 서명 파일(`signature`)이 필수입니다.
+                                        - `signatureRequired=false` 게시물은 파일 없이도 출석 처리됩니다.
+                                        - 동일 사용자 중복 출석은 허용되지 않습니다.
+                                        """, requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(required = false, content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE, schema = @Schema(implementation = EduReportAttendanceMultipartRequestDoc.class), encoding = @Encoding(name = "signature", contentType = "image/png"))))
+        @ApiResponses(value = {
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "출석 처리 성공"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음")
+        })
+        @PostMapping(value = "/department/{educationId}/attendance", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+        public ResponseEntity<ApiResponse<Void>> markDepartmentAttendance(
+                        @Parameter(description = "부서 교육 게시물 ID", example = "1") @PathVariable Long educationId,
+                        @Parameter(description = "서명 PNG 파일(signatureRequired=true인 경우 필수)") @RequestPart(value = "signature", required = false) MultipartFile signature,
+                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
+                        throws IOException {
+                eduReportService.markDepartmentAttendance(educationId, signature, userDetails.getId());
+                return ResponseEntity.ok(ApiResponse.onNoContent());
+        }
 
-    @Operation(
-            tags = {"부서교육"},
-            summary = "부서 교육 서명 현황 목록 조회",
-            description =
-                    """
-                부서 교육 게시물의 대상 직원별 서명 현황을 조회합니다.
+        @Operation(tags = { "부서교육" }, summary = "부서 교육 서명 현황 목록 조회", description = """
+                        부서 교육 게시물의 대상 직원별 서명 현황을 조회합니다.
 
-                - `MANAGE_DEPARTMENT_EDUCATION` 권한이 필요합니다.
-                - `name` 파라미터로 한글명(nameKor) 또는 영문명(nameEng)에 대한 부분 일치 검색이 가능합니다.
-                """)
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "조회 성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "403",
-                description = "권한 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "리소스 없음")
-    })
-    @GetMapping("/{educationId}/signatures")
-    public ResponseEntity<ApiResponse<List<EduReportSignatureStatusDto>>> getSignatureStatuses(
-            @Parameter(description = "교육 보고서 ID", example = "1") @PathVariable Long educationId,
-            @Parameter(description = "직원명 검색 필터 (한글명/영문명 부분 일치)", example = "홍")
-                    @RequestParam(required = false)
-                    String name,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
-        List<EduReportSignatureStatusDto> result =
-                eduReportService.getSignatureStatuses(educationId, name, userDetails.getId());
-        return ResponseEntity.ok(ApiResponse.onSuccess(result));
-    }
+                        - `MANAGE_DEPARTMENT_EDUCATION` 권한이 필요합니다.
+                        - `name` 파라미터로 한글명(nameKor) 또는 영문명(nameEng)에 대한 부분 일치 검색이 가능합니다.
+                        """)
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "리소스 없음")
+        })
+        @GetMapping("/{educationId}/signatures")
+        public ResponseEntity<ApiResponse<List<EduReportSignatureStatusDto>>> getSignatureStatuses(
+                        @Parameter(description = "교육 보고서 ID", example = "1") @PathVariable Long educationId,
+                        @Parameter(description = "직원명 검색 필터 (한글명/영문명 부분 일치)", example = "홍") @RequestParam(required = false) String name,
+                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+                List<EduReportSignatureStatusDto> result = eduReportService.getSignatureStatuses(educationId, name,
+                                userDetails.getId());
+                return ResponseEntity.ok(ApiResponse.onSuccess(result));
+        }
 
-    @Schema(name = "EduReportAttendanceMultipartRequestDoc", description = "출석(서명) multipart 요청")
-    static class EduReportAttendanceMultipartRequestDoc {
+        @Operation(tags = { "교육 (공통)" }, summary = "교육 리마인드 알림 전송", description = """
+                        교육 생성자(createdBy)만 요청 가능합니다.
 
-        @Schema(
-                description = "서명 PNG 파일(signatureRequired=true인 경우 필수)",
-                type = "string",
-                format = "binary")
-        public String signature;
-    }
+                        - 생성 시와 동일한 대상자에게 title에 `[리마인드]` prefix를 붙여 알림을 재전송합니다.
+                        - 부서교육 / PSM / 안전보건 모든 타입에 사용 가능합니다.
+                        """)
+        @ApiResponses({
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "전송 성공"),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "권한 없음 (교육 생성자가 아님)", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                                        {
+                                          "isSuccess": false,
+                                          "code": "NO_AUTHORITY_FOR_EDU_REPORT",
+                                          "message": "교육 게시물 관리 권한이 없습니다.",
+                                          "result": null
+                                        }
+                                        """))),
+                        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "교육 게시물 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                                        {
+                                          "isSuccess": false,
+                                          "code": "EDU_REPORT_NOT_FOUND",
+                                          "message": "해당 교육 게시물을 찾을 수 없습니다.",
+                                          "result": null
+                                        }
+                                        """)))
+        })
+        @PostMapping("/{educationId}/remind")
+        public ResponseEntity<ApiResponse<Void>> remindEduReport(
+                        @Parameter(description = "리마인드 알림을 전송할 교육 게시물 ID", example = "1") @PathVariable Long educationId,
+                        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+                eduReportService.remindEduReport(educationId, userDetails.getId());
+                return ResponseEntity.ok(ApiResponse.onNoContent());
+        }
+
+        @Schema(name = "EduReportAttendanceMultipartRequestDoc", description = "출석(서명) multipart 요청")
+        static class EduReportAttendanceMultipartRequestDoc {
+
+                @Schema(description = "서명 PNG 파일(signatureRequired=true인 경우 필수)", type = "string", format = "binary")
+                public String signature;
+        }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -76,14 +76,15 @@ public class EduReportService {
     public Long createPsmEduReport(
             PsmEduReportCreateRequestDto requestDto, List<MultipartFile> files, Long id)
             throws IOException {
-        EduReportRequestDto baseRequest = EduReportRequestDto.builder()
-                .eduType(EduType.PSM)
-                .title(requestDto.getTitle())
-                .content(requestDto.getContent())
-                .pinned(requestDto.isPinned())
-                .signatureRequired(false)
-                .categoryId(requestDto.getCategoryId())
-                .build();
+        EduReportRequestDto baseRequest =
+                EduReportRequestDto.builder()
+                        .eduType(EduType.PSM)
+                        .title(requestDto.getTitle())
+                        .content(requestDto.getContent())
+                        .pinned(requestDto.isPinned())
+                        .signatureRequired(false)
+                        .categoryId(requestDto.getCategoryId())
+                        .build();
         Company companyOverride = resolveCompanyScopeOverride(requestDto.getCompanyScope());
         return createEduReportInternal(baseRequest, files, id, true, companyOverride);
     }
@@ -92,14 +93,15 @@ public class EduReportService {
     public Long createSafetyEduReport(
             SafetyEduReportCreateRequestDto requestDto, List<MultipartFile> files, Long id)
             throws IOException {
-        EduReportRequestDto baseRequest = EduReportRequestDto.builder()
-                .eduType(EduType.SAFETY)
-                .title(requestDto.getTitle())
-                .content(requestDto.getContent())
-                .pinned(requestDto.isPinned())
-                .signatureRequired(false)
-                .categoryId(requestDto.getCategoryId())
-                .build();
+        EduReportRequestDto baseRequest =
+                EduReportRequestDto.builder()
+                        .eduType(EduType.SAFETY)
+                        .title(requestDto.getTitle())
+                        .content(requestDto.getContent())
+                        .pinned(requestDto.isPinned())
+                        .signatureRequired(false)
+                        .categoryId(requestDto.getCategoryId())
+                        .build();
         Company companyOverride = resolveCompanyScopeOverride(requestDto.getCompanyScope());
         return createEduReportInternal(baseRequest, files, id, true, companyOverride);
     }
@@ -112,9 +114,10 @@ public class EduReportService {
             Company companyOverride)
             throws IOException {
 
-        User user = userRepository
-                .findById(id)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user =
+                userRepository
+                        .findById(id)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         validateCreateAuthority(user, requestDto.getEduType());
 
@@ -123,9 +126,10 @@ public class EduReportService {
             if (requestDto.getDepartmentId() == null) {
                 throw new CustomException(ErrorCode.DEPARTMENT_ID_REQUIRED);
             }
-            department = departmentRepository
-                    .findById(requestDto.getDepartmentId())
-                    .orElseThrow(() -> new CustomException(ErrorCode.DEPARTMENT_NOT_FOUND));
+            department =
+                    departmentRepository
+                            .findById(requestDto.getDepartmentId())
+                            .orElseThrow(() -> new CustomException(ErrorCode.DEPARTMENT_NOT_FOUND));
         }
 
         EducationCategory category = null;
@@ -177,13 +181,14 @@ public class EduReportService {
         } else {
             targetUserIds = userRepository.findAllIdsByDepartmentId(requestDto.getDepartmentId());
         }
-        Map<String, Object> metadata = requestDto.getEduType() == EduType.SAFETY
-                ? Map.of(
-                        "educationType",
-                        requestDto.getEduType().name(),
-                        "detailType",
-                        "GENERAL")
-                : Map.of("educationType", requestDto.getEduType().name());
+        Map<String, Object> metadata =
+                requestDto.getEduType() == EduType.SAFETY
+                        ? Map.of(
+                                "educationType",
+                                requestDto.getEduType().name(),
+                                "detailType",
+                                "GENERAL")
+                        : Map.of("educationType", requestDto.getEduType().name());
         notificationService.sendEduReportAlertToTargets(
                 requestDto.getEduType().getDescription(),
                 requestDto.getTitle(),
@@ -198,14 +203,15 @@ public class EduReportService {
     public Long createDepartmentEduReport(
             DepartmentEduReportCreateRequestDto requestDto, List<MultipartFile> files, Long id)
             throws IOException {
-        EduReportRequestDto baseRequest = EduReportRequestDto.builder()
-                .eduType(EduType.DEPARTMENT)
-                .title(requestDto.getTitle())
-                .content(requestDto.getContent())
-                .pinned(requestDto.isPinned())
-                .signatureRequired(requestDto.isSignatureRequired())
-                .departmentId(requestDto.getDepartmentId())
-                .build();
+        EduReportRequestDto baseRequest =
+                EduReportRequestDto.builder()
+                        .eduType(EduType.DEPARTMENT)
+                        .title(requestDto.getTitle())
+                        .content(requestDto.getContent())
+                        .pinned(requestDto.isPinned())
+                        .signatureRequired(requestDto.isSignatureRequired())
+                        .departmentId(requestDto.getDepartmentId())
+                        .build();
         return createEduReport(baseRequest, files, id);
     }
 
@@ -233,9 +239,10 @@ public class EduReportService {
     public List<EduReportSummaryDto> getEduReports(
             EduType type, DepartmentName departmentName, Long categoryId, Long id, String title) {
 
-        User user = userRepository
-                .findById(id)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user =
+                userRepository
+                        .findById(id)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         boolean hasAccess = user.hasAuthority(Authority.MANAGE_DEPARTMENT_EDUCATION);
         boolean canReadAllPsmCompanies = user.hasAuthority(Authority.MANAGE_PSM);
@@ -244,27 +251,30 @@ public class EduReportService {
         Department dept;
         if (hasAccess) {
             // 권한 있음: departmentName이 지정되면 해당 부서, 없으면 null(전체 조회)
-            dept = (departmentName != null)
-                    ? departmentRepository
-                            .findByName(departmentName)
-                            .orElseThrow(
-                                    () -> new CustomException(
-                                            ErrorCode.DEPARTMENT_NOT_FOUND))
-                    : null;
+            dept =
+                    (departmentName != null)
+                            ? departmentRepository
+                                    .findByName(departmentName)
+                                    .orElseThrow(
+                                            () ->
+                                                    new CustomException(
+                                                            ErrorCode.DEPARTMENT_NOT_FOUND))
+                            : null;
         } else {
             // 권한 없음: 자신의 부서로 제한
             dept = user.getDepartment();
         }
 
-        List<EduReportSummaryDto> summaries = eduReportQueryRepository.findEduReports(
-                type,
-                dept,
-                categoryId,
-                id,
-                hasAccess,
-                psmCompanyFilter,
-                canReadAllPsmCompanies,
-                title);
+        List<EduReportSummaryDto> summaries =
+                eduReportQueryRepository.findEduReports(
+                        type,
+                        dept,
+                        categoryId,
+                        id,
+                        hasAccess,
+                        psmCompanyFilter,
+                        canReadAllPsmCompanies,
+                        title);
 
         summaries.forEach(
                 summary -> {
@@ -282,28 +292,32 @@ public class EduReportService {
 
     @Transactional(readOnly = true)
     public List<EduReportSummaryDto> getPsmEduReports(Long categoryId, Long id, String title) {
-        User user = userRepository
-                .findById(id)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user =
+                userRepository
+                        .findById(id)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         boolean canReadAllCompanies = user.hasAuthority(Authority.MANAGE_PSM);
         Company companyFilter = canReadAllCompanies ? null : user.getWorkLocation();
-        List<EduReportSummaryDto> summaries = eduReportQueryRepository.findPsmEduReports(
-                categoryId, id, companyFilter, canReadAllCompanies, title);
+        List<EduReportSummaryDto> summaries =
+                eduReportQueryRepository.findPsmEduReports(
+                        categoryId, id, companyFilter, canReadAllCompanies, title);
         summaries.forEach(this::applyCompanyScopeToSummary);
         return summaries;
     }
 
     @Transactional(readOnly = true)
     public List<EduReportSummaryDto> getSafetyEduReports(Long categoryId, Long id, String title) {
-        User user = userRepository
-                .findById(id)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user =
+                userRepository
+                        .findById(id)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         boolean canReadAllCompanies = user.hasAuthority(Authority.MANAGE_SAFETY);
         Company companyFilter = canReadAllCompanies ? null : user.getWorkLocation();
-        List<EduReportSummaryDto> summaries = eduReportQueryRepository.findSafetyEduReports(
-                categoryId, id, companyFilter, canReadAllCompanies, title);
+        List<EduReportSummaryDto> summaries =
+                eduReportQueryRepository.findSafetyEduReports(
+                        categoryId, id, companyFilter, canReadAllCompanies, title);
         summaries.forEach(this::applyCompanyScopeToSummary);
         return summaries;
     }
@@ -311,13 +325,15 @@ public class EduReportService {
     @Transactional(readOnly = true)
     public EduReportDetailDto getEduReport(Long eduReportId, Long id) {
 
-        User user = userRepository
-                .findById(id)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user =
+                userRepository
+                        .findById(id)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        EduReport report = eduReportRepository
-                .findById(eduReportId)
-                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+        EduReport report =
+                eduReportRepository
+                        .findById(eduReportId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
 
         boolean hasAccess = user.hasAuthority(Authority.MANAGE_DEPARTMENT_EDUCATION);
         return buildEduReportDetailDto(user, report, hasAccess, false);
@@ -325,13 +341,15 @@ public class EduReportService {
 
     @Transactional(readOnly = true)
     public EduReportDetailDto getDepartmentEduReport(Long eduReportId, Long id) {
-        User user = userRepository
-                .findById(id)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user =
+                userRepository
+                        .findById(id)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        EduReport report = eduReportRepository
-                .findById(eduReportId)
-                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+        EduReport report =
+                eduReportRepository
+                        .findById(eduReportId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
 
         if (report.getEduType() != EduType.DEPARTMENT) {
             throw new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND);
@@ -358,13 +376,15 @@ public class EduReportService {
 
     @Transactional(readOnly = true)
     public EduReportDetailDto getPsmEduReport(Long eduReportId, Long id) {
-        User user = userRepository
-                .findById(id)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user =
+                userRepository
+                        .findById(id)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        EduReport report = eduReportRepository
-                .findById(eduReportId)
-                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+        EduReport report =
+                eduReportRepository
+                        .findById(eduReportId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
 
         if (report.getEduType() != EduType.PSM) {
             throw new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND);
@@ -404,13 +424,15 @@ public class EduReportService {
 
     @Transactional(readOnly = true)
     public EduReportDetailDto getSafetyEduReport(Long eduReportId, Long id) {
-        User user = userRepository
-                .findById(id)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user =
+                userRepository
+                        .findById(id)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        EduReport report = eduReportRepository
-                .findById(eduReportId)
-                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+        EduReport report =
+                eduReportRepository
+                        .findById(eduReportId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
 
         if (report.getEduType() != EduType.SAFETY) {
             throw new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND);
@@ -459,7 +481,8 @@ public class EduReportService {
             numberOfPeople = calculateTargetPeopleCount(report);
         }
 
-        EduReportDetailDto dto = eduMapper.toDetailDto(report, attendances, numberOfPeople, s3Service);
+        EduReportDetailDto dto =
+                eduMapper.toDetailDto(report, attendances, numberOfPeople, s3Service);
 
         if (includeSignatureCounts) {
             long targetCount = calculateTargetPeopleCount(report);
@@ -487,8 +510,9 @@ public class EduReportService {
             return;
         }
 
-        Boolean mySigned = resolveDepartmentMySigned(
-                user, summary.getDepartmentName(), summary.isAttendance());
+        Boolean mySigned =
+                resolveDepartmentMySigned(
+                        user, summary.getDepartmentName(), summary.isAttendance());
         summary.setMySigned(mySigned);
         summary.setMyCompletionStatus(
                 resolveDepartmentMyCompletionStatus(summary.isSignatureRequired(), mySigned));
@@ -575,30 +599,34 @@ public class EduReportService {
     @Transactional
     public void deleteEduReport(Long eduReportId, Long id) {
 
-        User user = userRepository
-                .findById(id)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user =
+                userRepository
+                        .findById(id)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         if (!user.hasAuthority(Authority.MANAGE_DEPARTMENT_EDUCATION)) {
             throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_EDU_REPORT);
         }
 
-        EduReport report = eduReportRepository
-                .findById(eduReportId)
-                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+        EduReport report =
+                eduReportRepository
+                        .findById(eduReportId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
 
         performDeleteEduReport(report);
     }
 
     private void deleteEduReportByType(Long eduReportId, Long userId, EduType expectedType) {
-        User user = userRepository
-                .findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         validateCreateAuthority(user, expectedType);
 
-        EduReport report = eduReportRepository
-                .findById(eduReportId)
-                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+        EduReport report =
+                eduReportRepository
+                        .findById(eduReportId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
         validateExpectedType(report, expectedType);
 
         performDeleteEduReport(report);
@@ -614,15 +642,15 @@ public class EduReportService {
         eduReportRepository.delete(report);
     }
 
-    public record FileDownloadDto(byte[] fileData, String originalFileName, long fileSize) {
-    }
+    public record FileDownloadDto(byte[] fileData, String originalFileName, long fileSize) {}
 
     @Transactional(readOnly = true)
     public FileDownloadDto getFileForDownload(Long attachmentId) {
         // DB 조회
-        EduAttachment attachment = eduAttachmentRepository
-                .findById(attachmentId)
-                .orElseThrow(() -> new CustomException(ErrorCode.EDU_ATTACHMENT_NOT_FOUND));
+        EduAttachment attachment =
+                eduAttachmentRepository
+                        .findById(attachmentId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_ATTACHMENT_NOT_FOUND));
 
         // S3 데이터 다운로드
         byte[] fileData = s3Service.downloadFile(attachment.getS3Key());
@@ -644,13 +672,15 @@ public class EduReportService {
     public void markAttendance(Long reportId, MultipartFile signatureFile, Long userId)
             throws IOException {
 
-        User user = userRepository
-                .findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        EduReport report = eduReportRepository
-                .findById(reportId)
-                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+        EduReport report =
+                eduReportRepository
+                        .findById(reportId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
 
         markAttendanceInternal(user, report, signatureFile, report.isSignatureRequired());
     }
@@ -664,16 +694,19 @@ public class EduReportService {
     private void markAttendanceByType(
             Long reportId, MultipartFile signatureFile, Long userId, EduType expectedType)
             throws IOException {
-        User user = userRepository
-                .findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        EduReport report = eduReportRepository
-                .findById(reportId)
-                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+        EduReport report =
+                eduReportRepository
+                        .findById(reportId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
         validateExpectedType(report, expectedType);
 
-        boolean requireSignature = expectedType == EduType.DEPARTMENT && report.isSignatureRequired();
+        boolean requireSignature =
+                expectedType == EduType.DEPARTMENT && report.isSignatureRequired();
         markAttendanceInternal(user, report, signatureFile, requireSignature);
     }
 
@@ -771,13 +804,15 @@ public class EduReportService {
             EduReportUpdateRequestDto requestDto,
             List<MultipartFile> files,
             Long userId) {
-        User user = userRepository
-                .findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        EduReport report = eduReportRepository
-                .findById(eduReportId)
-                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+        EduReport report =
+                eduReportRepository
+                        .findById(eduReportId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
         validateCreateAuthority(user, report.getEduType());
         return updateEduReportInternal(eduReportId, report, requestDto, files);
     }
@@ -788,14 +823,16 @@ public class EduReportService {
             List<MultipartFile> files,
             Long userId,
             EduType expectedType) {
-        User user = userRepository
-                .findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         validateCreateAuthority(user, expectedType);
 
-        EduReport report = eduReportRepository
-                .findById(eduReportId)
-                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+        EduReport report =
+                eduReportRepository
+                        .findById(eduReportId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
         validateExpectedType(report, expectedType);
 
         return updateEduReportInternal(eduReportId, report, requestDto, files);
@@ -824,23 +861,26 @@ public class EduReportService {
                 if (requestDto.getDepartmentId() == null) {
                     throw new CustomException(ErrorCode.DEPARTMENT_ID_REQUIRED);
                 }
-                Department department = departmentRepository
-                        .findById(requestDto.getDepartmentId())
-                        .orElseThrow(
-                                () -> new CustomException(ErrorCode.DEPARTMENT_NOT_FOUND));
+                Department department =
+                        departmentRepository
+                                .findById(requestDto.getDepartmentId())
+                                .orElseThrow(
+                                        () -> new CustomException(ErrorCode.DEPARTMENT_NOT_FOUND));
                 report.setDepartment(department);
                 report.setCategory(null);
                 report.setCompany(null);
             } else {
                 if (requestDto.getCategoryId() != null) {
-                    EducationCategory category = getValidatedCategory(report.getEduType(), requestDto.getCategoryId());
+                    EducationCategory category =
+                            getValidatedCategory(report.getEduType(), requestDto.getCategoryId());
                     report.setCategory(category);
                 } else if (report.getCategory() == null) {
                     throw new CustomException(ErrorCode.EDUCATION_CATEGORY_REQUIRED);
                 }
                 report.setDepartment(null);
                 if (requestDto.getCompanyScope() != null) {
-                    Company companyOverride = resolveCompanyScopeOverride(requestDto.getCompanyScope());
+                    Company companyOverride =
+                            resolveCompanyScopeOverride(requestDto.getCompanyScope());
                     report.setCompany(companyOverride);
                 }
             }
@@ -858,13 +898,15 @@ public class EduReportService {
     @Transactional
     public Long updateEduReportStatus(
             Long eduReportId, EduReportStatusUpdateRequestDto requestDto, Long userId) {
-        User user = userRepository
-                .findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        EduReport report = eduReportRepository
-                .findById(eduReportId)
-                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+        EduReport report =
+                eduReportRepository
+                        .findById(eduReportId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
         validateCreateAuthority(user, report.getEduType());
         return updateEduReportStatusInternal(report, requestDto);
     }
@@ -892,14 +934,16 @@ public class EduReportService {
             EduReportStatusUpdateRequestDto requestDto,
             Long userId,
             EduType expectedType) {
-        User user = userRepository
-                .findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         validateCreateAuthority(user, expectedType);
 
-        EduReport report = eduReportRepository
-                .findById(eduReportId)
-                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+        EduReport report =
+                eduReportRepository
+                        .findById(eduReportId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
         validateExpectedType(report, expectedType);
 
         return updateEduReportStatusInternal(report, requestDto);
@@ -973,10 +1017,11 @@ public class EduReportService {
         }
 
         for (Long attachmentId : new LinkedHashSet<>(deleteAttachmentIds)) {
-            EduAttachment attachment = eduAttachmentRepository
-                    .findById(attachmentId)
-                    .orElseThrow(
-                            () -> new CustomException(ErrorCode.EDU_ATTACHMENT_NOT_FOUND));
+            EduAttachment attachment =
+                    eduAttachmentRepository
+                            .findById(attachmentId)
+                            .orElseThrow(
+                                    () -> new CustomException(ErrorCode.EDU_ATTACHMENT_NOT_FOUND));
 
             if (attachment.getEduReport() == null
                     || !attachment.getEduReport().getId().equals(report.getId())) {
@@ -1022,13 +1067,14 @@ public class EduReportService {
             return null;
         }
 
-        EducationCategory category = educationCategoryRepository
-                .findById(categoryId)
-                .orElseThrow(
-                        () -> new CustomException(ErrorCode.EDUCATION_CATEGORY_NOT_FOUND));
+        EducationCategory category =
+                educationCategoryRepository
+                        .findById(categoryId)
+                        .orElseThrow(
+                                () -> new CustomException(ErrorCode.EDUCATION_CATEGORY_NOT_FOUND));
 
-        EducationCategoryType expectedType = eduType == EduType.PSM ? EducationCategoryType.PSM
-                : EducationCategoryType.SAFETY;
+        EducationCategoryType expectedType =
+                eduType == EduType.PSM ? EducationCategoryType.PSM : EducationCategoryType.SAFETY;
         if (category.getCategoryType() != expectedType) {
             throw new CustomException(ErrorCode.INVALID_ARGUMENT);
         }
@@ -1039,13 +1085,15 @@ public class EduReportService {
     public List<EduReportSignatureStatusDto> getSignatureStatuses(
             Long educationId, String name, Long userId) {
 
-        User user = userRepository
-                .findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        EduReport report = eduReportRepository
-                .findById(educationId)
-                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+        EduReport report =
+                eduReportRepository
+                        .findById(educationId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
 
         // 부서 교육 서명 현황 조회 API는 부서 교육 게시물에 대해서만 허용한다.
         if (report.getEduType() != EduType.DEPARTMENT) {
@@ -1061,8 +1109,10 @@ public class EduReportService {
 
     private EduReportSignatureStatusDto toSignatureStatusDto(
             EduReportQueryRepository.SignatureStatusRow row) {
-        String displayName = (row.nameKor() != null && !row.nameKor().isBlank()) ? row.nameKor() : row.nameEng();
-        String deptName = row.departmentName() != null ? row.departmentName().getDescription() : null;
+        String displayName =
+                (row.nameKor() != null && !row.nameKor().isBlank()) ? row.nameKor() : row.nameEng();
+        String deptName =
+                row.departmentName() != null ? row.departmentName().getDescription() : null;
         String positionStr = row.position() != null ? row.position().getDescription() : null;
         boolean isSigned = row.signatureKey() != null;
         String signatureUrl = isSigned ? s3Service.getPresignedViewUrl(row.signatureKey()) : null;
@@ -1117,9 +1167,10 @@ public class EduReportService {
                 .findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        EduReport report = eduReportRepository
-                .findById(eduReportId)
-                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+        EduReport report =
+                eduReportRepository
+                        .findById(eduReportId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
 
         if (report.getCreatedBy() == null || !report.getCreatedBy().getId().equals(userId)) {
             throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_EDU_REPORT);
@@ -1133,14 +1184,17 @@ public class EduReportService {
                 targetUserIds = userRepository.findAllIdsByCompany(report.getCompany());
             }
         } else {
-            targetUserIds = report.getDepartment() != null
-                    ? userRepository.findAllIdsByDepartmentId(report.getDepartment().getId())
-                    : List.of();
+            targetUserIds =
+                    report.getDepartment() != null
+                            ? userRepository.findAllIdsByDepartmentId(
+                                    report.getDepartment().getId())
+                            : List.of();
         }
 
-        Map<String, Object> metadata = report.getEduType() == EduType.SAFETY
-                ? Map.of("educationType", "SAFETY", "detailType", "GENERAL")
-                : Map.of("educationType", report.getEduType().name());
+        Map<String, Object> metadata =
+                report.getEduType() == EduType.SAFETY
+                        ? Map.of("educationType", "SAFETY", "detailType", "GENERAL")
+                        : Map.of("educationType", report.getEduType().name());
 
         notificationService.sendEduReportRemindAlertToTargets(
                 report.getEduType().getDescription(),

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -76,15 +76,14 @@ public class EduReportService {
     public Long createPsmEduReport(
             PsmEduReportCreateRequestDto requestDto, List<MultipartFile> files, Long id)
             throws IOException {
-        EduReportRequestDto baseRequest =
-                EduReportRequestDto.builder()
-                        .eduType(EduType.PSM)
-                        .title(requestDto.getTitle())
-                        .content(requestDto.getContent())
-                        .pinned(requestDto.isPinned())
-                        .signatureRequired(false)
-                        .categoryId(requestDto.getCategoryId())
-                        .build();
+        EduReportRequestDto baseRequest = EduReportRequestDto.builder()
+                .eduType(EduType.PSM)
+                .title(requestDto.getTitle())
+                .content(requestDto.getContent())
+                .pinned(requestDto.isPinned())
+                .signatureRequired(false)
+                .categoryId(requestDto.getCategoryId())
+                .build();
         Company companyOverride = resolveCompanyScopeOverride(requestDto.getCompanyScope());
         return createEduReportInternal(baseRequest, files, id, true, companyOverride);
     }
@@ -93,15 +92,14 @@ public class EduReportService {
     public Long createSafetyEduReport(
             SafetyEduReportCreateRequestDto requestDto, List<MultipartFile> files, Long id)
             throws IOException {
-        EduReportRequestDto baseRequest =
-                EduReportRequestDto.builder()
-                        .eduType(EduType.SAFETY)
-                        .title(requestDto.getTitle())
-                        .content(requestDto.getContent())
-                        .pinned(requestDto.isPinned())
-                        .signatureRequired(false)
-                        .categoryId(requestDto.getCategoryId())
-                        .build();
+        EduReportRequestDto baseRequest = EduReportRequestDto.builder()
+                .eduType(EduType.SAFETY)
+                .title(requestDto.getTitle())
+                .content(requestDto.getContent())
+                .pinned(requestDto.isPinned())
+                .signatureRequired(false)
+                .categoryId(requestDto.getCategoryId())
+                .build();
         Company companyOverride = resolveCompanyScopeOverride(requestDto.getCompanyScope());
         return createEduReportInternal(baseRequest, files, id, true, companyOverride);
     }
@@ -114,10 +112,9 @@ public class EduReportService {
             Company companyOverride)
             throws IOException {
 
-        User user =
-                userRepository
-                        .findById(id)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user = userRepository
+                .findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         validateCreateAuthority(user, requestDto.getEduType());
 
@@ -126,10 +123,9 @@ public class EduReportService {
             if (requestDto.getDepartmentId() == null) {
                 throw new CustomException(ErrorCode.DEPARTMENT_ID_REQUIRED);
             }
-            department =
-                    departmentRepository
-                            .findById(requestDto.getDepartmentId())
-                            .orElseThrow(() -> new CustomException(ErrorCode.DEPARTMENT_NOT_FOUND));
+            department = departmentRepository
+                    .findById(requestDto.getDepartmentId())
+                    .orElseThrow(() -> new CustomException(ErrorCode.DEPARTMENT_NOT_FOUND));
         }
 
         EducationCategory category = null;
@@ -181,14 +177,13 @@ public class EduReportService {
         } else {
             targetUserIds = userRepository.findAllIdsByDepartmentId(requestDto.getDepartmentId());
         }
-        Map<String, Object> metadata =
-                requestDto.getEduType() == EduType.SAFETY
-                        ? Map.of(
-                                "educationType",
-                                requestDto.getEduType().name(),
-                                "detailType",
-                                "GENERAL")
-                        : Map.of("educationType", requestDto.getEduType().name());
+        Map<String, Object> metadata = requestDto.getEduType() == EduType.SAFETY
+                ? Map.of(
+                        "educationType",
+                        requestDto.getEduType().name(),
+                        "detailType",
+                        "GENERAL")
+                : Map.of("educationType", requestDto.getEduType().name());
         notificationService.sendEduReportAlertToTargets(
                 requestDto.getEduType().getDescription(),
                 requestDto.getTitle(),
@@ -203,15 +198,14 @@ public class EduReportService {
     public Long createDepartmentEduReport(
             DepartmentEduReportCreateRequestDto requestDto, List<MultipartFile> files, Long id)
             throws IOException {
-        EduReportRequestDto baseRequest =
-                EduReportRequestDto.builder()
-                        .eduType(EduType.DEPARTMENT)
-                        .title(requestDto.getTitle())
-                        .content(requestDto.getContent())
-                        .pinned(requestDto.isPinned())
-                        .signatureRequired(requestDto.isSignatureRequired())
-                        .departmentId(requestDto.getDepartmentId())
-                        .build();
+        EduReportRequestDto baseRequest = EduReportRequestDto.builder()
+                .eduType(EduType.DEPARTMENT)
+                .title(requestDto.getTitle())
+                .content(requestDto.getContent())
+                .pinned(requestDto.isPinned())
+                .signatureRequired(requestDto.isSignatureRequired())
+                .departmentId(requestDto.getDepartmentId())
+                .build();
         return createEduReport(baseRequest, files, id);
     }
 
@@ -239,10 +233,9 @@ public class EduReportService {
     public List<EduReportSummaryDto> getEduReports(
             EduType type, DepartmentName departmentName, Long categoryId, Long id, String title) {
 
-        User user =
-                userRepository
-                        .findById(id)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user = userRepository
+                .findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         boolean hasAccess = user.hasAuthority(Authority.MANAGE_DEPARTMENT_EDUCATION);
         boolean canReadAllPsmCompanies = user.hasAuthority(Authority.MANAGE_PSM);
@@ -251,30 +244,27 @@ public class EduReportService {
         Department dept;
         if (hasAccess) {
             // 권한 있음: departmentName이 지정되면 해당 부서, 없으면 null(전체 조회)
-            dept =
-                    (departmentName != null)
-                            ? departmentRepository
-                                    .findByName(departmentName)
-                                    .orElseThrow(
-                                            () ->
-                                                    new CustomException(
-                                                            ErrorCode.DEPARTMENT_NOT_FOUND))
-                            : null;
+            dept = (departmentName != null)
+                    ? departmentRepository
+                            .findByName(departmentName)
+                            .orElseThrow(
+                                    () -> new CustomException(
+                                            ErrorCode.DEPARTMENT_NOT_FOUND))
+                    : null;
         } else {
             // 권한 없음: 자신의 부서로 제한
             dept = user.getDepartment();
         }
 
-        List<EduReportSummaryDto> summaries =
-                eduReportQueryRepository.findEduReports(
-                        type,
-                        dept,
-                        categoryId,
-                        id,
-                        hasAccess,
-                        psmCompanyFilter,
-                        canReadAllPsmCompanies,
-                        title);
+        List<EduReportSummaryDto> summaries = eduReportQueryRepository.findEduReports(
+                type,
+                dept,
+                categoryId,
+                id,
+                hasAccess,
+                psmCompanyFilter,
+                canReadAllPsmCompanies,
+                title);
 
         summaries.forEach(
                 summary -> {
@@ -292,32 +282,28 @@ public class EduReportService {
 
     @Transactional(readOnly = true)
     public List<EduReportSummaryDto> getPsmEduReports(Long categoryId, Long id, String title) {
-        User user =
-                userRepository
-                        .findById(id)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user = userRepository
+                .findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         boolean canReadAllCompanies = user.hasAuthority(Authority.MANAGE_PSM);
         Company companyFilter = canReadAllCompanies ? null : user.getWorkLocation();
-        List<EduReportSummaryDto> summaries =
-                eduReportQueryRepository.findPsmEduReports(
-                        categoryId, id, companyFilter, canReadAllCompanies, title);
+        List<EduReportSummaryDto> summaries = eduReportQueryRepository.findPsmEduReports(
+                categoryId, id, companyFilter, canReadAllCompanies, title);
         summaries.forEach(this::applyCompanyScopeToSummary);
         return summaries;
     }
 
     @Transactional(readOnly = true)
     public List<EduReportSummaryDto> getSafetyEduReports(Long categoryId, Long id, String title) {
-        User user =
-                userRepository
-                        .findById(id)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user = userRepository
+                .findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         boolean canReadAllCompanies = user.hasAuthority(Authority.MANAGE_SAFETY);
         Company companyFilter = canReadAllCompanies ? null : user.getWorkLocation();
-        List<EduReportSummaryDto> summaries =
-                eduReportQueryRepository.findSafetyEduReports(
-                        categoryId, id, companyFilter, canReadAllCompanies, title);
+        List<EduReportSummaryDto> summaries = eduReportQueryRepository.findSafetyEduReports(
+                categoryId, id, companyFilter, canReadAllCompanies, title);
         summaries.forEach(this::applyCompanyScopeToSummary);
         return summaries;
     }
@@ -325,15 +311,13 @@ public class EduReportService {
     @Transactional(readOnly = true)
     public EduReportDetailDto getEduReport(Long eduReportId, Long id) {
 
-        User user =
-                userRepository
-                        .findById(id)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user = userRepository
+                .findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        EduReport report =
-                eduReportRepository
-                        .findById(eduReportId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+        EduReport report = eduReportRepository
+                .findById(eduReportId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
 
         boolean hasAccess = user.hasAuthority(Authority.MANAGE_DEPARTMENT_EDUCATION);
         return buildEduReportDetailDto(user, report, hasAccess, false);
@@ -341,15 +325,13 @@ public class EduReportService {
 
     @Transactional(readOnly = true)
     public EduReportDetailDto getDepartmentEduReport(Long eduReportId, Long id) {
-        User user =
-                userRepository
-                        .findById(id)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user = userRepository
+                .findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        EduReport report =
-                eduReportRepository
-                        .findById(eduReportId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+        EduReport report = eduReportRepository
+                .findById(eduReportId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
 
         if (report.getEduType() != EduType.DEPARTMENT) {
             throw new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND);
@@ -376,15 +358,13 @@ public class EduReportService {
 
     @Transactional(readOnly = true)
     public EduReportDetailDto getPsmEduReport(Long eduReportId, Long id) {
-        User user =
-                userRepository
-                        .findById(id)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user = userRepository
+                .findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        EduReport report =
-                eduReportRepository
-                        .findById(eduReportId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+        EduReport report = eduReportRepository
+                .findById(eduReportId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
 
         if (report.getEduType() != EduType.PSM) {
             throw new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND);
@@ -424,15 +404,13 @@ public class EduReportService {
 
     @Transactional(readOnly = true)
     public EduReportDetailDto getSafetyEduReport(Long eduReportId, Long id) {
-        User user =
-                userRepository
-                        .findById(id)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user = userRepository
+                .findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        EduReport report =
-                eduReportRepository
-                        .findById(eduReportId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+        EduReport report = eduReportRepository
+                .findById(eduReportId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
 
         if (report.getEduType() != EduType.SAFETY) {
             throw new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND);
@@ -481,8 +459,7 @@ public class EduReportService {
             numberOfPeople = calculateTargetPeopleCount(report);
         }
 
-        EduReportDetailDto dto =
-                eduMapper.toDetailDto(report, attendances, numberOfPeople, s3Service);
+        EduReportDetailDto dto = eduMapper.toDetailDto(report, attendances, numberOfPeople, s3Service);
 
         if (includeSignatureCounts) {
             long targetCount = calculateTargetPeopleCount(report);
@@ -510,9 +487,8 @@ public class EduReportService {
             return;
         }
 
-        Boolean mySigned =
-                resolveDepartmentMySigned(
-                        user, summary.getDepartmentName(), summary.isAttendance());
+        Boolean mySigned = resolveDepartmentMySigned(
+                user, summary.getDepartmentName(), summary.isAttendance());
         summary.setMySigned(mySigned);
         summary.setMyCompletionStatus(
                 resolveDepartmentMyCompletionStatus(summary.isSignatureRequired(), mySigned));
@@ -599,34 +575,30 @@ public class EduReportService {
     @Transactional
     public void deleteEduReport(Long eduReportId, Long id) {
 
-        User user =
-                userRepository
-                        .findById(id)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user = userRepository
+                .findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         if (!user.hasAuthority(Authority.MANAGE_DEPARTMENT_EDUCATION)) {
             throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_EDU_REPORT);
         }
 
-        EduReport report =
-                eduReportRepository
-                        .findById(eduReportId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+        EduReport report = eduReportRepository
+                .findById(eduReportId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
 
         performDeleteEduReport(report);
     }
 
     private void deleteEduReportByType(Long eduReportId, Long userId, EduType expectedType) {
-        User user =
-                userRepository
-                        .findById(userId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user = userRepository
+                .findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         validateCreateAuthority(user, expectedType);
 
-        EduReport report =
-                eduReportRepository
-                        .findById(eduReportId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+        EduReport report = eduReportRepository
+                .findById(eduReportId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
         validateExpectedType(report, expectedType);
 
         performDeleteEduReport(report);
@@ -642,15 +614,15 @@ public class EduReportService {
         eduReportRepository.delete(report);
     }
 
-    public record FileDownloadDto(byte[] fileData, String originalFileName, long fileSize) {}
+    public record FileDownloadDto(byte[] fileData, String originalFileName, long fileSize) {
+    }
 
     @Transactional(readOnly = true)
     public FileDownloadDto getFileForDownload(Long attachmentId) {
         // DB 조회
-        EduAttachment attachment =
-                eduAttachmentRepository
-                        .findById(attachmentId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_ATTACHMENT_NOT_FOUND));
+        EduAttachment attachment = eduAttachmentRepository
+                .findById(attachmentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EDU_ATTACHMENT_NOT_FOUND));
 
         // S3 데이터 다운로드
         byte[] fileData = s3Service.downloadFile(attachment.getS3Key());
@@ -672,15 +644,13 @@ public class EduReportService {
     public void markAttendance(Long reportId, MultipartFile signatureFile, Long userId)
             throws IOException {
 
-        User user =
-                userRepository
-                        .findById(userId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user = userRepository
+                .findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        EduReport report =
-                eduReportRepository
-                        .findById(reportId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+        EduReport report = eduReportRepository
+                .findById(reportId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
 
         markAttendanceInternal(user, report, signatureFile, report.isSignatureRequired());
     }
@@ -694,19 +664,16 @@ public class EduReportService {
     private void markAttendanceByType(
             Long reportId, MultipartFile signatureFile, Long userId, EduType expectedType)
             throws IOException {
-        User user =
-                userRepository
-                        .findById(userId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user = userRepository
+                .findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        EduReport report =
-                eduReportRepository
-                        .findById(reportId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+        EduReport report = eduReportRepository
+                .findById(reportId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
         validateExpectedType(report, expectedType);
 
-        boolean requireSignature =
-                expectedType == EduType.DEPARTMENT && report.isSignatureRequired();
+        boolean requireSignature = expectedType == EduType.DEPARTMENT && report.isSignatureRequired();
         markAttendanceInternal(user, report, signatureFile, requireSignature);
     }
 
@@ -804,15 +771,13 @@ public class EduReportService {
             EduReportUpdateRequestDto requestDto,
             List<MultipartFile> files,
             Long userId) {
-        User user =
-                userRepository
-                        .findById(userId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user = userRepository
+                .findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        EduReport report =
-                eduReportRepository
-                        .findById(eduReportId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+        EduReport report = eduReportRepository
+                .findById(eduReportId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
         validateCreateAuthority(user, report.getEduType());
         return updateEduReportInternal(eduReportId, report, requestDto, files);
     }
@@ -823,16 +788,14 @@ public class EduReportService {
             List<MultipartFile> files,
             Long userId,
             EduType expectedType) {
-        User user =
-                userRepository
-                        .findById(userId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user = userRepository
+                .findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         validateCreateAuthority(user, expectedType);
 
-        EduReport report =
-                eduReportRepository
-                        .findById(eduReportId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+        EduReport report = eduReportRepository
+                .findById(eduReportId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
         validateExpectedType(report, expectedType);
 
         return updateEduReportInternal(eduReportId, report, requestDto, files);
@@ -861,26 +824,23 @@ public class EduReportService {
                 if (requestDto.getDepartmentId() == null) {
                     throw new CustomException(ErrorCode.DEPARTMENT_ID_REQUIRED);
                 }
-                Department department =
-                        departmentRepository
-                                .findById(requestDto.getDepartmentId())
-                                .orElseThrow(
-                                        () -> new CustomException(ErrorCode.DEPARTMENT_NOT_FOUND));
+                Department department = departmentRepository
+                        .findById(requestDto.getDepartmentId())
+                        .orElseThrow(
+                                () -> new CustomException(ErrorCode.DEPARTMENT_NOT_FOUND));
                 report.setDepartment(department);
                 report.setCategory(null);
                 report.setCompany(null);
             } else {
                 if (requestDto.getCategoryId() != null) {
-                    EducationCategory category =
-                            getValidatedCategory(report.getEduType(), requestDto.getCategoryId());
+                    EducationCategory category = getValidatedCategory(report.getEduType(), requestDto.getCategoryId());
                     report.setCategory(category);
                 } else if (report.getCategory() == null) {
                     throw new CustomException(ErrorCode.EDUCATION_CATEGORY_REQUIRED);
                 }
                 report.setDepartment(null);
                 if (requestDto.getCompanyScope() != null) {
-                    Company companyOverride =
-                            resolveCompanyScopeOverride(requestDto.getCompanyScope());
+                    Company companyOverride = resolveCompanyScopeOverride(requestDto.getCompanyScope());
                     report.setCompany(companyOverride);
                 }
             }
@@ -898,15 +858,13 @@ public class EduReportService {
     @Transactional
     public Long updateEduReportStatus(
             Long eduReportId, EduReportStatusUpdateRequestDto requestDto, Long userId) {
-        User user =
-                userRepository
-                        .findById(userId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user = userRepository
+                .findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        EduReport report =
-                eduReportRepository
-                        .findById(eduReportId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+        EduReport report = eduReportRepository
+                .findById(eduReportId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
         validateCreateAuthority(user, report.getEduType());
         return updateEduReportStatusInternal(report, requestDto);
     }
@@ -934,16 +892,14 @@ public class EduReportService {
             EduReportStatusUpdateRequestDto requestDto,
             Long userId,
             EduType expectedType) {
-        User user =
-                userRepository
-                        .findById(userId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user = userRepository
+                .findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         validateCreateAuthority(user, expectedType);
 
-        EduReport report =
-                eduReportRepository
-                        .findById(eduReportId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+        EduReport report = eduReportRepository
+                .findById(eduReportId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
         validateExpectedType(report, expectedType);
 
         return updateEduReportStatusInternal(report, requestDto);
@@ -983,7 +939,8 @@ public class EduReportService {
             return false;
         }
 
-        // Swagger UI generated curl can send placeholder part: files=string -> filename "blob"
+        // Swagger UI generated curl can send placeholder part: files=string -> filename
+        // "blob"
         if ("blob".equalsIgnoreCase(originalFileName) && file.getSize() <= 32) {
             try {
                 String payload = new String(file.getBytes(), StandardCharsets.UTF_8).trim();
@@ -1016,11 +973,10 @@ public class EduReportService {
         }
 
         for (Long attachmentId : new LinkedHashSet<>(deleteAttachmentIds)) {
-            EduAttachment attachment =
-                    eduAttachmentRepository
-                            .findById(attachmentId)
-                            .orElseThrow(
-                                    () -> new CustomException(ErrorCode.EDU_ATTACHMENT_NOT_FOUND));
+            EduAttachment attachment = eduAttachmentRepository
+                    .findById(attachmentId)
+                    .orElseThrow(
+                            () -> new CustomException(ErrorCode.EDU_ATTACHMENT_NOT_FOUND));
 
             if (attachment.getEduReport() == null
                     || !attachment.getEduReport().getId().equals(report.getId())) {
@@ -1066,14 +1022,13 @@ public class EduReportService {
             return null;
         }
 
-        EducationCategory category =
-                educationCategoryRepository
-                        .findById(categoryId)
-                        .orElseThrow(
-                                () -> new CustomException(ErrorCode.EDUCATION_CATEGORY_NOT_FOUND));
+        EducationCategory category = educationCategoryRepository
+                .findById(categoryId)
+                .orElseThrow(
+                        () -> new CustomException(ErrorCode.EDUCATION_CATEGORY_NOT_FOUND));
 
-        EducationCategoryType expectedType =
-                eduType == EduType.PSM ? EducationCategoryType.PSM : EducationCategoryType.SAFETY;
+        EducationCategoryType expectedType = eduType == EduType.PSM ? EducationCategoryType.PSM
+                : EducationCategoryType.SAFETY;
         if (category.getCategoryType() != expectedType) {
             throw new CustomException(ErrorCode.INVALID_ARGUMENT);
         }
@@ -1084,15 +1039,13 @@ public class EduReportService {
     public List<EduReportSignatureStatusDto> getSignatureStatuses(
             Long educationId, String name, Long userId) {
 
-        User user =
-                userRepository
-                        .findById(userId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user = userRepository
+                .findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        EduReport report =
-                eduReportRepository
-                        .findById(educationId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+        EduReport report = eduReportRepository
+                .findById(educationId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
 
         // 부서 교육 서명 현황 조회 API는 부서 교육 게시물에 대해서만 허용한다.
         if (report.getEduType() != EduType.DEPARTMENT) {
@@ -1108,10 +1061,8 @@ public class EduReportService {
 
     private EduReportSignatureStatusDto toSignatureStatusDto(
             EduReportQueryRepository.SignatureStatusRow row) {
-        String displayName =
-                (row.nameKor() != null && !row.nameKor().isBlank()) ? row.nameKor() : row.nameEng();
-        String deptName =
-                row.departmentName() != null ? row.departmentName().getDescription() : null;
+        String displayName = (row.nameKor() != null && !row.nameKor().isBlank()) ? row.nameKor() : row.nameEng();
+        String deptName = row.departmentName() != null ? row.departmentName().getDescription() : null;
         String positionStr = row.position() != null ? row.position().getDescription() : null;
         boolean isSigned = row.signatureKey() != null;
         String signatureUrl = isSigned ? s3Service.getPresignedViewUrl(row.signatureKey()) : null;
@@ -1158,6 +1109,45 @@ public class EduReportService {
             return List.of(Company.AWESOME.name(), Company.MARUI.name());
         }
         return List.of(storedCompany.name());
+    }
+
+    @Transactional
+    public void remindEduReport(Long eduReportId, Long userId) {
+        userRepository
+                .findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        EduReport report = eduReportRepository
+                .findById(eduReportId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND));
+
+        if (report.getCreatedBy() == null || !report.getCreatedBy().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_EDU_REPORT);
+        }
+
+        List<Long> targetUserIds;
+        if (report.getEduType() == EduType.PSM || report.getEduType() == EduType.SAFETY) {
+            if (report.getCompany() == null) {
+                targetUserIds = userRepository.findAllActiveUserIds();
+            } else {
+                targetUserIds = userRepository.findAllIdsByCompany(report.getCompany());
+            }
+        } else {
+            targetUserIds = report.getDepartment() != null
+                    ? userRepository.findAllIdsByDepartmentId(report.getDepartment().getId())
+                    : List.of();
+        }
+
+        Map<String, Object> metadata = report.getEduType() == EduType.SAFETY
+                ? Map.of("educationType", "SAFETY", "detailType", "GENERAL")
+                : Map.of("educationType", report.getEduType().name());
+
+        notificationService.sendEduReportRemindAlertToTargets(
+                report.getEduType().getDescription(),
+                report.getTitle(),
+                eduReportId,
+                targetUserIds,
+                metadata);
     }
 
     private Integer safeToInteger(long value) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/service/NotificationService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/service/NotificationService.java
@@ -34,769 +34,775 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class NotificationService {
 
-        private final NotificationRepository notificationRepository;
-        private final ApplicationEventPublisher eventPublisher;
-        private final UserRepository userRepository;
-        private final ObjectMapper objectMapper = new ObjectMapper();
+    private final NotificationRepository notificationRepository;
+    private final ApplicationEventPublisher eventPublisher;
+    private final UserRepository userRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
-        @Transactional
-        public void createNotification(
-                        Long userId,
-                        String title,
-                        String content,
-                        NotificationDomainType domainType,
-                        Long domainId) {
-                createNotification(userId, title, content, domainType, domainId, null);
+    @Transactional
+    public void createNotification(
+            Long userId,
+            String title,
+            String content,
+            NotificationDomainType domainType,
+            Long domainId) {
+        createNotification(userId, title, content, domainType, domainId, null);
+    }
+
+    @Transactional
+    public void createNotification(
+            Long userId,
+            String title,
+            String content,
+            NotificationDomainType domainType,
+            Long domainId,
+            Map<String, Object> metadata) {
+        createNotification(userId, title, content, domainType, domainId, metadata, false);
+    }
+
+    @Transactional
+    public void createNotification(
+            Long userId,
+            String title,
+            String content,
+            NotificationDomainType domainType,
+            Long domainId,
+            Map<String, Object> metadata,
+            boolean requiresApproval) {
+        Notification notification =
+                Notification.of(
+                        userId, title, content, domainType, domainId, metadata, requiresApproval);
+        notificationRepository.save(notification);
+        log.info("알림 생성 - userId: {}, domainType: {}", userId, domainType);
+    }
+
+    private void doCreateNotification(
+            Long userId,
+            String title,
+            String content,
+            NotificationMessage messageType,
+            NotificationDomainType domainType,
+            Long domainId,
+            Map<String, Object> metadata,
+            boolean requiresApproval) {
+        Notification notification =
+                Notification.of(
+                        userId,
+                        title,
+                        content,
+                        domainType,
+                        domainId,
+                        metadata,
+                        requiresApproval,
+                        messageType);
+        notificationRepository.save(notification);
+        log.info("알림 생성 - userId: {}, domainType: {}", userId, domainType);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<NotificationResponseDto> getNotifications(
+            Long userId, boolean pendingApproval, Pageable pageable) {
+        Page<Notification> page =
+                pendingApproval
+                        ? notificationRepository
+                                .findByUserIdAndRequiresApprovalTrueOrderByCreatedAtDesc(
+                                        userId, pageable)
+                        : notificationRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable);
+        return page.map(NotificationResponseDto::from);
+    }
+
+    @Transactional
+    public void resolveRequiresApproval(NotificationDomainType domainType, Long domainId) {
+        notificationRepository.resolveRequiresApprovalByDomainTypeAndDomainId(domainType, domainId);
+        log.info("requiresApproval 해제 - domainType: {}, domainId: {}", domainType, domainId);
+    }
+
+    @Transactional
+    public void markAsRead(Long notificationId, Long userId) {
+        Notification notification =
+                notificationRepository
+                        .findById(notificationId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+        if (!notification.getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_NOTIFICATION);
         }
 
-        @Transactional
-        public void createNotification(
-                        Long userId,
-                        String title,
-                        String content,
-                        NotificationDomainType domainType,
-                        Long domainId,
-                        Map<String, Object> metadata) {
-                createNotification(userId, title, content, domainType, domainId, metadata, false);
+        notification.markAsRead();
+    }
+
+    @Transactional(readOnly = true)
+    public long getUnreadCount(Long userId) {
+        return notificationRepository.countByUserIdAndIsReadFalse(userId);
+    }
+
+    /**
+     * Admin/MasterAdmin 유저 전체에게 FCM 알림 전송 + Notification 저장
+     *
+     * @param template 알림 메시지 템플릿
+     * @param domainType 생성할 알림의 도메인 타입
+     * @param domainId 생성할 알림의 도메인 ID (선택)
+     * @param args 템플릿 포맷팅에 사용할 인자
+     */
+    @Transactional
+    public void sendAlertToAdmins(
+            NotificationMessage template,
+            NotificationDomainType domainType,
+            Long domainId,
+            Object... args) {
+        sendAlertToAdmins(template, domainType, domainId, null, args);
+    }
+
+    @Transactional
+    public void sendAlertToAdmins(
+            NotificationMessage template,
+            NotificationDomainType domainType,
+            Long domainId,
+            Map<String, Object> metadata,
+            Object... args) {
+        sendAlertToAdminsInternal(template, domainType, domainId, metadata, false, args);
+    }
+
+    @Transactional
+    public void sendAlertToAdminsRequiringApproval(
+            NotificationMessage template,
+            NotificationDomainType domainType,
+            Long domainId,
+            Map<String, Object> metadata,
+            Object... args) {
+        sendAlertToAdminsInternal(template, domainType, domainId, metadata, true, args);
+    }
+
+    private void sendAlertToAdminsInternal(
+            NotificationMessage template,
+            NotificationDomainType domainType,
+            Long domainId,
+            Map<String, Object> metadata,
+            boolean requiresApproval,
+            Object... args) {
+        String title = template.getTitle();
+        String content = template.formatContent(args);
+
+        List<User> admins = userRepository.findAllByRole(Role.ADMIN);
+        admins.addAll(userRepository.findAllByRole(Role.MASTER_ADMIN));
+
+        for (User admin : admins) {
+            // 1. 알림함 저장
+            doCreateNotification(
+                    admin.getId(),
+                    title,
+                    content,
+                    template,
+                    domainType,
+                    domainId,
+                    metadata,
+                    requiresApproval);
+
+            // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
+            eventPublisher.publishEvent(
+                    new FcmSendEvent(
+                            admin.getId(),
+                            title,
+                            content,
+                            buildFcmData(domainType, domainId, metadata)));
         }
 
-        @Transactional
-        public void createNotification(
-                        Long userId,
-                        String title,
-                        String content,
-                        NotificationDomainType domainType,
-                        Long domainId,
-                        Map<String, Object> metadata,
-                        boolean requiresApproval) {
-                Notification notification = Notification.of(
-                                userId, title, content, domainType, domainId, metadata, requiresApproval);
-                notificationRepository.save(notification);
-                log.info("알림 생성 - userId: {}, domainType: {}", userId, domainType);
+        log.info("관리자 그룹 알림 전송 완료 - 대상 Admin 수: {}, 템플릿: {}", admins.size(), template.name());
+    }
+
+    /**
+     * 특정 단일 유저에게 FCM 알림 전송 + Notification 저장
+     *
+     * @param userId 수신 유저 ID
+     * @param template 알림 메시지 템플릿
+     * @param domainType 생성할 알림의 도메인 타입
+     * @param domainId 생성할 알림의 도메인 ID
+     * @param args 템플릿 포맷팅에 사용할 인자
+     */
+    @Transactional
+    public void sendAlertToUser(
+            Long userId,
+            NotificationMessage template,
+            NotificationDomainType domainType,
+            Long domainId,
+            Object... args) {
+        sendAlertToUser(userId, template, domainType, domainId, null, args);
+    }
+
+    @Transactional
+    public void sendAlertToUser(
+            Long userId,
+            NotificationMessage template,
+            NotificationDomainType domainType,
+            Long domainId,
+            Map<String, Object> metadata,
+            Object... args) {
+        String title = template.getTitle();
+        String content = template.formatContent(args);
+
+        // 1. 알림함 저장
+        doCreateNotification(
+                userId, title, content, template, domainType, domainId, metadata, false);
+
+        // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
+        eventPublisher.publishEvent(
+                new FcmSendEvent(
+                        userId, title, content, buildFcmData(domainType, domainId, metadata)));
+
+        log.info("단일 유저 알림 전송 완료 - userId: {}, 템플릿: {}", userId, template.name());
+    }
+
+    /**
+     * 공지사항 등록 시 대상 유저 전체에게 FCM 알림 전송 + Notification 저장
+     *
+     * @param noticeTitle 등록된 공지사항 제목
+     * @param noticeId 등록된 공지사항 ID (알림 domainId로 저장)
+     * @param targetUserIds 알림을 받을 유저 ID 집합
+     */
+    @Transactional
+    public void sendNoticeAlertToTargets(
+            String noticeTitle, Long noticeId, Set<Long> targetUserIds) {
+        if (targetUserIds == null || targetUserIds.isEmpty()) {
+            log.info("공지 알림 전송 건너뜀 - 대상 없음, noticeId: {}", noticeId);
+            return;
         }
 
-        private void doCreateNotification(
-                        Long userId,
-                        String title,
-                        String content,
-                        NotificationMessage messageType,
-                        NotificationDomainType domainType,
-                        Long domainId,
-                        Map<String, Object> metadata,
-                        boolean requiresApproval) {
-                Notification notification = Notification.of(
-                                userId,
-                                title,
-                                content,
-                                domainType,
-                                domainId,
-                                metadata,
-                                requiresApproval,
-                                messageType);
-                notificationRepository.save(notification);
-                log.info("알림 생성 - userId: {}, domainType: {}", userId, domainType);
+        String title = NotificationMessage.NOTICE_CREATED.getTitle();
+        String content = NotificationMessage.NOTICE_CREATED.formatContent(noticeTitle);
+
+        for (Long userId : targetUserIds) {
+            // 1. 알림함 저장
+            doCreateNotification(
+                    userId,
+                    title,
+                    content,
+                    NotificationMessage.NOTICE_CREATED,
+                    NotificationDomainType.NOTICE,
+                    noticeId,
+                    null,
+                    false);
+
+            // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
+            eventPublisher.publishEvent(
+                    new FcmSendEvent(
+                            userId,
+                            title,
+                            content,
+                            buildFcmData(NotificationDomainType.NOTICE, noticeId)));
         }
 
-        @Transactional(readOnly = true)
-        public Page<NotificationResponseDto> getNotifications(
-                        Long userId, boolean pendingApproval, Pageable pageable) {
-                Page<Notification> page = pendingApproval
-                                ? notificationRepository
-                                                .findByUserIdAndRequiresApprovalTrueOrderByCreatedAtDesc(
-                                                                userId, pageable)
-                                : notificationRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable);
-                return page.map(NotificationResponseDto::from);
+        log.info("공지 알림 전송 완료 - noticeId: {}, 대상 수: {}", noticeId, targetUserIds.size());
+    }
+
+    /**
+     * 교육(EduReport) 등록 시 대상 유저 전체에게 FCM 알림 전송 + Notification 저장
+     *
+     * @param eduTypeLabel 교육 유형 라벨 (예: SAFETY, PSM, 부서명 등)
+     * @param eduTitle 등록된 교육 제목
+     * @param reportId 등록된 교육 ID (알림 domainId로 저장)
+     * @param targetUserIds 알림을 받을 유저 ID 집합 (리스트 형태)
+     */
+    @Transactional
+    public void sendEduReportAlertToTargets(
+            String eduTypeLabel, String eduTitle, Long reportId, List<Long> targetUserIds) {
+        sendEduReportAlertToTargets(eduTypeLabel, eduTitle, reportId, targetUserIds, null);
+    }
+
+    @Transactional
+    public void sendEduReportAlertToTargets(
+            String eduTypeLabel,
+            String eduTitle,
+            Long reportId,
+            List<Long> targetUserIds,
+            Map<String, Object> metadata) {
+        if (targetUserIds == null || targetUserIds.isEmpty()) {
+            log.info("교육 알림 전송 건너뜀 - 대상 없음, reportId: {}", reportId);
+            return;
         }
 
-        @Transactional
-        public void resolveRequiresApproval(NotificationDomainType domainType, Long domainId) {
-                notificationRepository.resolveRequiresApprovalByDomainTypeAndDomainId(domainType, domainId);
-                log.info("requiresApproval 해제 - domainType: {}, domainId: {}", domainType, domainId);
+        String title = NotificationMessage.EDU_REPORT_CREATED.getTitle();
+        String content =
+                NotificationMessage.EDU_REPORT_CREATED.formatContent(eduTypeLabel, eduTitle);
+
+        for (Long userId : targetUserIds) {
+            // 1. 알림함 저장
+            doCreateNotification(
+                    userId,
+                    title,
+                    content,
+                    NotificationMessage.EDU_REPORT_CREATED,
+                    NotificationDomainType.EDUCATION,
+                    reportId,
+                    metadata,
+                    false);
+
+            // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
+            eventPublisher.publishEvent(
+                    new FcmSendEvent(
+                            userId,
+                            title,
+                            content,
+                            buildFcmData(NotificationDomainType.EDUCATION, reportId, metadata)));
         }
 
-        @Transactional
-        public void markAsRead(Long notificationId, Long userId) {
-                Notification notification = notificationRepository
-                                .findById(notificationId)
-                                .orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_NOT_FOUND));
+        log.info("교육 알림 전송 완료 - reportId: {}, 대상 수: {}", reportId, targetUserIds.size());
+    }
 
-                if (!notification.getUserId().equals(userId)) {
-                        throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_NOTIFICATION);
-                }
+    /**
+     * 방문 이벤트(사전 예약/입실) 발생 시 host 담당 부서 소속 전원에게 FCM 알림 전송 + Notification 저장
+     *
+     * @param template 알림 메시지 템플릿
+     * @param visitId 방문 ID (domainId로 저장)
+     * @param hostDepartmentId host 직원의 부서 ID
+     * @param contentArgs 템플릿 포맷팅에 사용할 인자
+     */
+    @Transactional
+    public void sendVisitAlertToDepartment(
+            NotificationMessage template,
+            Long visitId,
+            Long hostDepartmentId,
+            Object... contentArgs) {
+        sendVisitAlertToDepartment(template, visitId, hostDepartmentId, null, contentArgs);
+    }
 
-                notification.markAsRead();
+    @Transactional
+    public void sendVisitAlertToDepartment(
+            NotificationMessage template,
+            Long visitId,
+            Long hostDepartmentId,
+            Map<String, Object> metadata,
+            Object... contentArgs) {
+        List<Long> targetUserIds = userRepository.findAllIdsByDepartmentId(hostDepartmentId);
+
+        if (targetUserIds.isEmpty()) {
+            log.info("방문 알림 전송 건너뜀 - 대상 없음, visitId: {}", visitId);
+            return;
         }
 
-        @Transactional(readOnly = true)
-        public long getUnreadCount(Long userId) {
-                return notificationRepository.countByUserIdAndIsReadFalse(userId);
+        String title = template.getTitle();
+        String content = template.formatContent(contentArgs);
+        boolean requiresApproval =
+                metadata != null && Boolean.TRUE.equals(metadata.get("isApprovalTarget"));
+
+        for (Long userId : targetUserIds) {
+            // 1. 알림함 저장
+            doCreateNotification(
+                    userId,
+                    title,
+                    content,
+                    template,
+                    NotificationDomainType.VISIT,
+                    visitId,
+                    metadata,
+                    requiresApproval);
+
+            // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
+            eventPublisher.publishEvent(
+                    new FcmSendEvent(
+                            userId,
+                            title,
+                            content,
+                            buildFcmData(NotificationDomainType.VISIT, visitId, metadata)));
         }
 
-        /**
-         * Admin/MasterAdmin 유저 전체에게 FCM 알림 전송 + Notification 저장
-         *
-         * @param template   알림 메시지 템플릿
-         * @param domainType 생성할 알림의 도메인 타입
-         * @param domainId   생성할 알림의 도메인 ID (선택)
-         * @param args       템플릿 포맷팅에 사용할 인자
-         */
-        @Transactional
-        public void sendAlertToAdmins(
-                        NotificationMessage template,
-                        NotificationDomainType domainType,
-                        Long domainId,
-                        Object... args) {
-                sendAlertToAdmins(template, domainType, domainId, null, args);
+        log.info(
+                "방문 알림 전송 완료 - visitId: {}, 대상 수: {}, 템플릿: {}",
+                visitId,
+                targetUserIds.size(),
+                template.name());
+    }
+
+    /**
+     * 연차 갱신/등록 시 단일 유저에게 알림 전송
+     *
+     * @param userId 알림 대상 유저 ID
+     * @param baseDateFormatted 포맷팅된 기준일 문자열 (예: "2025년 08월 01일")
+     */
+    @Transactional
+    public void sendAnnualLeaveAlertToUser(Long userId, String baseDateFormatted) {
+        NotificationMessage template = NotificationMessage.ANNUAL_LEAVE_UPDATED;
+        String title = template.getTitle();
+        String content = template.formatContent(baseDateFormatted);
+
+        // 1. 알림함 DB 저장 (domainId는 단일 엔티티 연차 특성상 null 처리)
+        doCreateNotification(
+                userId,
+                title,
+                content,
+                template,
+                NotificationDomainType.ANNUAL_LEAVE,
+                null,
+                null,
+                false);
+
+        // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
+        eventPublisher.publishEvent(
+                new FcmSendEvent(
+                        userId,
+                        title,
+                        content,
+                        buildFcmData(NotificationDomainType.ANNUAL_LEAVE, null)));
+
+        log.info("연차 알림 전송 완료 - userId: {}, 기준일: {}", userId, baseDateFormatted);
+    }
+
+    /**
+     * 급여명세서 발송 시 단일 유저에게 알림 전송
+     *
+     * @param userId 알림 대상 유저 ID
+     * @param payslipId 발송된 Payslip ID (domainId로 저장)
+     */
+    @Transactional
+    public void sendPayslipAlertToUser(Long userId, Long payslipId) {
+        NotificationMessage template = NotificationMessage.PAYSLIP_SENT;
+        String title = template.getTitle();
+        String content = template.formatContent();
+
+        // 1. 알림함 DB 저장
+        doCreateNotification(
+                userId,
+                title,
+                content,
+                template,
+                NotificationDomainType.PAYSLIP,
+                payslipId,
+                null,
+                false);
+
+        // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
+        eventPublisher.publishEvent(
+                new FcmSendEvent(
+                        userId,
+                        title,
+                        content,
+                        buildFcmData(NotificationDomainType.PAYSLIP, payslipId)));
+
+        log.info("급여명세서 알림 전송 완료 - userId: {}, payslipId: {}", userId, payslipId);
+    }
+
+    /**
+     * 전자결재 생성 시 첫 번째 결재자와 참조자(REFERRER)에게 알림 전송
+     *
+     * @param approvalId 결재 문서 ID
+     * @param docTitle 결재 문서 제목
+     * @param firstApproverId 첫 번째 결재자 유저 ID
+     * @param referrerIds 참조자(REFERRER) 유저 ID 목록
+     */
+    @Transactional
+    public void sendApprovalCreatedAlert(
+            Long approvalId, String docTitle, Long firstApproverId, List<Long> referrerIds) {
+
+        // 1. 첫 번째 결재자에게 알림
+        String approverTitle = NotificationMessage.APPROVAL_CREATED_APPROVER.getTitle();
+        String approverContent =
+                NotificationMessage.APPROVAL_CREATED_APPROVER.formatContent(docTitle);
+        doCreateNotification(
+                firstApproverId,
+                approverTitle,
+                approverContent,
+                NotificationMessage.APPROVAL_CREATED_APPROVER,
+                NotificationDomainType.APPROVAL,
+                approvalId,
+                null,
+                true);
+        eventPublisher.publishEvent(
+                new FcmSendEvent(
+                        firstApproverId,
+                        approverTitle,
+                        approverContent,
+                        buildFcmData(NotificationDomainType.APPROVAL, approvalId)));
+        log.info(
+                "전자결재 생성 알림(결재자) 전송 - approvalId: {}, approverId: {}", approvalId, firstApproverId);
+
+        // 2. 참조자들에게 알림
+        String referrerTitle = NotificationMessage.APPROVAL_CREATED_REFERRER.getTitle();
+        String referrerContent =
+                NotificationMessage.APPROVAL_CREATED_REFERRER.formatContent(docTitle);
+        for (Long referrerId : referrerIds) {
+            doCreateNotification(
+                    referrerId,
+                    referrerTitle,
+                    referrerContent,
+                    NotificationMessage.APPROVAL_CREATED_REFERRER,
+                    NotificationDomainType.APPROVAL,
+                    approvalId,
+                    null,
+                    false);
+            eventPublisher.publishEvent(
+                    new FcmSendEvent(
+                            referrerId,
+                            referrerTitle,
+                            referrerContent,
+                            buildFcmData(NotificationDomainType.APPROVAL, approvalId)));
+        }
+        log.info("전자결재 생성 알림(참조자 {}명) 전송 완료 - approvalId: {}", referrerIds.size(), approvalId);
+    }
+
+    /**
+     * N번째 결재자가 승인 시 N+1번째 결재자에게 알림 전송
+     *
+     * @param nextApproverId 다음 결재자 유저 ID
+     * @param approvalId 결재 문서 ID
+     * @param docTitle 결재 문서 제목
+     */
+    @Transactional
+    public void sendApprovalNextStepAlert(Long nextApproverId, Long approvalId, String docTitle) {
+        String title = NotificationMessage.APPROVAL_CREATED_APPROVER.getTitle();
+        String content = NotificationMessage.APPROVAL_CREATED_APPROVER.formatContent(docTitle);
+
+        doCreateNotification(
+                nextApproverId,
+                title,
+                content,
+                NotificationMessage.APPROVAL_CREATED_APPROVER,
+                NotificationDomainType.APPROVAL,
+                approvalId,
+                null,
+                true);
+        eventPublisher.publishEvent(
+                new FcmSendEvent(
+                        nextApproverId,
+                        title,
+                        content,
+                        buildFcmData(NotificationDomainType.APPROVAL, approvalId)));
+
+        log.info(
+                "전자결재 다음 결재자 알림 전송 - approvalId: {}, nextApproverId: {}",
+                approvalId,
+                nextApproverId);
+    }
+
+    /**
+     * 전자결재 반려 시 기안자에게 사유와 함께 알림 전송
+     *
+     * @param drafterId 기안자 유저 ID
+     * @param approvalId 결재 문서 ID
+     * @param docTitle 결재 문서 제목
+     * @param comment 반려 사유
+     */
+    @Transactional
+    public void sendApprovalRejectedAlert(
+            Long drafterId, Long approvalId, String docTitle, String comment) {
+        String title = NotificationMessage.APPROVAL_REJECTED.getTitle();
+        String content = NotificationMessage.APPROVAL_REJECTED.formatContent(docTitle, comment);
+
+        doCreateNotification(
+                drafterId,
+                title,
+                content,
+                NotificationMessage.APPROVAL_REJECTED,
+                NotificationDomainType.APPROVAL,
+                approvalId,
+                null,
+                false);
+        eventPublisher.publishEvent(
+                new FcmSendEvent(
+                        drafterId,
+                        title,
+                        content,
+                        buildFcmData(NotificationDomainType.APPROVAL, approvalId)));
+
+        log.info("전자결재 반려 알림 전송 - approvalId: {}, drafterId: {}", approvalId, drafterId);
+    }
+
+    /**
+     * 전자결재 최종 승인 시 기안자와 열람권자(VIEWER)에게 알림 전송
+     *
+     * @param approvalId 결재 문서 ID
+     * @param docTitle 결재 문서 제목
+     * @param drafterId 기안자 유저 ID
+     * @param viewerIds 열람권자(VIEWER) 유저 ID 목록
+     */
+    @Transactional
+    public void sendApprovalFinallyApprovedAlert(
+            Long approvalId, String docTitle, Long drafterId, List<Long> viewerIds) {
+        String title = NotificationMessage.APPROVAL_FINALLY_APPROVED.getTitle();
+        String content = NotificationMessage.APPROVAL_FINALLY_APPROVED.formatContent(docTitle);
+
+        // 1. 기안자에게 알림
+        doCreateNotification(
+                drafterId,
+                title,
+                content,
+                NotificationMessage.APPROVAL_FINALLY_APPROVED,
+                NotificationDomainType.APPROVAL,
+                approvalId,
+                null,
+                false);
+        eventPublisher.publishEvent(
+                new FcmSendEvent(
+                        drafterId,
+                        title,
+                        content,
+                        buildFcmData(NotificationDomainType.APPROVAL, approvalId)));
+
+        // 2. 열람권자들에게 알림
+        for (Long viewerId : viewerIds) {
+            doCreateNotification(
+                    viewerId,
+                    title,
+                    content,
+                    NotificationMessage.APPROVAL_FINALLY_APPROVED,
+                    NotificationDomainType.APPROVAL,
+                    approvalId,
+                    null,
+                    false);
+            eventPublisher.publishEvent(
+                    new FcmSendEvent(
+                            viewerId,
+                            title,
+                            content,
+                            buildFcmData(NotificationDomainType.APPROVAL, approvalId)));
         }
 
-        @Transactional
-        public void sendAlertToAdmins(
-                        NotificationMessage template,
-                        NotificationDomainType domainType,
-                        Long domainId,
-                        Map<String, Object> metadata,
-                        Object... args) {
-                sendAlertToAdminsInternal(template, domainType, domainId, metadata, false, args);
+        log.info(
+                "전자결재 최종 승인 알림 전송 - approvalId: {}, drafterId: {}, viewers: {}명",
+                approvalId,
+                drafterId,
+                viewerIds.size());
+    }
+
+    /**
+     * 안전보건교육 세션 생성 시 대상 유저 전체에게 FCM 알림 전송 + Notification 저장
+     *
+     * @param sessionId 생성된 세션 ID (domainId로 저장)
+     * @param sessionTitle 세션 제목
+     * @param targetUserIds 알림을 받을 유저 ID 목록
+     */
+    @Transactional
+    public void sendSafetyTrainingSessionAlertToAttendees(
+            Long sessionId, String sessionTitle, List<Long> targetUserIds) {
+        if (targetUserIds == null || targetUserIds.isEmpty()) {
+            log.info("안전보건교육 알림 전송 건너뜀 - 대상 없음, sessionId: {}", sessionId);
+            return;
         }
 
-        @Transactional
-        public void sendAlertToAdminsRequiringApproval(
-                        NotificationMessage template,
-                        NotificationDomainType domainType,
-                        Long domainId,
-                        Map<String, Object> metadata,
-                        Object... args) {
-                sendAlertToAdminsInternal(template, domainType, domainId, metadata, true, args);
+        String title = NotificationMessage.SAFETY_TRAINING_SESSION_CREATED.getTitle();
+        String content =
+                NotificationMessage.SAFETY_TRAINING_SESSION_CREATED.formatContent(sessionTitle);
+        Map<String, Object> metadata = Map.of("educationType", "SAFETY", "detailType", "SESSION");
+
+        for (Long userId : targetUserIds) {
+            doCreateNotification(
+                    userId,
+                    title,
+                    content,
+                    NotificationMessage.SAFETY_TRAINING_SESSION_CREATED,
+                    NotificationDomainType.SAFETY_TRAINING,
+                    sessionId,
+                    metadata,
+                    false);
+            eventPublisher.publishEvent(
+                    new FcmSendEvent(
+                            userId,
+                            title,
+                            content,
+                            buildFcmData(
+                                    NotificationDomainType.SAFETY_TRAINING, sessionId, metadata)));
         }
 
-        private void sendAlertToAdminsInternal(
-                        NotificationMessage template,
-                        NotificationDomainType domainType,
-                        Long domainId,
-                        Map<String, Object> metadata,
-                        boolean requiresApproval,
-                        Object... args) {
-                String title = template.getTitle();
-                String content = template.formatContent(args);
+        log.info("안전보건교육 세션 알림 전송 완료 - sessionId: {}, 대상 수: {}", sessionId, targetUserIds.size());
+    }
 
-                List<User> admins = userRepository.findAllByRole(Role.ADMIN);
-                admins.addAll(userRepository.findAllByRole(Role.MASTER_ADMIN));
+    /** 교육(EduReport) 리마인드 알림 - 대상 유저 전체에게 FCM 알림 전송 + Notification 저장 */
+    @Transactional
+    public void sendEduReportRemindAlertToTargets(
+            String eduTypeLabel, String eduTitle, Long reportId, List<Long> targetUserIds) {
+        sendEduReportRemindAlertToTargets(eduTypeLabel, eduTitle, reportId, targetUserIds, null);
+    }
 
-                for (User admin : admins) {
-                        // 1. 알림함 저장
-                        doCreateNotification(
-                                        admin.getId(),
-                                        title,
-                                        content,
-                                        template,
-                                        domainType,
-                                        domainId,
-                                        metadata,
-                                        requiresApproval);
-
-                        // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
-                        eventPublisher.publishEvent(
-                                        new FcmSendEvent(
-                                                        admin.getId(),
-                                                        title,
-                                                        content,
-                                                        buildFcmData(domainType, domainId, metadata)));
-                }
-
-                log.info("관리자 그룹 알림 전송 완료 - 대상 Admin 수: {}, 템플릿: {}", admins.size(), template.name());
+    @Transactional
+    public void sendEduReportRemindAlertToTargets(
+            String eduTypeLabel,
+            String eduTitle,
+            Long reportId,
+            List<Long> targetUserIds,
+            Map<String, Object> metadata) {
+        if (targetUserIds == null || targetUserIds.isEmpty()) {
+            log.info("교육 리마인드 알림 전송 건너뜀 - 대상 없음, reportId: {}", reportId);
+            return;
         }
 
-        /**
-         * 특정 단일 유저에게 FCM 알림 전송 + Notification 저장
-         *
-         * @param userId     수신 유저 ID
-         * @param template   알림 메시지 템플릿
-         * @param domainType 생성할 알림의 도메인 타입
-         * @param domainId   생성할 알림의 도메인 ID
-         * @param args       템플릿 포맷팅에 사용할 인자
-         */
-        @Transactional
-        public void sendAlertToUser(
-                        Long userId,
-                        NotificationMessage template,
-                        NotificationDomainType domainType,
-                        Long domainId,
-                        Object... args) {
-                sendAlertToUser(userId, template, domainType, domainId, null, args);
+        String title = "[리마인드] " + NotificationMessage.EDU_REPORT_CREATED.getTitle();
+        String content =
+                NotificationMessage.EDU_REPORT_CREATED.formatContent(eduTypeLabel, eduTitle);
+
+        for (Long userId : targetUserIds) {
+            doCreateNotification(
+                    userId,
+                    title,
+                    content,
+                    NotificationMessage.EDU_REPORT_CREATED,
+                    NotificationDomainType.EDUCATION,
+                    reportId,
+                    metadata,
+                    false);
+            eventPublisher.publishEvent(
+                    new FcmSendEvent(
+                            userId,
+                            title,
+                            content,
+                            buildFcmData(NotificationDomainType.EDUCATION, reportId, metadata)));
         }
 
-        @Transactional
-        public void sendAlertToUser(
-                        Long userId,
-                        NotificationMessage template,
-                        NotificationDomainType domainType,
-                        Long domainId,
-                        Map<String, Object> metadata,
-                        Object... args) {
-                String title = template.getTitle();
-                String content = template.formatContent(args);
+        log.info("교육 리마인드 알림 전송 완료 - reportId: {}, 대상 수: {}", reportId, targetUserIds.size());
+    }
 
-                // 1. 알림함 저장
-                doCreateNotification(
-                                userId, title, content, template, domainType, domainId, metadata, false);
-
-                // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
-                eventPublisher.publishEvent(
-                                new FcmSendEvent(
-                                                userId, title, content, buildFcmData(domainType, domainId, metadata)));
-
-                log.info("단일 유저 알림 전송 완료 - userId: {}, 템플릿: {}", userId, template.name());
+    /** 안전보건교육 세션 리마인드 알림 - 대상 유저 전체에게 FCM 알림 전송 + Notification 저장 */
+    @Transactional
+    public void sendSafetyTrainingSessionRemindAlertToAttendees(
+            Long sessionId, String sessionTitle, List<Long> targetUserIds) {
+        if (targetUserIds == null || targetUserIds.isEmpty()) {
+            log.info("안전보건교육 리마인드 알림 전송 건너뜀 - 대상 없음, sessionId: {}", sessionId);
+            return;
         }
 
-        /**
-         * 공지사항 등록 시 대상 유저 전체에게 FCM 알림 전송 + Notification 저장
-         *
-         * @param noticeTitle   등록된 공지사항 제목
-         * @param noticeId      등록된 공지사항 ID (알림 domainId로 저장)
-         * @param targetUserIds 알림을 받을 유저 ID 집합
-         */
-        @Transactional
-        public void sendNoticeAlertToTargets(
-                        String noticeTitle, Long noticeId, Set<Long> targetUserIds) {
-                if (targetUserIds == null || targetUserIds.isEmpty()) {
-                        log.info("공지 알림 전송 건너뜀 - 대상 없음, noticeId: {}", noticeId);
-                        return;
-                }
+        String title = "[리마인드] " + NotificationMessage.SAFETY_TRAINING_SESSION_CREATED.getTitle();
+        String content =
+                NotificationMessage.SAFETY_TRAINING_SESSION_CREATED.formatContent(sessionTitle);
+        Map<String, Object> metadata = Map.of("educationType", "SAFETY", "detailType", "SESSION");
 
-                String title = NotificationMessage.NOTICE_CREATED.getTitle();
-                String content = NotificationMessage.NOTICE_CREATED.formatContent(noticeTitle);
-
-                for (Long userId : targetUserIds) {
-                        // 1. 알림함 저장
-                        doCreateNotification(
-                                        userId,
-                                        title,
-                                        content,
-                                        NotificationMessage.NOTICE_CREATED,
-                                        NotificationDomainType.NOTICE,
-                                        noticeId,
-                                        null,
-                                        false);
-
-                        // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
-                        eventPublisher.publishEvent(
-                                        new FcmSendEvent(
-                                                        userId,
-                                                        title,
-                                                        content,
-                                                        buildFcmData(NotificationDomainType.NOTICE, noticeId)));
-                }
-
-                log.info("공지 알림 전송 완료 - noticeId: {}, 대상 수: {}", noticeId, targetUserIds.size());
+        for (Long userId : targetUserIds) {
+            doCreateNotification(
+                    userId,
+                    title,
+                    content,
+                    NotificationMessage.SAFETY_TRAINING_SESSION_CREATED,
+                    NotificationDomainType.SAFETY_TRAINING,
+                    sessionId,
+                    metadata,
+                    false);
+            eventPublisher.publishEvent(
+                    new FcmSendEvent(
+                            userId,
+                            title,
+                            content,
+                            buildFcmData(
+                                    NotificationDomainType.SAFETY_TRAINING, sessionId, metadata)));
         }
 
-        /**
-         * 교육(EduReport) 등록 시 대상 유저 전체에게 FCM 알림 전송 + Notification 저장
-         *
-         * @param eduTypeLabel  교육 유형 라벨 (예: SAFETY, PSM, 부서명 등)
-         * @param eduTitle      등록된 교육 제목
-         * @param reportId      등록된 교육 ID (알림 domainId로 저장)
-         * @param targetUserIds 알림을 받을 유저 ID 집합 (리스트 형태)
-         */
-        @Transactional
-        public void sendEduReportAlertToTargets(
-                        String eduTypeLabel, String eduTitle, Long reportId, List<Long> targetUserIds) {
-                sendEduReportAlertToTargets(eduTypeLabel, eduTitle, reportId, targetUserIds, null);
+        log.info(
+                "안전보건교육 세션 리마인드 알림 전송 완료 - sessionId: {}, 대상 수: {}",
+                sessionId,
+                targetUserIds.size());
+    }
+
+    private Map<String, String> buildFcmData(NotificationDomainType domainType, Long domainId) {
+        return buildFcmData(domainType, domainId, null);
+    }
+
+    private Map<String, String> buildFcmData(
+            NotificationDomainType domainType, Long domainId, Map<String, Object> metadata) {
+        Map<String, String> data = new HashMap<>();
+        data.put("domainType", domainType.name());
+        data.put("domainId", domainId != null ? domainId.toString() : "");
+        if (metadata != null && !metadata.isEmpty()) {
+            try {
+                data.put("metadata", objectMapper.writeValueAsString(metadata));
+            } catch (JsonProcessingException e) {
+                log.error("FCM metadata 직렬화 실패", e);
+            }
         }
-
-        @Transactional
-        public void sendEduReportAlertToTargets(
-                        String eduTypeLabel,
-                        String eduTitle,
-                        Long reportId,
-                        List<Long> targetUserIds,
-                        Map<String, Object> metadata) {
-                if (targetUserIds == null || targetUserIds.isEmpty()) {
-                        log.info("교육 알림 전송 건너뜀 - 대상 없음, reportId: {}", reportId);
-                        return;
-                }
-
-                String title = NotificationMessage.EDU_REPORT_CREATED.getTitle();
-                String content = NotificationMessage.EDU_REPORT_CREATED.formatContent(eduTypeLabel, eduTitle);
-
-                for (Long userId : targetUserIds) {
-                        // 1. 알림함 저장
-                        doCreateNotification(
-                                        userId,
-                                        title,
-                                        content,
-                                        NotificationMessage.EDU_REPORT_CREATED,
-                                        NotificationDomainType.EDUCATION,
-                                        reportId,
-                                        metadata,
-                                        false);
-
-                        // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
-                        eventPublisher.publishEvent(
-                                        new FcmSendEvent(
-                                                        userId,
-                                                        title,
-                                                        content,
-                                                        buildFcmData(NotificationDomainType.EDUCATION, reportId,
-                                                                        metadata)));
-                }
-
-                log.info("교육 알림 전송 완료 - reportId: {}, 대상 수: {}", reportId, targetUserIds.size());
-        }
-
-        /**
-         * 방문 이벤트(사전 예약/입실) 발생 시 host 담당 부서 소속 전원에게 FCM 알림 전송 + Notification 저장
-         *
-         * @param template         알림 메시지 템플릿
-         * @param visitId          방문 ID (domainId로 저장)
-         * @param hostDepartmentId host 직원의 부서 ID
-         * @param contentArgs      템플릿 포맷팅에 사용할 인자
-         */
-        @Transactional
-        public void sendVisitAlertToDepartment(
-                        NotificationMessage template,
-                        Long visitId,
-                        Long hostDepartmentId,
-                        Object... contentArgs) {
-                sendVisitAlertToDepartment(template, visitId, hostDepartmentId, null, contentArgs);
-        }
-
-        @Transactional
-        public void sendVisitAlertToDepartment(
-                        NotificationMessage template,
-                        Long visitId,
-                        Long hostDepartmentId,
-                        Map<String, Object> metadata,
-                        Object... contentArgs) {
-                List<Long> targetUserIds = userRepository.findAllIdsByDepartmentId(hostDepartmentId);
-
-                if (targetUserIds.isEmpty()) {
-                        log.info("방문 알림 전송 건너뜀 - 대상 없음, visitId: {}", visitId);
-                        return;
-                }
-
-                String title = template.getTitle();
-                String content = template.formatContent(contentArgs);
-                boolean requiresApproval = metadata != null && Boolean.TRUE.equals(metadata.get("isApprovalTarget"));
-
-                for (Long userId : targetUserIds) {
-                        // 1. 알림함 저장
-                        doCreateNotification(
-                                        userId,
-                                        title,
-                                        content,
-                                        template,
-                                        NotificationDomainType.VISIT,
-                                        visitId,
-                                        metadata,
-                                        requiresApproval);
-
-                        // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
-                        eventPublisher.publishEvent(
-                                        new FcmSendEvent(
-                                                        userId,
-                                                        title,
-                                                        content,
-                                                        buildFcmData(NotificationDomainType.VISIT, visitId, metadata)));
-                }
-
-                log.info(
-                                "방문 알림 전송 완료 - visitId: {}, 대상 수: {}, 템플릿: {}",
-                                visitId,
-                                targetUserIds.size(),
-                                template.name());
-        }
-
-        /**
-         * 연차 갱신/등록 시 단일 유저에게 알림 전송
-         *
-         * @param userId            알림 대상 유저 ID
-         * @param baseDateFormatted 포맷팅된 기준일 문자열 (예: "2025년 08월 01일")
-         */
-        @Transactional
-        public void sendAnnualLeaveAlertToUser(Long userId, String baseDateFormatted) {
-                NotificationMessage template = NotificationMessage.ANNUAL_LEAVE_UPDATED;
-                String title = template.getTitle();
-                String content = template.formatContent(baseDateFormatted);
-
-                // 1. 알림함 DB 저장 (domainId는 단일 엔티티 연차 특성상 null 처리)
-                doCreateNotification(
-                                userId,
-                                title,
-                                content,
-                                template,
-                                NotificationDomainType.ANNUAL_LEAVE,
-                                null,
-                                null,
-                                false);
-
-                // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
-                eventPublisher.publishEvent(
-                                new FcmSendEvent(
-                                                userId,
-                                                title,
-                                                content,
-                                                buildFcmData(NotificationDomainType.ANNUAL_LEAVE, null)));
-
-                log.info("연차 알림 전송 완료 - userId: {}, 기준일: {}", userId, baseDateFormatted);
-        }
-
-        /**
-         * 급여명세서 발송 시 단일 유저에게 알림 전송
-         *
-         * @param userId    알림 대상 유저 ID
-         * @param payslipId 발송된 Payslip ID (domainId로 저장)
-         */
-        @Transactional
-        public void sendPayslipAlertToUser(Long userId, Long payslipId) {
-                NotificationMessage template = NotificationMessage.PAYSLIP_SENT;
-                String title = template.getTitle();
-                String content = template.formatContent();
-
-                // 1. 알림함 DB 저장
-                doCreateNotification(
-                                userId,
-                                title,
-                                content,
-                                template,
-                                NotificationDomainType.PAYSLIP,
-                                payslipId,
-                                null,
-                                false);
-
-                // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
-                eventPublisher.publishEvent(
-                                new FcmSendEvent(
-                                                userId,
-                                                title,
-                                                content,
-                                                buildFcmData(NotificationDomainType.PAYSLIP, payslipId)));
-
-                log.info("급여명세서 알림 전송 완료 - userId: {}, payslipId: {}", userId, payslipId);
-        }
-
-        /**
-         * 전자결재 생성 시 첫 번째 결재자와 참조자(REFERRER)에게 알림 전송
-         *
-         * @param approvalId      결재 문서 ID
-         * @param docTitle        결재 문서 제목
-         * @param firstApproverId 첫 번째 결재자 유저 ID
-         * @param referrerIds     참조자(REFERRER) 유저 ID 목록
-         */
-        @Transactional
-        public void sendApprovalCreatedAlert(
-                        Long approvalId, String docTitle, Long firstApproverId, List<Long> referrerIds) {
-
-                // 1. 첫 번째 결재자에게 알림
-                String approverTitle = NotificationMessage.APPROVAL_CREATED_APPROVER.getTitle();
-                String approverContent = NotificationMessage.APPROVAL_CREATED_APPROVER.formatContent(docTitle);
-                doCreateNotification(
-                                firstApproverId,
-                                approverTitle,
-                                approverContent,
-                                NotificationMessage.APPROVAL_CREATED_APPROVER,
-                                NotificationDomainType.APPROVAL,
-                                approvalId,
-                                null,
-                                true);
-                eventPublisher.publishEvent(
-                                new FcmSendEvent(
-                                                firstApproverId,
-                                                approverTitle,
-                                                approverContent,
-                                                buildFcmData(NotificationDomainType.APPROVAL, approvalId)));
-                log.info(
-                                "전자결재 생성 알림(결재자) 전송 - approvalId: {}, approverId: {}", approvalId, firstApproverId);
-
-                // 2. 참조자들에게 알림
-                String referrerTitle = NotificationMessage.APPROVAL_CREATED_REFERRER.getTitle();
-                String referrerContent = NotificationMessage.APPROVAL_CREATED_REFERRER.formatContent(docTitle);
-                for (Long referrerId : referrerIds) {
-                        doCreateNotification(
-                                        referrerId,
-                                        referrerTitle,
-                                        referrerContent,
-                                        NotificationMessage.APPROVAL_CREATED_REFERRER,
-                                        NotificationDomainType.APPROVAL,
-                                        approvalId,
-                                        null,
-                                        false);
-                        eventPublisher.publishEvent(
-                                        new FcmSendEvent(
-                                                        referrerId,
-                                                        referrerTitle,
-                                                        referrerContent,
-                                                        buildFcmData(NotificationDomainType.APPROVAL, approvalId)));
-                }
-                log.info("전자결재 생성 알림(참조자 {}명) 전송 완료 - approvalId: {}", referrerIds.size(), approvalId);
-        }
-
-        /**
-         * N번째 결재자가 승인 시 N+1번째 결재자에게 알림 전송
-         *
-         * @param nextApproverId 다음 결재자 유저 ID
-         * @param approvalId     결재 문서 ID
-         * @param docTitle       결재 문서 제목
-         */
-        @Transactional
-        public void sendApprovalNextStepAlert(Long nextApproverId, Long approvalId, String docTitle) {
-                String title = NotificationMessage.APPROVAL_CREATED_APPROVER.getTitle();
-                String content = NotificationMessage.APPROVAL_CREATED_APPROVER.formatContent(docTitle);
-
-                doCreateNotification(
-                                nextApproverId,
-                                title,
-                                content,
-                                NotificationMessage.APPROVAL_CREATED_APPROVER,
-                                NotificationDomainType.APPROVAL,
-                                approvalId,
-                                null,
-                                true);
-                eventPublisher.publishEvent(
-                                new FcmSendEvent(
-                                                nextApproverId,
-                                                title,
-                                                content,
-                                                buildFcmData(NotificationDomainType.APPROVAL, approvalId)));
-
-                log.info(
-                                "전자결재 다음 결재자 알림 전송 - approvalId: {}, nextApproverId: {}",
-                                approvalId,
-                                nextApproverId);
-        }
-
-        /**
-         * 전자결재 반려 시 기안자에게 사유와 함께 알림 전송
-         *
-         * @param drafterId  기안자 유저 ID
-         * @param approvalId 결재 문서 ID
-         * @param docTitle   결재 문서 제목
-         * @param comment    반려 사유
-         */
-        @Transactional
-        public void sendApprovalRejectedAlert(
-                        Long drafterId, Long approvalId, String docTitle, String comment) {
-                String title = NotificationMessage.APPROVAL_REJECTED.getTitle();
-                String content = NotificationMessage.APPROVAL_REJECTED.formatContent(docTitle, comment);
-
-                doCreateNotification(
-                                drafterId,
-                                title,
-                                content,
-                                NotificationMessage.APPROVAL_REJECTED,
-                                NotificationDomainType.APPROVAL,
-                                approvalId,
-                                null,
-                                false);
-                eventPublisher.publishEvent(
-                                new FcmSendEvent(
-                                                drafterId,
-                                                title,
-                                                content,
-                                                buildFcmData(NotificationDomainType.APPROVAL, approvalId)));
-
-                log.info("전자결재 반려 알림 전송 - approvalId: {}, drafterId: {}", approvalId, drafterId);
-        }
-
-        /**
-         * 전자결재 최종 승인 시 기안자와 열람권자(VIEWER)에게 알림 전송
-         *
-         * @param approvalId 결재 문서 ID
-         * @param docTitle   결재 문서 제목
-         * @param drafterId  기안자 유저 ID
-         * @param viewerIds  열람권자(VIEWER) 유저 ID 목록
-         */
-        @Transactional
-        public void sendApprovalFinallyApprovedAlert(
-                        Long approvalId, String docTitle, Long drafterId, List<Long> viewerIds) {
-                String title = NotificationMessage.APPROVAL_FINALLY_APPROVED.getTitle();
-                String content = NotificationMessage.APPROVAL_FINALLY_APPROVED.formatContent(docTitle);
-
-                // 1. 기안자에게 알림
-                doCreateNotification(
-                                drafterId,
-                                title,
-                                content,
-                                NotificationMessage.APPROVAL_FINALLY_APPROVED,
-                                NotificationDomainType.APPROVAL,
-                                approvalId,
-                                null,
-                                false);
-                eventPublisher.publishEvent(
-                                new FcmSendEvent(
-                                                drafterId,
-                                                title,
-                                                content,
-                                                buildFcmData(NotificationDomainType.APPROVAL, approvalId)));
-
-                // 2. 열람권자들에게 알림
-                for (Long viewerId : viewerIds) {
-                        doCreateNotification(
-                                        viewerId,
-                                        title,
-                                        content,
-                                        NotificationMessage.APPROVAL_FINALLY_APPROVED,
-                                        NotificationDomainType.APPROVAL,
-                                        approvalId,
-                                        null,
-                                        false);
-                        eventPublisher.publishEvent(
-                                        new FcmSendEvent(
-                                                        viewerId,
-                                                        title,
-                                                        content,
-                                                        buildFcmData(NotificationDomainType.APPROVAL, approvalId)));
-                }
-
-                log.info(
-                                "전자결재 최종 승인 알림 전송 - approvalId: {}, drafterId: {}, viewers: {}명",
-                                approvalId,
-                                drafterId,
-                                viewerIds.size());
-        }
-
-        /**
-         * 안전보건교육 세션 생성 시 대상 유저 전체에게 FCM 알림 전송 + Notification 저장
-         *
-         * @param sessionId     생성된 세션 ID (domainId로 저장)
-         * @param sessionTitle  세션 제목
-         * @param targetUserIds 알림을 받을 유저 ID 목록
-         */
-        @Transactional
-        public void sendSafetyTrainingSessionAlertToAttendees(
-                        Long sessionId, String sessionTitle, List<Long> targetUserIds) {
-                if (targetUserIds == null || targetUserIds.isEmpty()) {
-                        log.info("안전보건교육 알림 전송 건너뜀 - 대상 없음, sessionId: {}", sessionId);
-                        return;
-                }
-
-                String title = NotificationMessage.SAFETY_TRAINING_SESSION_CREATED.getTitle();
-                String content = NotificationMessage.SAFETY_TRAINING_SESSION_CREATED.formatContent(sessionTitle);
-                Map<String, Object> metadata = Map.of("educationType", "SAFETY", "detailType", "SESSION");
-
-                for (Long userId : targetUserIds) {
-                        doCreateNotification(
-                                        userId,
-                                        title,
-                                        content,
-                                        NotificationMessage.SAFETY_TRAINING_SESSION_CREATED,
-                                        NotificationDomainType.SAFETY_TRAINING,
-                                        sessionId,
-                                        metadata,
-                                        false);
-                        eventPublisher.publishEvent(
-                                        new FcmSendEvent(
-                                                        userId,
-                                                        title,
-                                                        content,
-                                                        buildFcmData(
-                                                                        NotificationDomainType.SAFETY_TRAINING,
-                                                                        sessionId, metadata)));
-                }
-
-                log.info("안전보건교육 세션 알림 전송 완료 - sessionId: {}, 대상 수: {}", sessionId, targetUserIds.size());
-        }
-
-        /**
-         * 교육(EduReport) 리마인드 알림 - 대상 유저 전체에게 FCM 알림 전송 + Notification 저장
-         */
-        @Transactional
-        public void sendEduReportRemindAlertToTargets(
-                        String eduTypeLabel, String eduTitle, Long reportId, List<Long> targetUserIds) {
-                sendEduReportRemindAlertToTargets(eduTypeLabel, eduTitle, reportId, targetUserIds, null);
-        }
-
-        @Transactional
-        public void sendEduReportRemindAlertToTargets(
-                        String eduTypeLabel,
-                        String eduTitle,
-                        Long reportId,
-                        List<Long> targetUserIds,
-                        Map<String, Object> metadata) {
-                if (targetUserIds == null || targetUserIds.isEmpty()) {
-                        log.info("교육 리마인드 알림 전송 건너뜀 - 대상 없음, reportId: {}", reportId);
-                        return;
-                }
-
-                String title = "[리마인드] " + NotificationMessage.EDU_REPORT_CREATED.getTitle();
-                String content = NotificationMessage.EDU_REPORT_CREATED.formatContent(eduTypeLabel, eduTitle);
-
-                for (Long userId : targetUserIds) {
-                        doCreateNotification(
-                                        userId,
-                                        title,
-                                        content,
-                                        NotificationMessage.EDU_REPORT_CREATED,
-                                        NotificationDomainType.EDUCATION,
-                                        reportId,
-                                        metadata,
-                                        false);
-                        eventPublisher.publishEvent(
-                                        new FcmSendEvent(
-                                                        userId,
-                                                        title,
-                                                        content,
-                                                        buildFcmData(NotificationDomainType.EDUCATION, reportId,
-                                                                        metadata)));
-                }
-
-                log.info("교육 리마인드 알림 전송 완료 - reportId: {}, 대상 수: {}", reportId, targetUserIds.size());
-        }
-
-        /**
-         * 안전보건교육 세션 리마인드 알림 - 대상 유저 전체에게 FCM 알림 전송 + Notification 저장
-         */
-        @Transactional
-        public void sendSafetyTrainingSessionRemindAlertToAttendees(
-                        Long sessionId, String sessionTitle, List<Long> targetUserIds) {
-                if (targetUserIds == null || targetUserIds.isEmpty()) {
-                        log.info("안전보건교육 리마인드 알림 전송 건너뜀 - 대상 없음, sessionId: {}", sessionId);
-                        return;
-                }
-
-                String title = "[리마인드] " + NotificationMessage.SAFETY_TRAINING_SESSION_CREATED.getTitle();
-                String content = NotificationMessage.SAFETY_TRAINING_SESSION_CREATED.formatContent(sessionTitle);
-                Map<String, Object> metadata = Map.of("educationType", "SAFETY", "detailType", "SESSION");
-
-                for (Long userId : targetUserIds) {
-                        doCreateNotification(
-                                        userId,
-                                        title,
-                                        content,
-                                        NotificationMessage.SAFETY_TRAINING_SESSION_CREATED,
-                                        NotificationDomainType.SAFETY_TRAINING,
-                                        sessionId,
-                                        metadata,
-                                        false);
-                        eventPublisher.publishEvent(
-                                        new FcmSendEvent(
-                                                        userId,
-                                                        title,
-                                                        content,
-                                                        buildFcmData(
-                                                                        NotificationDomainType.SAFETY_TRAINING,
-                                                                        sessionId, metadata)));
-                }
-
-                log.info("안전보건교육 세션 리마인드 알림 전송 완료 - sessionId: {}, 대상 수: {}", sessionId, targetUserIds.size());
-        }
-
-        private Map<String, String> buildFcmData(NotificationDomainType domainType, Long domainId) {
-                return buildFcmData(domainType, domainId, null);
-        }
-
-        private Map<String, String> buildFcmData(
-                        NotificationDomainType domainType, Long domainId, Map<String, Object> metadata) {
-                Map<String, String> data = new HashMap<>();
-                data.put("domainType", domainType.name());
-                data.put("domainId", domainId != null ? domainId.toString() : "");
-                if (metadata != null && !metadata.isEmpty()) {
-                        try {
-                                data.put("metadata", objectMapper.writeValueAsString(metadata));
-                        } catch (JsonProcessingException e) {
-                                log.error("FCM metadata 직렬화 실패", e);
-                        }
-                }
-                return data;
-        }
+        return data;
+    }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/service/NotificationService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/service/NotificationService.java
@@ -34,692 +34,769 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class NotificationService {
 
-    private final NotificationRepository notificationRepository;
-    private final ApplicationEventPublisher eventPublisher;
-    private final UserRepository userRepository;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+        private final NotificationRepository notificationRepository;
+        private final ApplicationEventPublisher eventPublisher;
+        private final UserRepository userRepository;
+        private final ObjectMapper objectMapper = new ObjectMapper();
 
-    @Transactional
-    public void createNotification(
-            Long userId,
-            String title,
-            String content,
-            NotificationDomainType domainType,
-            Long domainId) {
-        createNotification(userId, title, content, domainType, domainId, null);
-    }
-
-    @Transactional
-    public void createNotification(
-            Long userId,
-            String title,
-            String content,
-            NotificationDomainType domainType,
-            Long domainId,
-            Map<String, Object> metadata) {
-        createNotification(userId, title, content, domainType, domainId, metadata, false);
-    }
-
-    @Transactional
-    public void createNotification(
-            Long userId,
-            String title,
-            String content,
-            NotificationDomainType domainType,
-            Long domainId,
-            Map<String, Object> metadata,
-            boolean requiresApproval) {
-        Notification notification =
-                Notification.of(
-                        userId, title, content, domainType, domainId, metadata, requiresApproval);
-        notificationRepository.save(notification);
-        log.info("알림 생성 - userId: {}, domainType: {}", userId, domainType);
-    }
-
-    private void doCreateNotification(
-            Long userId,
-            String title,
-            String content,
-            NotificationMessage messageType,
-            NotificationDomainType domainType,
-            Long domainId,
-            Map<String, Object> metadata,
-            boolean requiresApproval) {
-        Notification notification =
-                Notification.of(
-                        userId,
-                        title,
-                        content,
-                        domainType,
-                        domainId,
-                        metadata,
-                        requiresApproval,
-                        messageType);
-        notificationRepository.save(notification);
-        log.info("알림 생성 - userId: {}, domainType: {}", userId, domainType);
-    }
-
-    @Transactional(readOnly = true)
-    public Page<NotificationResponseDto> getNotifications(
-            Long userId, boolean pendingApproval, Pageable pageable) {
-        Page<Notification> page =
-                pendingApproval
-                        ? notificationRepository
-                                .findByUserIdAndRequiresApprovalTrueOrderByCreatedAtDesc(
-                                        userId, pageable)
-                        : notificationRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable);
-        return page.map(NotificationResponseDto::from);
-    }
-
-    @Transactional
-    public void resolveRequiresApproval(NotificationDomainType domainType, Long domainId) {
-        notificationRepository.resolveRequiresApprovalByDomainTypeAndDomainId(domainType, domainId);
-        log.info("requiresApproval 해제 - domainType: {}, domainId: {}", domainType, domainId);
-    }
-
-    @Transactional
-    public void markAsRead(Long notificationId, Long userId) {
-        Notification notification =
-                notificationRepository
-                        .findById(notificationId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_NOT_FOUND));
-
-        if (!notification.getUserId().equals(userId)) {
-            throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_NOTIFICATION);
+        @Transactional
+        public void createNotification(
+                        Long userId,
+                        String title,
+                        String content,
+                        NotificationDomainType domainType,
+                        Long domainId) {
+                createNotification(userId, title, content, domainType, domainId, null);
         }
 
-        notification.markAsRead();
-    }
-
-    @Transactional(readOnly = true)
-    public long getUnreadCount(Long userId) {
-        return notificationRepository.countByUserIdAndIsReadFalse(userId);
-    }
-
-    /**
-     * Admin/MasterAdmin 유저 전체에게 FCM 알림 전송 + Notification 저장
-     *
-     * @param template 알림 메시지 템플릿
-     * @param domainType 생성할 알림의 도메인 타입
-     * @param domainId 생성할 알림의 도메인 ID (선택)
-     * @param args 템플릿 포맷팅에 사용할 인자
-     */
-    @Transactional
-    public void sendAlertToAdmins(
-            NotificationMessage template,
-            NotificationDomainType domainType,
-            Long domainId,
-            Object... args) {
-        sendAlertToAdmins(template, domainType, domainId, null, args);
-    }
-
-    @Transactional
-    public void sendAlertToAdmins(
-            NotificationMessage template,
-            NotificationDomainType domainType,
-            Long domainId,
-            Map<String, Object> metadata,
-            Object... args) {
-        sendAlertToAdminsInternal(template, domainType, domainId, metadata, false, args);
-    }
-
-    @Transactional
-    public void sendAlertToAdminsRequiringApproval(
-            NotificationMessage template,
-            NotificationDomainType domainType,
-            Long domainId,
-            Map<String, Object> metadata,
-            Object... args) {
-        sendAlertToAdminsInternal(template, domainType, domainId, metadata, true, args);
-    }
-
-    private void sendAlertToAdminsInternal(
-            NotificationMessage template,
-            NotificationDomainType domainType,
-            Long domainId,
-            Map<String, Object> metadata,
-            boolean requiresApproval,
-            Object... args) {
-        String title = template.getTitle();
-        String content = template.formatContent(args);
-
-        List<User> admins = userRepository.findAllByRole(Role.ADMIN);
-        admins.addAll(userRepository.findAllByRole(Role.MASTER_ADMIN));
-
-        for (User admin : admins) {
-            // 1. 알림함 저장
-            doCreateNotification(
-                    admin.getId(),
-                    title,
-                    content,
-                    template,
-                    domainType,
-                    domainId,
-                    metadata,
-                    requiresApproval);
-
-            // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
-            eventPublisher.publishEvent(
-                    new FcmSendEvent(
-                            admin.getId(),
-                            title,
-                            content,
-                            buildFcmData(domainType, domainId, metadata)));
+        @Transactional
+        public void createNotification(
+                        Long userId,
+                        String title,
+                        String content,
+                        NotificationDomainType domainType,
+                        Long domainId,
+                        Map<String, Object> metadata) {
+                createNotification(userId, title, content, domainType, domainId, metadata, false);
         }
 
-        log.info("관리자 그룹 알림 전송 완료 - 대상 Admin 수: {}, 템플릿: {}", admins.size(), template.name());
-    }
-
-    /**
-     * 특정 단일 유저에게 FCM 알림 전송 + Notification 저장
-     *
-     * @param userId 수신 유저 ID
-     * @param template 알림 메시지 템플릿
-     * @param domainType 생성할 알림의 도메인 타입
-     * @param domainId 생성할 알림의 도메인 ID
-     * @param args 템플릿 포맷팅에 사용할 인자
-     */
-    @Transactional
-    public void sendAlertToUser(
-            Long userId,
-            NotificationMessage template,
-            NotificationDomainType domainType,
-            Long domainId,
-            Object... args) {
-        sendAlertToUser(userId, template, domainType, domainId, null, args);
-    }
-
-    @Transactional
-    public void sendAlertToUser(
-            Long userId,
-            NotificationMessage template,
-            NotificationDomainType domainType,
-            Long domainId,
-            Map<String, Object> metadata,
-            Object... args) {
-        String title = template.getTitle();
-        String content = template.formatContent(args);
-
-        // 1. 알림함 저장
-        doCreateNotification(
-                userId, title, content, template, domainType, domainId, metadata, false);
-
-        // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
-        eventPublisher.publishEvent(
-                new FcmSendEvent(
-                        userId, title, content, buildFcmData(domainType, domainId, metadata)));
-
-        log.info("단일 유저 알림 전송 완료 - userId: {}, 템플릿: {}", userId, template.name());
-    }
-
-    /**
-     * 공지사항 등록 시 대상 유저 전체에게 FCM 알림 전송 + Notification 저장
-     *
-     * @param noticeTitle 등록된 공지사항 제목
-     * @param noticeId 등록된 공지사항 ID (알림 domainId로 저장)
-     * @param targetUserIds 알림을 받을 유저 ID 집합
-     */
-    @Transactional
-    public void sendNoticeAlertToTargets(
-            String noticeTitle, Long noticeId, Set<Long> targetUserIds) {
-        if (targetUserIds == null || targetUserIds.isEmpty()) {
-            log.info("공지 알림 전송 건너뜀 - 대상 없음, noticeId: {}", noticeId);
-            return;
+        @Transactional
+        public void createNotification(
+                        Long userId,
+                        String title,
+                        String content,
+                        NotificationDomainType domainType,
+                        Long domainId,
+                        Map<String, Object> metadata,
+                        boolean requiresApproval) {
+                Notification notification = Notification.of(
+                                userId, title, content, domainType, domainId, metadata, requiresApproval);
+                notificationRepository.save(notification);
+                log.info("알림 생성 - userId: {}, domainType: {}", userId, domainType);
         }
 
-        String title = NotificationMessage.NOTICE_CREATED.getTitle();
-        String content = NotificationMessage.NOTICE_CREATED.formatContent(noticeTitle);
-
-        for (Long userId : targetUserIds) {
-            // 1. 알림함 저장
-            doCreateNotification(
-                    userId,
-                    title,
-                    content,
-                    NotificationMessage.NOTICE_CREATED,
-                    NotificationDomainType.NOTICE,
-                    noticeId,
-                    null,
-                    false);
-
-            // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
-            eventPublisher.publishEvent(
-                    new FcmSendEvent(
-                            userId,
-                            title,
-                            content,
-                            buildFcmData(NotificationDomainType.NOTICE, noticeId)));
+        private void doCreateNotification(
+                        Long userId,
+                        String title,
+                        String content,
+                        NotificationMessage messageType,
+                        NotificationDomainType domainType,
+                        Long domainId,
+                        Map<String, Object> metadata,
+                        boolean requiresApproval) {
+                Notification notification = Notification.of(
+                                userId,
+                                title,
+                                content,
+                                domainType,
+                                domainId,
+                                metadata,
+                                requiresApproval,
+                                messageType);
+                notificationRepository.save(notification);
+                log.info("알림 생성 - userId: {}, domainType: {}", userId, domainType);
         }
 
-        log.info("공지 알림 전송 완료 - noticeId: {}, 대상 수: {}", noticeId, targetUserIds.size());
-    }
-
-    /**
-     * 교육(EduReport) 등록 시 대상 유저 전체에게 FCM 알림 전송 + Notification 저장
-     *
-     * @param eduTypeLabel 교육 유형 라벨 (예: SAFETY, PSM, 부서명 등)
-     * @param eduTitle 등록된 교육 제목
-     * @param reportId 등록된 교육 ID (알림 domainId로 저장)
-     * @param targetUserIds 알림을 받을 유저 ID 집합 (리스트 형태)
-     */
-    @Transactional
-    public void sendEduReportAlertToTargets(
-            String eduTypeLabel, String eduTitle, Long reportId, List<Long> targetUserIds) {
-        sendEduReportAlertToTargets(eduTypeLabel, eduTitle, reportId, targetUserIds, null);
-    }
-
-    @Transactional
-    public void sendEduReportAlertToTargets(
-            String eduTypeLabel,
-            String eduTitle,
-            Long reportId,
-            List<Long> targetUserIds,
-            Map<String, Object> metadata) {
-        if (targetUserIds == null || targetUserIds.isEmpty()) {
-            log.info("교육 알림 전송 건너뜀 - 대상 없음, reportId: {}", reportId);
-            return;
+        @Transactional(readOnly = true)
+        public Page<NotificationResponseDto> getNotifications(
+                        Long userId, boolean pendingApproval, Pageable pageable) {
+                Page<Notification> page = pendingApproval
+                                ? notificationRepository
+                                                .findByUserIdAndRequiresApprovalTrueOrderByCreatedAtDesc(
+                                                                userId, pageable)
+                                : notificationRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable);
+                return page.map(NotificationResponseDto::from);
         }
 
-        String title = NotificationMessage.EDU_REPORT_CREATED.getTitle();
-        String content =
-                NotificationMessage.EDU_REPORT_CREATED.formatContent(eduTypeLabel, eduTitle);
-
-        for (Long userId : targetUserIds) {
-            // 1. 알림함 저장
-            doCreateNotification(
-                    userId,
-                    title,
-                    content,
-                    NotificationMessage.EDU_REPORT_CREATED,
-                    NotificationDomainType.EDUCATION,
-                    reportId,
-                    metadata,
-                    false);
-
-            // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
-            eventPublisher.publishEvent(
-                    new FcmSendEvent(
-                            userId,
-                            title,
-                            content,
-                            buildFcmData(NotificationDomainType.EDUCATION, reportId, metadata)));
+        @Transactional
+        public void resolveRequiresApproval(NotificationDomainType domainType, Long domainId) {
+                notificationRepository.resolveRequiresApprovalByDomainTypeAndDomainId(domainType, domainId);
+                log.info("requiresApproval 해제 - domainType: {}, domainId: {}", domainType, domainId);
         }
 
-        log.info("교육 알림 전송 완료 - reportId: {}, 대상 수: {}", reportId, targetUserIds.size());
-    }
+        @Transactional
+        public void markAsRead(Long notificationId, Long userId) {
+                Notification notification = notificationRepository
+                                .findById(notificationId)
+                                .orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_NOT_FOUND));
 
-    /**
-     * 방문 이벤트(사전 예약/입실) 발생 시 host 담당 부서 소속 전원에게 FCM 알림 전송 + Notification 저장
-     *
-     * @param template 알림 메시지 템플릿
-     * @param visitId 방문 ID (domainId로 저장)
-     * @param hostDepartmentId host 직원의 부서 ID
-     * @param contentArgs 템플릿 포맷팅에 사용할 인자
-     */
-    @Transactional
-    public void sendVisitAlertToDepartment(
-            NotificationMessage template,
-            Long visitId,
-            Long hostDepartmentId,
-            Object... contentArgs) {
-        sendVisitAlertToDepartment(template, visitId, hostDepartmentId, null, contentArgs);
-    }
+                if (!notification.getUserId().equals(userId)) {
+                        throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_NOTIFICATION);
+                }
 
-    @Transactional
-    public void sendVisitAlertToDepartment(
-            NotificationMessage template,
-            Long visitId,
-            Long hostDepartmentId,
-            Map<String, Object> metadata,
-            Object... contentArgs) {
-        List<Long> targetUserIds = userRepository.findAllIdsByDepartmentId(hostDepartmentId);
-
-        if (targetUserIds.isEmpty()) {
-            log.info("방문 알림 전송 건너뜀 - 대상 없음, visitId: {}", visitId);
-            return;
+                notification.markAsRead();
         }
 
-        String title = template.getTitle();
-        String content = template.formatContent(contentArgs);
-        boolean requiresApproval =
-                metadata != null && Boolean.TRUE.equals(metadata.get("isApprovalTarget"));
-
-        for (Long userId : targetUserIds) {
-            // 1. 알림함 저장
-            doCreateNotification(
-                    userId,
-                    title,
-                    content,
-                    template,
-                    NotificationDomainType.VISIT,
-                    visitId,
-                    metadata,
-                    requiresApproval);
-
-            // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
-            eventPublisher.publishEvent(
-                    new FcmSendEvent(
-                            userId,
-                            title,
-                            content,
-                            buildFcmData(NotificationDomainType.VISIT, visitId, metadata)));
+        @Transactional(readOnly = true)
+        public long getUnreadCount(Long userId) {
+                return notificationRepository.countByUserIdAndIsReadFalse(userId);
         }
 
-        log.info(
-                "방문 알림 전송 완료 - visitId: {}, 대상 수: {}, 템플릿: {}",
-                visitId,
-                targetUserIds.size(),
-                template.name());
-    }
-
-    /**
-     * 연차 갱신/등록 시 단일 유저에게 알림 전송
-     *
-     * @param userId 알림 대상 유저 ID
-     * @param baseDateFormatted 포맷팅된 기준일 문자열 (예: "2025년 08월 01일")
-     */
-    @Transactional
-    public void sendAnnualLeaveAlertToUser(Long userId, String baseDateFormatted) {
-        NotificationMessage template = NotificationMessage.ANNUAL_LEAVE_UPDATED;
-        String title = template.getTitle();
-        String content = template.formatContent(baseDateFormatted);
-
-        // 1. 알림함 DB 저장 (domainId는 단일 엔티티 연차 특성상 null 처리)
-        doCreateNotification(
-                userId,
-                title,
-                content,
-                template,
-                NotificationDomainType.ANNUAL_LEAVE,
-                null,
-                null,
-                false);
-
-        // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
-        eventPublisher.publishEvent(
-                new FcmSendEvent(
-                        userId,
-                        title,
-                        content,
-                        buildFcmData(NotificationDomainType.ANNUAL_LEAVE, null)));
-
-        log.info("연차 알림 전송 완료 - userId: {}, 기준일: {}", userId, baseDateFormatted);
-    }
-
-    /**
-     * 급여명세서 발송 시 단일 유저에게 알림 전송
-     *
-     * @param userId 알림 대상 유저 ID
-     * @param payslipId 발송된 Payslip ID (domainId로 저장)
-     */
-    @Transactional
-    public void sendPayslipAlertToUser(Long userId, Long payslipId) {
-        NotificationMessage template = NotificationMessage.PAYSLIP_SENT;
-        String title = template.getTitle();
-        String content = template.formatContent();
-
-        // 1. 알림함 DB 저장
-        doCreateNotification(
-                userId,
-                title,
-                content,
-                template,
-                NotificationDomainType.PAYSLIP,
-                payslipId,
-                null,
-                false);
-
-        // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
-        eventPublisher.publishEvent(
-                new FcmSendEvent(
-                        userId,
-                        title,
-                        content,
-                        buildFcmData(NotificationDomainType.PAYSLIP, payslipId)));
-
-        log.info("급여명세서 알림 전송 완료 - userId: {}, payslipId: {}", userId, payslipId);
-    }
-
-    /**
-     * 전자결재 생성 시 첫 번째 결재자와 참조자(REFERRER)에게 알림 전송
-     *
-     * @param approvalId 결재 문서 ID
-     * @param docTitle 결재 문서 제목
-     * @param firstApproverId 첫 번째 결재자 유저 ID
-     * @param referrerIds 참조자(REFERRER) 유저 ID 목록
-     */
-    @Transactional
-    public void sendApprovalCreatedAlert(
-            Long approvalId, String docTitle, Long firstApproverId, List<Long> referrerIds) {
-
-        // 1. 첫 번째 결재자에게 알림
-        String approverTitle = NotificationMessage.APPROVAL_CREATED_APPROVER.getTitle();
-        String approverContent =
-                NotificationMessage.APPROVAL_CREATED_APPROVER.formatContent(docTitle);
-        doCreateNotification(
-                firstApproverId,
-                approverTitle,
-                approverContent,
-                NotificationMessage.APPROVAL_CREATED_APPROVER,
-                NotificationDomainType.APPROVAL,
-                approvalId,
-                null,
-                true);
-        eventPublisher.publishEvent(
-                new FcmSendEvent(
-                        firstApproverId,
-                        approverTitle,
-                        approverContent,
-                        buildFcmData(NotificationDomainType.APPROVAL, approvalId)));
-        log.info(
-                "전자결재 생성 알림(결재자) 전송 - approvalId: {}, approverId: {}", approvalId, firstApproverId);
-
-        // 2. 참조자들에게 알림
-        String referrerTitle = NotificationMessage.APPROVAL_CREATED_REFERRER.getTitle();
-        String referrerContent =
-                NotificationMessage.APPROVAL_CREATED_REFERRER.formatContent(docTitle);
-        for (Long referrerId : referrerIds) {
-            doCreateNotification(
-                    referrerId,
-                    referrerTitle,
-                    referrerContent,
-                    NotificationMessage.APPROVAL_CREATED_REFERRER,
-                    NotificationDomainType.APPROVAL,
-                    approvalId,
-                    null,
-                    false);
-            eventPublisher.publishEvent(
-                    new FcmSendEvent(
-                            referrerId,
-                            referrerTitle,
-                            referrerContent,
-                            buildFcmData(NotificationDomainType.APPROVAL, approvalId)));
-        }
-        log.info("전자결재 생성 알림(참조자 {}명) 전송 완료 - approvalId: {}", referrerIds.size(), approvalId);
-    }
-
-    /**
-     * N번째 결재자가 승인 시 N+1번째 결재자에게 알림 전송
-     *
-     * @param nextApproverId 다음 결재자 유저 ID
-     * @param approvalId 결재 문서 ID
-     * @param docTitle 결재 문서 제목
-     */
-    @Transactional
-    public void sendApprovalNextStepAlert(Long nextApproverId, Long approvalId, String docTitle) {
-        String title = NotificationMessage.APPROVAL_CREATED_APPROVER.getTitle();
-        String content = NotificationMessage.APPROVAL_CREATED_APPROVER.formatContent(docTitle);
-
-        doCreateNotification(
-                nextApproverId,
-                title,
-                content,
-                NotificationMessage.APPROVAL_CREATED_APPROVER,
-                NotificationDomainType.APPROVAL,
-                approvalId,
-                null,
-                true);
-        eventPublisher.publishEvent(
-                new FcmSendEvent(
-                        nextApproverId,
-                        title,
-                        content,
-                        buildFcmData(NotificationDomainType.APPROVAL, approvalId)));
-
-        log.info(
-                "전자결재 다음 결재자 알림 전송 - approvalId: {}, nextApproverId: {}",
-                approvalId,
-                nextApproverId);
-    }
-
-    /**
-     * 전자결재 반려 시 기안자에게 사유와 함께 알림 전송
-     *
-     * @param drafterId 기안자 유저 ID
-     * @param approvalId 결재 문서 ID
-     * @param docTitle 결재 문서 제목
-     * @param comment 반려 사유
-     */
-    @Transactional
-    public void sendApprovalRejectedAlert(
-            Long drafterId, Long approvalId, String docTitle, String comment) {
-        String title = NotificationMessage.APPROVAL_REJECTED.getTitle();
-        String content = NotificationMessage.APPROVAL_REJECTED.formatContent(docTitle, comment);
-
-        doCreateNotification(
-                drafterId,
-                title,
-                content,
-                NotificationMessage.APPROVAL_REJECTED,
-                NotificationDomainType.APPROVAL,
-                approvalId,
-                null,
-                false);
-        eventPublisher.publishEvent(
-                new FcmSendEvent(
-                        drafterId,
-                        title,
-                        content,
-                        buildFcmData(NotificationDomainType.APPROVAL, approvalId)));
-
-        log.info("전자결재 반려 알림 전송 - approvalId: {}, drafterId: {}", approvalId, drafterId);
-    }
-
-    /**
-     * 전자결재 최종 승인 시 기안자와 열람권자(VIEWER)에게 알림 전송
-     *
-     * @param approvalId 결재 문서 ID
-     * @param docTitle 결재 문서 제목
-     * @param drafterId 기안자 유저 ID
-     * @param viewerIds 열람권자(VIEWER) 유저 ID 목록
-     */
-    @Transactional
-    public void sendApprovalFinallyApprovedAlert(
-            Long approvalId, String docTitle, Long drafterId, List<Long> viewerIds) {
-        String title = NotificationMessage.APPROVAL_FINALLY_APPROVED.getTitle();
-        String content = NotificationMessage.APPROVAL_FINALLY_APPROVED.formatContent(docTitle);
-
-        // 1. 기안자에게 알림
-        doCreateNotification(
-                drafterId,
-                title,
-                content,
-                NotificationMessage.APPROVAL_FINALLY_APPROVED,
-                NotificationDomainType.APPROVAL,
-                approvalId,
-                null,
-                false);
-        eventPublisher.publishEvent(
-                new FcmSendEvent(
-                        drafterId,
-                        title,
-                        content,
-                        buildFcmData(NotificationDomainType.APPROVAL, approvalId)));
-
-        // 2. 열람권자들에게 알림
-        for (Long viewerId : viewerIds) {
-            doCreateNotification(
-                    viewerId,
-                    title,
-                    content,
-                    NotificationMessage.APPROVAL_FINALLY_APPROVED,
-                    NotificationDomainType.APPROVAL,
-                    approvalId,
-                    null,
-                    false);
-            eventPublisher.publishEvent(
-                    new FcmSendEvent(
-                            viewerId,
-                            title,
-                            content,
-                            buildFcmData(NotificationDomainType.APPROVAL, approvalId)));
+        /**
+         * Admin/MasterAdmin 유저 전체에게 FCM 알림 전송 + Notification 저장
+         *
+         * @param template   알림 메시지 템플릿
+         * @param domainType 생성할 알림의 도메인 타입
+         * @param domainId   생성할 알림의 도메인 ID (선택)
+         * @param args       템플릿 포맷팅에 사용할 인자
+         */
+        @Transactional
+        public void sendAlertToAdmins(
+                        NotificationMessage template,
+                        NotificationDomainType domainType,
+                        Long domainId,
+                        Object... args) {
+                sendAlertToAdmins(template, domainType, domainId, null, args);
         }
 
-        log.info(
-                "전자결재 최종 승인 알림 전송 - approvalId: {}, drafterId: {}, viewers: {}명",
-                approvalId,
-                drafterId,
-                viewerIds.size());
-    }
-
-    /**
-     * 안전보건교육 세션 생성 시 대상 유저 전체에게 FCM 알림 전송 + Notification 저장
-     *
-     * @param sessionId 생성된 세션 ID (domainId로 저장)
-     * @param sessionTitle 세션 제목
-     * @param targetUserIds 알림을 받을 유저 ID 목록
-     */
-    @Transactional
-    public void sendSafetyTrainingSessionAlertToAttendees(
-            Long sessionId, String sessionTitle, List<Long> targetUserIds) {
-        if (targetUserIds == null || targetUserIds.isEmpty()) {
-            log.info("안전보건교육 알림 전송 건너뜀 - 대상 없음, sessionId: {}", sessionId);
-            return;
+        @Transactional
+        public void sendAlertToAdmins(
+                        NotificationMessage template,
+                        NotificationDomainType domainType,
+                        Long domainId,
+                        Map<String, Object> metadata,
+                        Object... args) {
+                sendAlertToAdminsInternal(template, domainType, domainId, metadata, false, args);
         }
 
-        String title = NotificationMessage.SAFETY_TRAINING_SESSION_CREATED.getTitle();
-        String content =
-                NotificationMessage.SAFETY_TRAINING_SESSION_CREATED.formatContent(sessionTitle);
-        Map<String, Object> metadata = Map.of("educationType", "SAFETY", "detailType", "SESSION");
-
-        for (Long userId : targetUserIds) {
-            doCreateNotification(
-                    userId,
-                    title,
-                    content,
-                    NotificationMessage.SAFETY_TRAINING_SESSION_CREATED,
-                    NotificationDomainType.SAFETY_TRAINING,
-                    sessionId,
-                    metadata,
-                    false);
-            eventPublisher.publishEvent(
-                    new FcmSendEvent(
-                            userId,
-                            title,
-                            content,
-                            buildFcmData(
-                                    NotificationDomainType.SAFETY_TRAINING, sessionId, metadata)));
+        @Transactional
+        public void sendAlertToAdminsRequiringApproval(
+                        NotificationMessage template,
+                        NotificationDomainType domainType,
+                        Long domainId,
+                        Map<String, Object> metadata,
+                        Object... args) {
+                sendAlertToAdminsInternal(template, domainType, domainId, metadata, true, args);
         }
 
-        log.info("안전보건교육 세션 알림 전송 완료 - sessionId: {}, 대상 수: {}", sessionId, targetUserIds.size());
-    }
+        private void sendAlertToAdminsInternal(
+                        NotificationMessage template,
+                        NotificationDomainType domainType,
+                        Long domainId,
+                        Map<String, Object> metadata,
+                        boolean requiresApproval,
+                        Object... args) {
+                String title = template.getTitle();
+                String content = template.formatContent(args);
 
-    private Map<String, String> buildFcmData(NotificationDomainType domainType, Long domainId) {
-        return buildFcmData(domainType, domainId, null);
-    }
+                List<User> admins = userRepository.findAllByRole(Role.ADMIN);
+                admins.addAll(userRepository.findAllByRole(Role.MASTER_ADMIN));
 
-    private Map<String, String> buildFcmData(
-            NotificationDomainType domainType, Long domainId, Map<String, Object> metadata) {
-        Map<String, String> data = new HashMap<>();
-        data.put("domainType", domainType.name());
-        data.put("domainId", domainId != null ? domainId.toString() : "");
-        if (metadata != null && !metadata.isEmpty()) {
-            try {
-                data.put("metadata", objectMapper.writeValueAsString(metadata));
-            } catch (JsonProcessingException e) {
-                log.error("FCM metadata 직렬화 실패", e);
-            }
+                for (User admin : admins) {
+                        // 1. 알림함 저장
+                        doCreateNotification(
+                                        admin.getId(),
+                                        title,
+                                        content,
+                                        template,
+                                        domainType,
+                                        domainId,
+                                        metadata,
+                                        requiresApproval);
+
+                        // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
+                        eventPublisher.publishEvent(
+                                        new FcmSendEvent(
+                                                        admin.getId(),
+                                                        title,
+                                                        content,
+                                                        buildFcmData(domainType, domainId, metadata)));
+                }
+
+                log.info("관리자 그룹 알림 전송 완료 - 대상 Admin 수: {}, 템플릿: {}", admins.size(), template.name());
         }
-        return data;
-    }
+
+        /**
+         * 특정 단일 유저에게 FCM 알림 전송 + Notification 저장
+         *
+         * @param userId     수신 유저 ID
+         * @param template   알림 메시지 템플릿
+         * @param domainType 생성할 알림의 도메인 타입
+         * @param domainId   생성할 알림의 도메인 ID
+         * @param args       템플릿 포맷팅에 사용할 인자
+         */
+        @Transactional
+        public void sendAlertToUser(
+                        Long userId,
+                        NotificationMessage template,
+                        NotificationDomainType domainType,
+                        Long domainId,
+                        Object... args) {
+                sendAlertToUser(userId, template, domainType, domainId, null, args);
+        }
+
+        @Transactional
+        public void sendAlertToUser(
+                        Long userId,
+                        NotificationMessage template,
+                        NotificationDomainType domainType,
+                        Long domainId,
+                        Map<String, Object> metadata,
+                        Object... args) {
+                String title = template.getTitle();
+                String content = template.formatContent(args);
+
+                // 1. 알림함 저장
+                doCreateNotification(
+                                userId, title, content, template, domainType, domainId, metadata, false);
+
+                // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
+                eventPublisher.publishEvent(
+                                new FcmSendEvent(
+                                                userId, title, content, buildFcmData(domainType, domainId, metadata)));
+
+                log.info("단일 유저 알림 전송 완료 - userId: {}, 템플릿: {}", userId, template.name());
+        }
+
+        /**
+         * 공지사항 등록 시 대상 유저 전체에게 FCM 알림 전송 + Notification 저장
+         *
+         * @param noticeTitle   등록된 공지사항 제목
+         * @param noticeId      등록된 공지사항 ID (알림 domainId로 저장)
+         * @param targetUserIds 알림을 받을 유저 ID 집합
+         */
+        @Transactional
+        public void sendNoticeAlertToTargets(
+                        String noticeTitle, Long noticeId, Set<Long> targetUserIds) {
+                if (targetUserIds == null || targetUserIds.isEmpty()) {
+                        log.info("공지 알림 전송 건너뜀 - 대상 없음, noticeId: {}", noticeId);
+                        return;
+                }
+
+                String title = NotificationMessage.NOTICE_CREATED.getTitle();
+                String content = NotificationMessage.NOTICE_CREATED.formatContent(noticeTitle);
+
+                for (Long userId : targetUserIds) {
+                        // 1. 알림함 저장
+                        doCreateNotification(
+                                        userId,
+                                        title,
+                                        content,
+                                        NotificationMessage.NOTICE_CREATED,
+                                        NotificationDomainType.NOTICE,
+                                        noticeId,
+                                        null,
+                                        false);
+
+                        // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
+                        eventPublisher.publishEvent(
+                                        new FcmSendEvent(
+                                                        userId,
+                                                        title,
+                                                        content,
+                                                        buildFcmData(NotificationDomainType.NOTICE, noticeId)));
+                }
+
+                log.info("공지 알림 전송 완료 - noticeId: {}, 대상 수: {}", noticeId, targetUserIds.size());
+        }
+
+        /**
+         * 교육(EduReport) 등록 시 대상 유저 전체에게 FCM 알림 전송 + Notification 저장
+         *
+         * @param eduTypeLabel  교육 유형 라벨 (예: SAFETY, PSM, 부서명 등)
+         * @param eduTitle      등록된 교육 제목
+         * @param reportId      등록된 교육 ID (알림 domainId로 저장)
+         * @param targetUserIds 알림을 받을 유저 ID 집합 (리스트 형태)
+         */
+        @Transactional
+        public void sendEduReportAlertToTargets(
+                        String eduTypeLabel, String eduTitle, Long reportId, List<Long> targetUserIds) {
+                sendEduReportAlertToTargets(eduTypeLabel, eduTitle, reportId, targetUserIds, null);
+        }
+
+        @Transactional
+        public void sendEduReportAlertToTargets(
+                        String eduTypeLabel,
+                        String eduTitle,
+                        Long reportId,
+                        List<Long> targetUserIds,
+                        Map<String, Object> metadata) {
+                if (targetUserIds == null || targetUserIds.isEmpty()) {
+                        log.info("교육 알림 전송 건너뜀 - 대상 없음, reportId: {}", reportId);
+                        return;
+                }
+
+                String title = NotificationMessage.EDU_REPORT_CREATED.getTitle();
+                String content = NotificationMessage.EDU_REPORT_CREATED.formatContent(eduTypeLabel, eduTitle);
+
+                for (Long userId : targetUserIds) {
+                        // 1. 알림함 저장
+                        doCreateNotification(
+                                        userId,
+                                        title,
+                                        content,
+                                        NotificationMessage.EDU_REPORT_CREATED,
+                                        NotificationDomainType.EDUCATION,
+                                        reportId,
+                                        metadata,
+                                        false);
+
+                        // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
+                        eventPublisher.publishEvent(
+                                        new FcmSendEvent(
+                                                        userId,
+                                                        title,
+                                                        content,
+                                                        buildFcmData(NotificationDomainType.EDUCATION, reportId,
+                                                                        metadata)));
+                }
+
+                log.info("교육 알림 전송 완료 - reportId: {}, 대상 수: {}", reportId, targetUserIds.size());
+        }
+
+        /**
+         * 방문 이벤트(사전 예약/입실) 발생 시 host 담당 부서 소속 전원에게 FCM 알림 전송 + Notification 저장
+         *
+         * @param template         알림 메시지 템플릿
+         * @param visitId          방문 ID (domainId로 저장)
+         * @param hostDepartmentId host 직원의 부서 ID
+         * @param contentArgs      템플릿 포맷팅에 사용할 인자
+         */
+        @Transactional
+        public void sendVisitAlertToDepartment(
+                        NotificationMessage template,
+                        Long visitId,
+                        Long hostDepartmentId,
+                        Object... contentArgs) {
+                sendVisitAlertToDepartment(template, visitId, hostDepartmentId, null, contentArgs);
+        }
+
+        @Transactional
+        public void sendVisitAlertToDepartment(
+                        NotificationMessage template,
+                        Long visitId,
+                        Long hostDepartmentId,
+                        Map<String, Object> metadata,
+                        Object... contentArgs) {
+                List<Long> targetUserIds = userRepository.findAllIdsByDepartmentId(hostDepartmentId);
+
+                if (targetUserIds.isEmpty()) {
+                        log.info("방문 알림 전송 건너뜀 - 대상 없음, visitId: {}", visitId);
+                        return;
+                }
+
+                String title = template.getTitle();
+                String content = template.formatContent(contentArgs);
+                boolean requiresApproval = metadata != null && Boolean.TRUE.equals(metadata.get("isApprovalTarget"));
+
+                for (Long userId : targetUserIds) {
+                        // 1. 알림함 저장
+                        doCreateNotification(
+                                        userId,
+                                        title,
+                                        content,
+                                        template,
+                                        NotificationDomainType.VISIT,
+                                        visitId,
+                                        metadata,
+                                        requiresApproval);
+
+                        // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
+                        eventPublisher.publishEvent(
+                                        new FcmSendEvent(
+                                                        userId,
+                                                        title,
+                                                        content,
+                                                        buildFcmData(NotificationDomainType.VISIT, visitId, metadata)));
+                }
+
+                log.info(
+                                "방문 알림 전송 완료 - visitId: {}, 대상 수: {}, 템플릿: {}",
+                                visitId,
+                                targetUserIds.size(),
+                                template.name());
+        }
+
+        /**
+         * 연차 갱신/등록 시 단일 유저에게 알림 전송
+         *
+         * @param userId            알림 대상 유저 ID
+         * @param baseDateFormatted 포맷팅된 기준일 문자열 (예: "2025년 08월 01일")
+         */
+        @Transactional
+        public void sendAnnualLeaveAlertToUser(Long userId, String baseDateFormatted) {
+                NotificationMessage template = NotificationMessage.ANNUAL_LEAVE_UPDATED;
+                String title = template.getTitle();
+                String content = template.formatContent(baseDateFormatted);
+
+                // 1. 알림함 DB 저장 (domainId는 단일 엔티티 연차 특성상 null 처리)
+                doCreateNotification(
+                                userId,
+                                title,
+                                content,
+                                template,
+                                NotificationDomainType.ANNUAL_LEAVE,
+                                null,
+                                null,
+                                false);
+
+                // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
+                eventPublisher.publishEvent(
+                                new FcmSendEvent(
+                                                userId,
+                                                title,
+                                                content,
+                                                buildFcmData(NotificationDomainType.ANNUAL_LEAVE, null)));
+
+                log.info("연차 알림 전송 완료 - userId: {}, 기준일: {}", userId, baseDateFormatted);
+        }
+
+        /**
+         * 급여명세서 발송 시 단일 유저에게 알림 전송
+         *
+         * @param userId    알림 대상 유저 ID
+         * @param payslipId 발송된 Payslip ID (domainId로 저장)
+         */
+        @Transactional
+        public void sendPayslipAlertToUser(Long userId, Long payslipId) {
+                NotificationMessage template = NotificationMessage.PAYSLIP_SENT;
+                String title = template.getTitle();
+                String content = template.formatContent();
+
+                // 1. 알림함 DB 저장
+                doCreateNotification(
+                                userId,
+                                title,
+                                content,
+                                template,
+                                NotificationDomainType.PAYSLIP,
+                                payslipId,
+                                null,
+                                false);
+
+                // 2. FCM 이벤트 발행 (트랜잭션 커밋 후 비동기 발송)
+                eventPublisher.publishEvent(
+                                new FcmSendEvent(
+                                                userId,
+                                                title,
+                                                content,
+                                                buildFcmData(NotificationDomainType.PAYSLIP, payslipId)));
+
+                log.info("급여명세서 알림 전송 완료 - userId: {}, payslipId: {}", userId, payslipId);
+        }
+
+        /**
+         * 전자결재 생성 시 첫 번째 결재자와 참조자(REFERRER)에게 알림 전송
+         *
+         * @param approvalId      결재 문서 ID
+         * @param docTitle        결재 문서 제목
+         * @param firstApproverId 첫 번째 결재자 유저 ID
+         * @param referrerIds     참조자(REFERRER) 유저 ID 목록
+         */
+        @Transactional
+        public void sendApprovalCreatedAlert(
+                        Long approvalId, String docTitle, Long firstApproverId, List<Long> referrerIds) {
+
+                // 1. 첫 번째 결재자에게 알림
+                String approverTitle = NotificationMessage.APPROVAL_CREATED_APPROVER.getTitle();
+                String approverContent = NotificationMessage.APPROVAL_CREATED_APPROVER.formatContent(docTitle);
+                doCreateNotification(
+                                firstApproverId,
+                                approverTitle,
+                                approverContent,
+                                NotificationMessage.APPROVAL_CREATED_APPROVER,
+                                NotificationDomainType.APPROVAL,
+                                approvalId,
+                                null,
+                                true);
+                eventPublisher.publishEvent(
+                                new FcmSendEvent(
+                                                firstApproverId,
+                                                approverTitle,
+                                                approverContent,
+                                                buildFcmData(NotificationDomainType.APPROVAL, approvalId)));
+                log.info(
+                                "전자결재 생성 알림(결재자) 전송 - approvalId: {}, approverId: {}", approvalId, firstApproverId);
+
+                // 2. 참조자들에게 알림
+                String referrerTitle = NotificationMessage.APPROVAL_CREATED_REFERRER.getTitle();
+                String referrerContent = NotificationMessage.APPROVAL_CREATED_REFERRER.formatContent(docTitle);
+                for (Long referrerId : referrerIds) {
+                        doCreateNotification(
+                                        referrerId,
+                                        referrerTitle,
+                                        referrerContent,
+                                        NotificationMessage.APPROVAL_CREATED_REFERRER,
+                                        NotificationDomainType.APPROVAL,
+                                        approvalId,
+                                        null,
+                                        false);
+                        eventPublisher.publishEvent(
+                                        new FcmSendEvent(
+                                                        referrerId,
+                                                        referrerTitle,
+                                                        referrerContent,
+                                                        buildFcmData(NotificationDomainType.APPROVAL, approvalId)));
+                }
+                log.info("전자결재 생성 알림(참조자 {}명) 전송 완료 - approvalId: {}", referrerIds.size(), approvalId);
+        }
+
+        /**
+         * N번째 결재자가 승인 시 N+1번째 결재자에게 알림 전송
+         *
+         * @param nextApproverId 다음 결재자 유저 ID
+         * @param approvalId     결재 문서 ID
+         * @param docTitle       결재 문서 제목
+         */
+        @Transactional
+        public void sendApprovalNextStepAlert(Long nextApproverId, Long approvalId, String docTitle) {
+                String title = NotificationMessage.APPROVAL_CREATED_APPROVER.getTitle();
+                String content = NotificationMessage.APPROVAL_CREATED_APPROVER.formatContent(docTitle);
+
+                doCreateNotification(
+                                nextApproverId,
+                                title,
+                                content,
+                                NotificationMessage.APPROVAL_CREATED_APPROVER,
+                                NotificationDomainType.APPROVAL,
+                                approvalId,
+                                null,
+                                true);
+                eventPublisher.publishEvent(
+                                new FcmSendEvent(
+                                                nextApproverId,
+                                                title,
+                                                content,
+                                                buildFcmData(NotificationDomainType.APPROVAL, approvalId)));
+
+                log.info(
+                                "전자결재 다음 결재자 알림 전송 - approvalId: {}, nextApproverId: {}",
+                                approvalId,
+                                nextApproverId);
+        }
+
+        /**
+         * 전자결재 반려 시 기안자에게 사유와 함께 알림 전송
+         *
+         * @param drafterId  기안자 유저 ID
+         * @param approvalId 결재 문서 ID
+         * @param docTitle   결재 문서 제목
+         * @param comment    반려 사유
+         */
+        @Transactional
+        public void sendApprovalRejectedAlert(
+                        Long drafterId, Long approvalId, String docTitle, String comment) {
+                String title = NotificationMessage.APPROVAL_REJECTED.getTitle();
+                String content = NotificationMessage.APPROVAL_REJECTED.formatContent(docTitle, comment);
+
+                doCreateNotification(
+                                drafterId,
+                                title,
+                                content,
+                                NotificationMessage.APPROVAL_REJECTED,
+                                NotificationDomainType.APPROVAL,
+                                approvalId,
+                                null,
+                                false);
+                eventPublisher.publishEvent(
+                                new FcmSendEvent(
+                                                drafterId,
+                                                title,
+                                                content,
+                                                buildFcmData(NotificationDomainType.APPROVAL, approvalId)));
+
+                log.info("전자결재 반려 알림 전송 - approvalId: {}, drafterId: {}", approvalId, drafterId);
+        }
+
+        /**
+         * 전자결재 최종 승인 시 기안자와 열람권자(VIEWER)에게 알림 전송
+         *
+         * @param approvalId 결재 문서 ID
+         * @param docTitle   결재 문서 제목
+         * @param drafterId  기안자 유저 ID
+         * @param viewerIds  열람권자(VIEWER) 유저 ID 목록
+         */
+        @Transactional
+        public void sendApprovalFinallyApprovedAlert(
+                        Long approvalId, String docTitle, Long drafterId, List<Long> viewerIds) {
+                String title = NotificationMessage.APPROVAL_FINALLY_APPROVED.getTitle();
+                String content = NotificationMessage.APPROVAL_FINALLY_APPROVED.formatContent(docTitle);
+
+                // 1. 기안자에게 알림
+                doCreateNotification(
+                                drafterId,
+                                title,
+                                content,
+                                NotificationMessage.APPROVAL_FINALLY_APPROVED,
+                                NotificationDomainType.APPROVAL,
+                                approvalId,
+                                null,
+                                false);
+                eventPublisher.publishEvent(
+                                new FcmSendEvent(
+                                                drafterId,
+                                                title,
+                                                content,
+                                                buildFcmData(NotificationDomainType.APPROVAL, approvalId)));
+
+                // 2. 열람권자들에게 알림
+                for (Long viewerId : viewerIds) {
+                        doCreateNotification(
+                                        viewerId,
+                                        title,
+                                        content,
+                                        NotificationMessage.APPROVAL_FINALLY_APPROVED,
+                                        NotificationDomainType.APPROVAL,
+                                        approvalId,
+                                        null,
+                                        false);
+                        eventPublisher.publishEvent(
+                                        new FcmSendEvent(
+                                                        viewerId,
+                                                        title,
+                                                        content,
+                                                        buildFcmData(NotificationDomainType.APPROVAL, approvalId)));
+                }
+
+                log.info(
+                                "전자결재 최종 승인 알림 전송 - approvalId: {}, drafterId: {}, viewers: {}명",
+                                approvalId,
+                                drafterId,
+                                viewerIds.size());
+        }
+
+        /**
+         * 안전보건교육 세션 생성 시 대상 유저 전체에게 FCM 알림 전송 + Notification 저장
+         *
+         * @param sessionId     생성된 세션 ID (domainId로 저장)
+         * @param sessionTitle  세션 제목
+         * @param targetUserIds 알림을 받을 유저 ID 목록
+         */
+        @Transactional
+        public void sendSafetyTrainingSessionAlertToAttendees(
+                        Long sessionId, String sessionTitle, List<Long> targetUserIds) {
+                if (targetUserIds == null || targetUserIds.isEmpty()) {
+                        log.info("안전보건교육 알림 전송 건너뜀 - 대상 없음, sessionId: {}", sessionId);
+                        return;
+                }
+
+                String title = NotificationMessage.SAFETY_TRAINING_SESSION_CREATED.getTitle();
+                String content = NotificationMessage.SAFETY_TRAINING_SESSION_CREATED.formatContent(sessionTitle);
+                Map<String, Object> metadata = Map.of("educationType", "SAFETY", "detailType", "SESSION");
+
+                for (Long userId : targetUserIds) {
+                        doCreateNotification(
+                                        userId,
+                                        title,
+                                        content,
+                                        NotificationMessage.SAFETY_TRAINING_SESSION_CREATED,
+                                        NotificationDomainType.SAFETY_TRAINING,
+                                        sessionId,
+                                        metadata,
+                                        false);
+                        eventPublisher.publishEvent(
+                                        new FcmSendEvent(
+                                                        userId,
+                                                        title,
+                                                        content,
+                                                        buildFcmData(
+                                                                        NotificationDomainType.SAFETY_TRAINING,
+                                                                        sessionId, metadata)));
+                }
+
+                log.info("안전보건교육 세션 알림 전송 완료 - sessionId: {}, 대상 수: {}", sessionId, targetUserIds.size());
+        }
+
+        /**
+         * 교육(EduReport) 리마인드 알림 - 대상 유저 전체에게 FCM 알림 전송 + Notification 저장
+         */
+        @Transactional
+        public void sendEduReportRemindAlertToTargets(
+                        String eduTypeLabel, String eduTitle, Long reportId, List<Long> targetUserIds) {
+                sendEduReportRemindAlertToTargets(eduTypeLabel, eduTitle, reportId, targetUserIds, null);
+        }
+
+        @Transactional
+        public void sendEduReportRemindAlertToTargets(
+                        String eduTypeLabel,
+                        String eduTitle,
+                        Long reportId,
+                        List<Long> targetUserIds,
+                        Map<String, Object> metadata) {
+                if (targetUserIds == null || targetUserIds.isEmpty()) {
+                        log.info("교육 리마인드 알림 전송 건너뜀 - 대상 없음, reportId: {}", reportId);
+                        return;
+                }
+
+                String title = "[리마인드] " + NotificationMessage.EDU_REPORT_CREATED.getTitle();
+                String content = NotificationMessage.EDU_REPORT_CREATED.formatContent(eduTypeLabel, eduTitle);
+
+                for (Long userId : targetUserIds) {
+                        doCreateNotification(
+                                        userId,
+                                        title,
+                                        content,
+                                        NotificationMessage.EDU_REPORT_CREATED,
+                                        NotificationDomainType.EDUCATION,
+                                        reportId,
+                                        metadata,
+                                        false);
+                        eventPublisher.publishEvent(
+                                        new FcmSendEvent(
+                                                        userId,
+                                                        title,
+                                                        content,
+                                                        buildFcmData(NotificationDomainType.EDUCATION, reportId,
+                                                                        metadata)));
+                }
+
+                log.info("교육 리마인드 알림 전송 완료 - reportId: {}, 대상 수: {}", reportId, targetUserIds.size());
+        }
+
+        /**
+         * 안전보건교육 세션 리마인드 알림 - 대상 유저 전체에게 FCM 알림 전송 + Notification 저장
+         */
+        @Transactional
+        public void sendSafetyTrainingSessionRemindAlertToAttendees(
+                        Long sessionId, String sessionTitle, List<Long> targetUserIds) {
+                if (targetUserIds == null || targetUserIds.isEmpty()) {
+                        log.info("안전보건교육 리마인드 알림 전송 건너뜀 - 대상 없음, sessionId: {}", sessionId);
+                        return;
+                }
+
+                String title = "[리마인드] " + NotificationMessage.SAFETY_TRAINING_SESSION_CREATED.getTitle();
+                String content = NotificationMessage.SAFETY_TRAINING_SESSION_CREATED.formatContent(sessionTitle);
+                Map<String, Object> metadata = Map.of("educationType", "SAFETY", "detailType", "SESSION");
+
+                for (Long userId : targetUserIds) {
+                        doCreateNotification(
+                                        userId,
+                                        title,
+                                        content,
+                                        NotificationMessage.SAFETY_TRAINING_SESSION_CREATED,
+                                        NotificationDomainType.SAFETY_TRAINING,
+                                        sessionId,
+                                        metadata,
+                                        false);
+                        eventPublisher.publishEvent(
+                                        new FcmSendEvent(
+                                                        userId,
+                                                        title,
+                                                        content,
+                                                        buildFcmData(
+                                                                        NotificationDomainType.SAFETY_TRAINING,
+                                                                        sessionId, metadata)));
+                }
+
+                log.info("안전보건교육 세션 리마인드 알림 전송 완료 - sessionId: {}, 대상 수: {}", sessionId, targetUserIds.size());
+        }
+
+        private Map<String, String> buildFcmData(NotificationDomainType domainType, Long domainId) {
+                return buildFcmData(domainType, domainId, null);
+        }
+
+        private Map<String, String> buildFcmData(
+                        NotificationDomainType domainType, Long domainId, Map<String, Object> metadata) {
+                Map<String, String> data = new HashMap<>();
+                data.put("domainType", domainType.name());
+                data.put("domainId", domainId != null ? domainId.toString() : "");
+                if (metadata != null && !metadata.isEmpty()) {
+                        try {
+                                data.put("metadata", objectMapper.writeValueAsString(metadata));
+                        } catch (JsonProcessingException e) {
+                                log.error("FCM metadata 직렬화 실패", e);
+                        }
+                }
+                return data;
+        }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/controller/SafetyTrainingSessionController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/controller/SafetyTrainingSessionController.java
@@ -795,19 +795,26 @@ public class SafetyTrainingSessionController {
 
     @Operation(
             summary = "안전보건 교육일지 리마인드 알림 전송",
-            description = """
+            description =
+                    """
                     교육 생성자(createdBy)만 요청 가능합니다.
 
                     - companyScope 기준 현재 활성 사용자에게 `[리마인드]` prefix를 붙여 알림을 재전송합니다.
                     """)
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "전송 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "403",
-                    description = "권한 없음 (교육일지 생성자가 아님)",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "전송 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "403",
+                description = "권한 없음 (교육일지 생성자가 아님)",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                                     {
                                       "isSuccess": false,
                                       "code": "NO_AUTHORITY_FOR_SAFETY_WRITE",
@@ -815,12 +822,16 @@ public class SafetyTrainingSessionController {
                                       "result": null
                                     }
                                     """))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "404",
-                    description = "교육일지 없음",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "교육일지 없음",
+                content =
+                        @Content(
+                                mediaType = "application/json",
+                                examples =
+                                        @ExampleObject(
+                                                value =
+                                                        """
                                     {
                                       "isSuccess": false,
                                       "code": "SAFETY_TRAINING_SESSION_NOT_FOUND",
@@ -831,7 +842,8 @@ public class SafetyTrainingSessionController {
     })
     @PostMapping("/{sessionId}/remind")
     public ResponseEntity<ApiResponse<Void>> remindSession(
-            @Parameter(description = "리마인드 알림을 전송할 교육일지 ID", example = "1") @PathVariable Long sessionId,
+            @Parameter(description = "리마인드 알림을 전송할 교육일지 ID", example = "1") @PathVariable
+                    Long sessionId,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         safetyTrainingSessionService.remindSession(sessionId, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onNoContent());

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/controller/SafetyTrainingSessionController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/controller/SafetyTrainingSessionController.java
@@ -792,4 +792,48 @@ public class SafetyTrainingSessionController {
         Long sessionId = safetyTrainingSessionService.create(userDetails.getId(), requestDto);
         return ResponseEntity.ok(ApiResponse.onSuccess(sessionId));
     }
+
+    @Operation(
+            summary = "안전보건 교육일지 리마인드 알림 전송",
+            description = """
+                    교육 생성자(createdBy)만 요청 가능합니다.
+
+                    - companyScope 기준 현재 활성 사용자에게 `[리마인드]` prefix를 붙여 알림을 재전송합니다.
+                    """)
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "전송 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "권한 없음 (교육일지 생성자가 아님)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "NO_AUTHORITY_FOR_SAFETY_WRITE",
+                                      "message": "안전 보건 관리 권한이 없습니다.",
+                                      "result": null
+                                    }
+                                    """))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "교육일지 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "SAFETY_TRAINING_SESSION_NOT_FOUND",
+                                      "message": "해당 안전보건 교육일지를 찾을 수 없습니다.",
+                                      "result": null
+                                    }
+                                    """)))
+    })
+    @PostMapping("/{sessionId}/remind")
+    public ResponseEntity<ApiResponse<Void>> remindSession(
+            @Parameter(description = "리마인드 알림을 전송할 교육일지 ID", example = "1") @PathVariable Long sessionId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        safetyTrainingSessionService.remindSession(sessionId, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onNoContent());
+    }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
@@ -55,934 +55,889 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class SafetyTrainingSessionService {
 
-    private static final DateTimeFormatter DATE_TIME_TEXT_FORMATTER =
-            DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH시 mm분");
-    private static final DateTimeFormatter FILE_DATE_FORMATTER =
-            DateTimeFormatter.ofPattern("yyyyMMdd");
+        private static final DateTimeFormatter DATE_TIME_TEXT_FORMATTER = DateTimeFormatter
+                        .ofPattern("yyyy년 MM월 dd일 HH시 mm분");
+        private static final DateTimeFormatter FILE_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
 
-    private final SafetyTrainingSessionRepository sessionRepository;
-    private final SafetyTrainingSessionAttendeeRepository attendeeRepository;
-    private final UserRepository userRepository;
-    private final ObjectMapper objectMapper;
-    private final SafetyTrainingExcelService safetyTrainingExcelService;
-    private final S3Service s3Service;
-    private final NotificationService notificationService;
+        private final SafetyTrainingSessionRepository sessionRepository;
+        private final SafetyTrainingSessionAttendeeRepository attendeeRepository;
+        private final UserRepository userRepository;
+        private final ObjectMapper objectMapper;
+        private final SafetyTrainingExcelService safetyTrainingExcelService;
+        private final S3Service s3Service;
+        private final NotificationService notificationService;
 
-    @Transactional(readOnly = true)
-    public SafetyTrainingPreviewResponseDto preview(
-            Long userId, SafetyTrainingSessionCreateRequestDto requestDto) {
-        User actor =
-                userRepository
-                        .findById(userId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        validateSafetyWriteAuthority(actor);
-        validateTimeRange(requestDto.getStartAt(), requestDto.getEndAt());
+        @Transactional(readOnly = true)
+        public SafetyTrainingPreviewResponseDto preview(
+                        Long userId, SafetyTrainingSessionCreateRequestDto requestDto) {
+                User actor = userRepository
+                                .findById(userId)
+                                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                validateSafetyWriteAuthority(actor);
+                validateTimeRange(requestDto.getStartAt(), requestDto.getEndAt());
 
-        User instructor = findAndValidateInstructor(requestDto.getInstructorUserId());
-        List<User> attendees = findTargetAttendees(requestDto.getCompanyScope());
-        String educationDateText =
-                toEducationDateText(requestDto.getStartAt(), requestDto.getEndAt());
+                User instructor = findAndValidateInstructor(requestDto.getInstructorUserId());
+                List<User> attendees = findTargetAttendees(requestDto.getCompanyScope());
+                String educationDateText = toEducationDateText(requestDto.getStartAt(), requestDto.getEndAt());
 
-        byte[] excelBytes =
-                safetyTrainingExcelService.buildPreviewExcel(
-                        requestDto, educationDateText, attendees, instructor.getNameKor());
+                byte[] excelBytes = safetyTrainingExcelService.buildPreviewExcel(
+                                requestDto, educationDateText, attendees, instructor.getNameKor());
 
-        String previewFileKey =
-                s3Service.uploadBytes(
-                        excelBytes,
-                        "safety-training-preview-" + System.currentTimeMillis() + ".xlsx",
-                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-        String previewFileName =
-                buildExportFileName(requestDto.getStartAt(), requestDto.getTitle());
-        String previewUrl = s3Service.getPresignedDownloadUrl(previewFileKey, previewFileName);
+                String previewFileKey = s3Service.uploadBytes(
+                                excelBytes,
+                                "safety-training-preview-" + System.currentTimeMillis() + ".xlsx",
+                                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+                String previewFileName = buildExportFileName(requestDto.getStartAt(), requestDto.getTitle());
+                String previewUrl = s3Service.getPresignedDownloadUrl(previewFileKey, previewFileName);
 
-        return SafetyTrainingPreviewResponseDto.builder()
-                .previewFileUrl(previewUrl)
-                .previewFileName(previewFileName)
-                .targetCount(attendees.size())
-                .attendedCount(0)
-                .absentCount(0)
-                .build();
-    }
-
-    @Transactional
-    public Long create(Long userId, SafetyTrainingSessionCreateRequestDto requestDto) {
-        User actor =
-                userRepository
-                        .findById(userId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        validateSafetyWriteAuthority(actor);
-        validateTimeRange(requestDto.getStartAt(), requestDto.getEndAt());
-
-        User instructor = findAndValidateInstructor(requestDto.getInstructorUserId());
-
-        String methodsJson = toMethodsJson(requestDto.getEducationMethods());
-        String educationDateText =
-                toEducationDateText(requestDto.getStartAt(), requestDto.getEndAt());
-
-        SafetyTrainingSession session =
-                SafetyTrainingSession.builder()
-                        .title(requestDto.getTitle().trim())
-                        .educationType(requestDto.getEducationType())
-                        .educationMethodsJson(methodsJson)
-                        .startAt(requestDto.getStartAt())
-                        .endAt(requestDto.getEndAt())
-                        .educationDateText(educationDateText)
-                        .educationContent(requestDto.getEducationContent())
-                        .place(requestDto.getPlace().trim())
-                        .companyScope(requestDto.getCompanyScope())
-                        .instructorUser(instructor)
-                        .instructorNameSnapshot(instructor.getNameKor())
-                        .createdBy(actor)
-                        .build();
-
-        SafetyTrainingSession saved = sessionRepository.save(session);
-
-        List<User> attendees = findTargetAttendees(requestDto.getCompanyScope());
-
-        List<SafetyTrainingSessionAttendee> rows =
-                attendees.stream()
-                        .map(
-                                user ->
-                                        SafetyTrainingSessionAttendee.builder()
-                                                .session(saved)
-                                                .user(user)
-                                                .status(SafetyTrainingAttendeeStatus.PENDING)
-                                                .build())
-                        .toList();
-
-        attendeeRepository.saveAll(rows);
-
-        saved.setTargetCount(rows.size());
-        saved.setAttendedCount(0);
-        saved.setAbsentCount(0);
-
-        // 안전보건교육 세션 생성 알림 전송
-        List<Long> attendeeIds = attendees.stream().map(User::getId).toList();
-        notificationService.sendSafetyTrainingSessionAlertToAttendees(
-                saved.getId(), saved.getTitle(), attendeeIds);
-
-        return saved.getId();
-    }
-
-    @Transactional(readOnly = true)
-    public Page<SafetyTrainingSessionSummaryResponseDto> getSessions(
-            Long userId, SafetyTrainingSessionSearchConditionDto condition, Pageable pageable) {
-        User actor =
-                userRepository
-                        .findById(userId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        SafetyTrainingSessionSearchConditionDto filter =
-                condition == null ? new SafetyTrainingSessionSearchConditionDto() : condition;
-
-        boolean canReadAllCompanies = actor.hasAuthority(Authority.MANAGE_SAFETY);
-        Company companyScope =
-                canReadAllCompanies ? filter.getCompanyScope() : actor.getWorkLocation();
-        SafetyTrainingSessionStatus status = canReadAllCompanies ? filter.getStatus() : null;
-
-        if (!canReadAllCompanies && companyScope == null) {
-            return Page.empty(pageable);
+                return SafetyTrainingPreviewResponseDto.builder()
+                                .previewFileUrl(previewUrl)
+                                .previewFileName(previewFileName)
+                                .targetCount(attendees.size())
+                                .attendedCount(0)
+                                .absentCount(0)
+                                .build();
         }
 
-        Page<SafetyTrainingSession> sessionsPage =
-                sessionRepository.findAllByFilters(
-                        companyScope,
-                        filter.getEducationType(),
-                        status,
-                        filter.getStartAtFrom(),
-                        filter.getStartAtTo(),
-                        filter.getNormalizedTitleKeyword(),
-                        pageable);
+        @Transactional
+        public Long create(Long userId, SafetyTrainingSessionCreateRequestDto requestDto) {
+                User actor = userRepository
+                                .findById(userId)
+                                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                validateSafetyWriteAuthority(actor);
+                validateTimeRange(requestDto.getStartAt(), requestDto.getEndAt());
 
-        List<Long> sessionIds =
-                sessionsPage.getContent().stream().map(SafetyTrainingSession::getId).toList();
-        Set<Long> signedSessionIds = Collections.emptySet();
-        if (!sessionIds.isEmpty() && canExposeMySigned(actor)) {
-            signedSessionIds =
-                    new HashSet<>(
-                            attendeeRepository.findSignedSessionIdsByUserIdAndSessionIds(
-                                    userId, sessionIds));
+                User instructor = findAndValidateInstructor(requestDto.getInstructorUserId());
+
+                String methodsJson = toMethodsJson(requestDto.getEducationMethods());
+                String educationDateText = toEducationDateText(requestDto.getStartAt(), requestDto.getEndAt());
+
+                SafetyTrainingSession session = SafetyTrainingSession.builder()
+                                .title(requestDto.getTitle().trim())
+                                .educationType(requestDto.getEducationType())
+                                .educationMethodsJson(methodsJson)
+                                .startAt(requestDto.getStartAt())
+                                .endAt(requestDto.getEndAt())
+                                .educationDateText(educationDateText)
+                                .educationContent(requestDto.getEducationContent())
+                                .place(requestDto.getPlace().trim())
+                                .companyScope(requestDto.getCompanyScope())
+                                .instructorUser(instructor)
+                                .instructorNameSnapshot(instructor.getNameKor())
+                                .createdBy(actor)
+                                .build();
+
+                SafetyTrainingSession saved = sessionRepository.save(session);
+
+                List<User> attendees = findTargetAttendees(requestDto.getCompanyScope());
+
+                List<SafetyTrainingSessionAttendee> rows = attendees.stream()
+                                .map(
+                                                user -> SafetyTrainingSessionAttendee.builder()
+                                                                .session(saved)
+                                                                .user(user)
+                                                                .status(SafetyTrainingAttendeeStatus.PENDING)
+                                                                .build())
+                                .toList();
+
+                attendeeRepository.saveAll(rows);
+
+                saved.setTargetCount(rows.size());
+                saved.setAttendedCount(0);
+                saved.setAbsentCount(0);
+
+                // 안전보건교육 세션 생성 알림 전송
+                List<Long> attendeeIds = attendees.stream().map(User::getId).toList();
+                notificationService.sendSafetyTrainingSessionAlertToAttendees(
+                                saved.getId(), saved.getTitle(), attendeeIds);
+
+                return saved.getId();
         }
 
-        Set<Long> finalSignedSessionIds = signedSessionIds;
-        return sessionsPage.map(
-                session ->
-                        toSummaryDto(
-                                session,
-                                resolveMySigned(
-                                        actor,
-                                        session,
-                                        finalSignedSessionIds.contains(session.getId()))));
-    }
+        @Transactional(readOnly = true)
+        public Page<SafetyTrainingSessionSummaryResponseDto> getSessions(
+                        Long userId, SafetyTrainingSessionSearchConditionDto condition, Pageable pageable) {
+                User actor = userRepository
+                                .findById(userId)
+                                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                SafetyTrainingSessionSearchConditionDto filter = condition == null
+                                ? new SafetyTrainingSessionSearchConditionDto()
+                                : condition;
 
-    @Transactional(readOnly = true)
-    public SafetyTrainingSessionDetailResponseDto getSessionDetail(Long sessionId, Long userId) {
-        User actor =
-                userRepository
-                        .findById(userId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                boolean canReadAllCompanies = actor.hasAuthority(Authority.MANAGE_SAFETY);
+                Company companyScope = canReadAllCompanies ? filter.getCompanyScope() : actor.getWorkLocation();
+                SafetyTrainingSessionStatus status = canReadAllCompanies ? filter.getStatus() : null;
 
-        SafetyTrainingSession session =
-                sessionRepository
-                        .findById(sessionId)
-                        .orElseThrow(
-                                () ->
-                                        new CustomException(
-                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
-
-        validateSessionReadAccess(actor, session);
-
-        SafetyTrainingSessionAttendee attendee =
-                attendeeRepository
-                        .findBySessionIdAndUserId(sessionId, userId)
-                        .orElse(
-                                SafetyTrainingSessionAttendee.builder()
-                                        .status(SafetyTrainingAttendeeStatus.PENDING)
-                                        .build());
-
-        SafetyTrainingAttendeeStatus myStatus = attendee.getStatus();
-        SafetyTrainingCompletionStatus completionStatus =
-                resolveMyCompletionStatus(actor, session, myStatus);
-
-        String reportFileUrl =
-                session.getReportFileKey() == null
-                        ? null
-                        : s3Service.getPresignedDownloadUrl(
-                                session.getReportFileKey(),
-                                buildExportFileName(session.getStartAt(), session.getTitle()));
-
-        SafetyTrainingSessionDetailResponseDto.SessionInfo prevSession =
-                findPrevSessionInfo(actor, session);
-        SafetyTrainingSessionDetailResponseDto.SessionInfo nextSession =
-                findNextSessionInfo(actor, session);
-
-        return SafetyTrainingSessionDetailResponseDto.builder()
-                .sessionId(session.getId())
-                .title(session.getTitle())
-                .authorName(
-                        session.getCreatedBy() == null
-                                ? null
-                                : session.getCreatedBy().getDisplayName())
-                .createdAt(session.getCreatedAt())
-                .educationType(session.getEducationType())
-                .educationMethods(toMethods(session.getEducationMethodsJson()))
-                .startAt(session.getStartAt())
-                .endAt(session.getEndAt())
-                .place(session.getPlace())
-                .companyScope(session.getCompanyScope())
-                .status(session.getStatus())
-                .instructorUserId(
-                        session.getInstructorUser() == null
-                                ? null
-                                : session.getInstructorUser().getId())
-                .instructorName(session.getInstructorNameSnapshot())
-                .instructorPosition(
-                        session.getInstructorUser() == null
-                                ? null
-                                : session.getInstructorUser().getPosition())
-                .instructorDepartmentName(
-                        session.getInstructorUser() == null
-                                        || session.getInstructorUser().getDepartment() == null
-                                        || session.getInstructorUser().getDepartment().getName()
-                                                == null
-                                ? null
-                                : session.getInstructorUser()
-                                        .getDepartment()
-                                        .getName()
-                                        .getDescription())
-                .educationContent(session.getEducationContent())
-                .targetCount(session.getTargetCount())
-                .attendedCount(session.getAttendedCount())
-                .absentCount(session.getAbsentCount())
-                .absentReasonSummary(session.getAbsentReasonSummary())
-                .reportFileUrl(reportFileUrl)
-                .myAttendanceStatus(myStatus)
-                .mySigned(
-                        resolveMySigned(
-                                actor, session, myStatus == SafetyTrainingAttendeeStatus.SIGNED))
-                .myCompletionStatus(completionStatus)
-                .mySignedAt(attendee.getSignedAt())
-                .mySignatureUrl(
-                        attendee.getSignatureKey() == null
-                                ? null
-                                : s3Service.getPresignedViewUrl(attendee.getSignatureKey()))
-                .canSign(canSignSession(actor, session, myStatus))
-                .prevSession(prevSession)
-                .nextSession(nextSession)
-                .build();
-    }
-
-    @Transactional(readOnly = true)
-    public SafetyTrainingSessionAttendeesResponseDto getSessionAttendees(
-            Long sessionId, Long userId) {
-        User actor =
-                userRepository
-                        .findById(userId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        validateSafetyWriteAuthority(actor);
-
-        SafetyTrainingSession session =
-                sessionRepository
-                        .findById(sessionId)
-                        .orElseThrow(
-                                () ->
-                                        new CustomException(
-                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
-
-        List<SafetyTrainingSessionAttendee> attendees =
-                attendeeRepository.findAllBySessionIdWithUser(sessionId);
-
-        int attendedCount =
-                (int)
-                        attendees.stream()
-                                .filter(it -> it.getStatus() == SafetyTrainingAttendeeStatus.SIGNED)
-                                .count();
-        int absentCount =
-                (int)
-                        attendees.stream()
-                                .filter(it -> it.getStatus() == SafetyTrainingAttendeeStatus.ABSENT)
-                                .count();
-
-        List<SafetyTrainingSessionAttendeesResponseDto.AttendeeItem> attendeeItems =
-                attendees.stream()
-                        .map(
-                                attendee -> {
-                                    User user = attendee.getUser();
-                                    String departmentName =
-                                            user.getDepartment() == null
-                                                            || user.getDepartment().getName()
-                                                                    == null
-                                                    ? null
-                                                    : user.getDepartment()
-                                                            .getName()
-                                                            .getDescription();
-                                    return SafetyTrainingSessionAttendeesResponseDto.AttendeeItem
-                                            .builder()
-                                            .userId(user.getId())
-                                            .userName(user.getNameKor())
-                                            .departmentName(departmentName)
-                                            .attendanceStatus(attendee.getStatus())
-                                            .completionStatus(
-                                                    attendee.getStatus()
-                                                                    == SafetyTrainingAttendeeStatus
-                                                                            .SIGNED
-                                                            ? SafetyTrainingCompletionStatus
-                                                                    .COMPLETED
-                                                            : SafetyTrainingCompletionStatus
-                                                                    .INCOMPLETE)
-                                            .signedAt(attendee.getSignedAt())
-                                            .signatureUrl(
-                                                    attendee.getSignatureKey() == null
-                                                            ? null
-                                                            : s3Service.getPresignedViewUrl(
-                                                                    attendee.getSignatureKey()))
-                                            .build();
-                                })
-                        .toList();
-
-        return SafetyTrainingSessionAttendeesResponseDto.builder()
-                .sessionId(sessionId)
-                .targetCount(attendees.size())
-                .attendedCount(attendedCount)
-                .absentCount(absentCount)
-                .absentReasonSummary(session.getAbsentReasonSummary())
-                .attendees(attendeeItems)
-                .build();
-    }
-
-    @Transactional
-    public SafetyTrainingSessionReportResponseDto generateSessionReport(
-            Long sessionId, Long userId) {
-        User actor =
-                userRepository
-                        .findById(userId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        validateSafetyWriteAuthority(actor);
-
-        SafetyTrainingSession session =
-                sessionRepository
-                        .findById(sessionId)
-                        .orElseThrow(
-                                () ->
-                                        new CustomException(
-                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
-
-        List<SafetyTrainingSessionAttendee> attendees =
-                attendeeRepository.findAllBySessionIdWithUser(sessionId);
-
-        syncSessionCounts(session, attendees);
-
-        Map<Long, byte[]> signatureImagesByUserId = new HashMap<>();
-        for (SafetyTrainingSessionAttendee attendee : attendees) {
-            String signatureKey = attendee.getSignatureKey();
-            if (signatureKey == null || signatureKey.isBlank()) {
-                continue;
-            }
-            try {
-                signatureImagesByUserId.put(
-                        attendee.getUser().getId(), s3Service.downloadFile(signatureKey));
-            } catch (Exception ignored) {
-                // 개별 서명 다운로드 실패 시에도 보고서 생성은 계속 진행
-            }
-        }
-
-        byte[] reportExcel =
-                safetyTrainingExcelService.buildSessionReportExcel(
-                        session,
-                        toMethods(session.getEducationMethodsJson()),
-                        attendees,
-                        signatureImagesByUserId);
-
-        String previousReportKey = session.getReportFileKey();
-        String newReportKey =
-                s3Service.uploadBytes(
-                        reportExcel,
-                        "safety-training-report-"
-                                + session.getId()
-                                + "-"
-                                + System.currentTimeMillis()
-                                + ".xlsx",
-                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-        session.setReportFileKey(newReportKey);
-
-        if (previousReportKey != null && !previousReportKey.equals(newReportKey)) {
-            try {
-                s3Service.deleteFile(previousReportKey);
-            } catch (Exception ignored) {
-                // 이전 보고서 정리 실패는 현재 요청을 실패시키지 않음
-            }
-        }
-
-        String reportFileName = buildExportFileName(session.getStartAt(), session.getTitle());
-        return SafetyTrainingSessionReportResponseDto.builder()
-                .sessionId(session.getId())
-                .reportFileUrl(s3Service.getPresignedDownloadUrl(newReportKey, reportFileName))
-                .reportFileName(reportFileName)
-                .build();
-    }
-
-    @Transactional(readOnly = true)
-    public SafetyTrainingSessionReportResponseDto getSessionReport(Long sessionId, Long userId) {
-        User actor =
-                userRepository
-                        .findById(userId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-        SafetyTrainingSession session =
-                sessionRepository
-                        .findById(sessionId)
-                        .orElseThrow(
-                                () ->
-                                        new CustomException(
-                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
-        validateSessionReadAccess(actor, session);
-
-        if (session.getReportFileKey() == null || session.getReportFileKey().isBlank()) {
-            throw new CustomException(ErrorCode.SAFETY_TRAINING_REPORT_NOT_FOUND);
-        }
-
-        String reportFileName = buildExportFileName(session.getStartAt(), session.getTitle());
-        return SafetyTrainingSessionReportResponseDto.builder()
-                .sessionId(session.getId())
-                .reportFileUrl(
-                        s3Service.getPresignedDownloadUrl(
-                                session.getReportFileKey(), reportFileName))
-                .reportFileName(reportFileName)
-                .build();
-    }
-
-    @Transactional
-    public void signAttendance(Long sessionId, Long userId, MultipartFile signatureFile)
-            throws IOException {
-        User actor =
-                userRepository
-                        .findById(userId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-        SafetyTrainingSession session =
-                sessionRepository
-                        .findById(sessionId)
-                        .orElseThrow(
-                                () ->
-                                        new CustomException(
-                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
-
-        if (session.getStatus() != SafetyTrainingSessionStatus.OPEN) {
-            throw new CustomException(ErrorCode.SAFETY_TRAINING_SESSION_CLOSED);
-        }
-
-        validateSessionReadAccess(actor, session);
-
-        SafetyTrainingSessionAttendee attendee =
-                attendeeRepository
-                        .findBySessionIdAndUserId(sessionId, userId)
-                        .orElseThrow(
-                                () ->
-                                        new CustomException(
-                                                ErrorCode.SAFETY_TRAINING_ATTENDEE_NOT_FOUND));
-
-        if (attendee.getStatus() == SafetyTrainingAttendeeStatus.SIGNED) {
-            throw new CustomException(ErrorCode.ALREADY_MARKED_ATTENDANCE);
-        }
-
-        if (signatureFile == null || signatureFile.isEmpty()) {
-            throw new CustomException(ErrorCode.NO_SIGNATURE_PROVIDED);
-        }
-        validatePngFormat(signatureFile);
-
-        String signatureKey = null;
-        try {
-            signatureKey = s3Service.uploadFile(signatureFile);
-
-            attendee.setStatus(SafetyTrainingAttendeeStatus.SIGNED);
-            attendee.setSignedAt(LocalDateTime.now());
-            attendee.setSignatureKey(signatureKey);
-            attendee.setAbsentReason(null);
-
-            syncSessionCounts(session);
-        } catch (Exception e) {
-            safeDeleteFile(signatureKey);
-            throw e;
-        }
-    }
-
-    @Transactional
-    public Long update(
-            Long sessionId, Long userId, SafetyTrainingSessionUpdateRequestDto requestDto) {
-        User actor =
-                userRepository
-                        .findById(userId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        validateSafetyWriteAuthority(actor);
-        validateTimeRange(requestDto.getStartAt(), requestDto.getEndAt());
-
-        SafetyTrainingSession session =
-                sessionRepository
-                        .findById(sessionId)
-                        .orElseThrow(
-                                () ->
-                                        new CustomException(
-                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
-
-        if (session.getStatus() != SafetyTrainingSessionStatus.OPEN) {
-            throw new CustomException(ErrorCode.SAFETY_TRAINING_SESSION_CLOSED);
-        }
-
-        long signedCount =
-                attendeeRepository.countBySessionIdAndStatus(
-                        sessionId, SafetyTrainingAttendeeStatus.SIGNED);
-        if (signedCount > 0) {
-            throw new CustomException(ErrorCode.SAFETY_TRAINING_SESSION_HAS_SIGNED_ATTENDEE);
-        }
-
-        User instructor = findAndValidateInstructor(requestDto.getInstructorUserId());
-        List<User> attendees = findTargetAttendees(requestDto.getCompanyScope());
-
-        session.setTitle(requestDto.getTitle().trim());
-        session.setEducationType(requestDto.getEducationType());
-        session.setEducationMethodsJson(toMethodsJson(requestDto.getEducationMethods()));
-        session.setStartAt(requestDto.getStartAt());
-        session.setEndAt(requestDto.getEndAt());
-        session.setEducationDateText(
-                toEducationDateText(requestDto.getStartAt(), requestDto.getEndAt()));
-        session.setEducationContent(requestDto.getEducationContent());
-        session.setPlace(requestDto.getPlace().trim());
-        session.setCompanyScope(requestDto.getCompanyScope());
-        session.setInstructorUser(instructor);
-        session.setInstructorNameSnapshot(instructor.getNameKor());
-
-        attendeeRepository.deleteBySessionId(sessionId);
-        attendeeRepository.flush();
-
-        List<SafetyTrainingSessionAttendee> rows =
-                attendees.stream()
-                        .map(
-                                user ->
-                                        SafetyTrainingSessionAttendee.builder()
-                                                .session(session)
-                                                .user(user)
-                                                .status(SafetyTrainingAttendeeStatus.PENDING)
-                                                .build())
-                        .toList();
-        attendeeRepository.saveAll(rows);
-
-        session.setTargetCount(rows.size());
-        session.setAttendedCount(0);
-        session.setAbsentCount(0);
-        session.setAbsentReasonSummary(null);
-
-        return session.getId();
-    }
-
-    @Transactional
-    public Long updateStatus(
-            Long sessionId, Long userId, SafetyTrainingSessionStatusUpdateRequestDto requestDto) {
-        User actor =
-                userRepository
-                        .findById(userId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        validateSafetyWriteAuthority(actor);
-
-        SafetyTrainingSession session =
-                sessionRepository
-                        .findById(sessionId)
-                        .orElseThrow(
-                                () ->
-                                        new CustomException(
-                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
-        if (requestDto.getStatus() == SafetyTrainingSessionStatus.CLOSED
-                && session.getStatus() != SafetyTrainingSessionStatus.CLOSED) {
-            List<SafetyTrainingSessionAttendee> pendingAttendees =
-                    attendeeRepository.findAllBySessionIdAndStatus(
-                            sessionId, SafetyTrainingAttendeeStatus.PENDING);
-            for (SafetyTrainingSessionAttendee attendee : pendingAttendees) {
-                attendee.setStatus(SafetyTrainingAttendeeStatus.ABSENT);
-                attendee.setAbsentReason(null);
-            }
-
-            List<SafetyTrainingSessionAttendee> absentAttendees =
-                    attendeeRepository.findAllBySessionIdAndStatus(
-                            sessionId, SafetyTrainingAttendeeStatus.ABSENT);
-            for (SafetyTrainingSessionAttendee attendee : absentAttendees) {
-                attendee.setAbsentReason(null);
-            }
-        } else if (requestDto.getStatus() == SafetyTrainingSessionStatus.OPEN) {
-            // 재공개(OPEN) 시 기존 결석 확정값을 초기화한다.
-            // ABSENT -> PENDING 으로 복원하면 absentCount는 0으로 계산된다.
-            List<SafetyTrainingSessionAttendee> absentAttendees =
-                    attendeeRepository.findAllBySessionIdAndStatus(
-                            sessionId, SafetyTrainingAttendeeStatus.ABSENT);
-            for (SafetyTrainingSessionAttendee attendee : absentAttendees) {
-                attendee.setStatus(SafetyTrainingAttendeeStatus.PENDING);
-                attendee.setAbsentReason(null);
-            }
-        }
-
-        session.setStatus(requestDto.getStatus());
-        syncSessionCounts(session);
-
-        if (requestDto.getStatus() == SafetyTrainingSessionStatus.CLOSED) {
-            if (session.getAbsentCount() > 0) {
-                String absentReasonSummary = trimToNull(requestDto.getAbsentReasonSummary());
-                if (absentReasonSummary == null) {
-                    throw new CustomException(ErrorCode.SAFETY_TRAINING_ABSENT_REASON_REQUIRED);
+                if (!canReadAllCompanies && companyScope == null) {
+                        return Page.empty(pageable);
                 }
-                session.setAbsentReasonSummary(absentReasonSummary);
-            } else {
-                session.setAbsentReasonSummary(null);
-            }
-        } else {
-            session.setAbsentReasonSummary(null);
+
+                Page<SafetyTrainingSession> sessionsPage = sessionRepository.findAllByFilters(
+                                companyScope,
+                                filter.getEducationType(),
+                                status,
+                                filter.getStartAtFrom(),
+                                filter.getStartAtTo(),
+                                filter.getNormalizedTitleKeyword(),
+                                pageable);
+
+                List<Long> sessionIds = sessionsPage.getContent().stream().map(SafetyTrainingSession::getId).toList();
+                Set<Long> signedSessionIds = Collections.emptySet();
+                if (!sessionIds.isEmpty() && canExposeMySigned(actor)) {
+                        signedSessionIds = new HashSet<>(
+                                        attendeeRepository.findSignedSessionIdsByUserIdAndSessionIds(
+                                                        userId, sessionIds));
+                }
+
+                Set<Long> finalSignedSessionIds = signedSessionIds;
+                return sessionsPage.map(
+                                session -> toSummaryDto(
+                                                session,
+                                                resolveMySigned(
+                                                                actor,
+                                                                session,
+                                                                finalSignedSessionIds.contains(session.getId()))));
         }
 
-        return session.getId();
-    }
+        @Transactional(readOnly = true)
+        public SafetyTrainingSessionDetailResponseDto getSessionDetail(Long sessionId, Long userId) {
+                User actor = userRepository
+                                .findById(userId)
+                                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-    @Transactional
-    public void delete(Long sessionId, Long userId) {
-        User actor =
-                userRepository
-                        .findById(userId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        validateSafetyWriteAuthority(actor);
+                SafetyTrainingSession session = sessionRepository
+                                .findById(sessionId)
+                                .orElseThrow(
+                                                () -> new CustomException(
+                                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
 
-        SafetyTrainingSession session =
-                sessionRepository
-                        .findById(sessionId)
-                        .orElseThrow(
-                                () ->
-                                        new CustomException(
-                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
+                validateSessionReadAccess(actor, session);
 
-        List<SafetyTrainingSessionAttendee> attendees =
-                attendeeRepository.findAllBySessionIdWithUser(sessionId);
-        String reportFileKey = session.getReportFileKey();
+                SafetyTrainingSessionAttendee attendee = attendeeRepository
+                                .findBySessionIdAndUserId(sessionId, userId)
+                                .orElse(
+                                                SafetyTrainingSessionAttendee.builder()
+                                                                .status(SafetyTrainingAttendeeStatus.PENDING)
+                                                                .build());
 
-        attendeeRepository.deleteBySessionId(sessionId);
-        attendeeRepository.flush();
-        sessionRepository.delete(session);
+                SafetyTrainingAttendeeStatus myStatus = attendee.getStatus();
+                SafetyTrainingCompletionStatus completionStatus = resolveMyCompletionStatus(actor, session, myStatus);
 
-        if (reportFileKey != null && !reportFileKey.isBlank()) {
-            safeDeleteFile(reportFileKey);
-        }
-        for (SafetyTrainingSessionAttendee attendee : attendees) {
-            String signatureKey = attendee.getSignatureKey();
-            if (signatureKey != null && !signatureKey.isBlank()) {
-                safeDeleteFile(signatureKey);
-            }
-        }
-    }
+                String reportFileUrl = session.getReportFileKey() == null
+                                ? null
+                                : s3Service.getPresignedDownloadUrl(
+                                                session.getReportFileKey(),
+                                                buildExportFileName(session.getStartAt(), session.getTitle()));
 
-    private void validateSafetyWriteAuthority(User user) {
-        if (!user.hasAuthority(Authority.MANAGE_SAFETY)) {
-            throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_SAFETY_WRITE);
-        }
-    }
+                SafetyTrainingSessionDetailResponseDto.SessionInfo prevSession = findPrevSessionInfo(actor, session);
+                SafetyTrainingSessionDetailResponseDto.SessionInfo nextSession = findNextSessionInfo(actor, session);
 
-    private User findAndValidateInstructor(Long instructorUserId) {
-        return userRepository
-                .findById(instructorUserId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-    }
-
-    private List<User> findTargetAttendees(Company companyScope) {
-        return userRepository.findAllByCompanyAndStatusExcludingPosition(
-                companyScope, Status.AVAILABLE, Position.CEO);
-    }
-
-    private void validateTimeRange(LocalDateTime startAt, LocalDateTime endAt) {
-        if (startAt == null || endAt == null || !startAt.isBefore(endAt)) {
-            throw new CustomException(ErrorCode.INVALID_TIME_RANGE);
-        }
-    }
-
-    private String trimToNull(String value) {
-        if (value == null) {
-            return null;
-        }
-        String trimmed = value.trim();
-        return trimmed.isEmpty() ? null : trimmed;
-    }
-
-    private String buildExportFileName(LocalDateTime startAt, String title) {
-        String datePart =
-                (startAt == null ? LocalDate.now() : startAt.toLocalDate())
-                        .format(FILE_DATE_FORMATTER);
-        String titlePart = sanitizeFileNamePart(title);
-        return datePart + "_" + titlePart + ".xlsx";
-    }
-
-    private String sanitizeFileNamePart(String title) {
-        String value = trimToNull(title);
-        if (value == null) {
-            return "안전보건교육";
-        }
-        String sanitized =
-                value.replaceAll("[\\\\/:*?\"<>|]", " ")
-                        .replaceAll("\\s+", "_")
-                        .replaceAll("^_+|_+$", "");
-        if (sanitized.isBlank()) {
-            sanitized = "안전보건교육";
-        }
-        if (sanitized.length() > 80) {
-            sanitized = sanitized.substring(0, 80);
-        }
-        return sanitized;
-    }
-
-    private String toMethodsJson(List<SafetyEducationMethod> educationMethods) {
-        try {
-            return objectMapper.writeValueAsString(educationMethods);
-        } catch (Exception e) {
-            throw new CustomException(ErrorCode.INVALID_ARGUMENT);
-        }
-    }
-
-    private String toEducationDateText(LocalDateTime startAt, LocalDateTime endAt) {
-        long minutes = Duration.between(startAt, endAt).toMinutes();
-        long hours = minutes / 60;
-        long remainMinutes = minutes % 60;
-
-        String durationText =
-                remainMinutes == 0
-                        ? String.format("%d시간", hours)
-                        : String.format("%d시간 %d분", hours, remainMinutes);
-
-        return String.format(
-                "%s ~ %s (%s)",
-                startAt.format(DATE_TIME_TEXT_FORMATTER),
-                endAt.format(DATE_TIME_TEXT_FORMATTER),
-                durationText);
-    }
-
-    private void safeDeleteFile(String s3Key) {
-        if (s3Key == null || s3Key.isBlank()) {
-            return;
-        }
-        try {
-            s3Service.deleteFile(s3Key);
-        } catch (Exception ignored) {
-            // 트랜잭션 롤백 시 S3 고아 파일 정리 실패 가능
-        }
-    }
-
-    private void validatePngFormat(MultipartFile file) {
-        String contentType = file.getContentType();
-        if (contentType == null || !contentType.equals("image/png")) {
-            throw new CustomException(ErrorCode.INVALID_SIGNATURE_FORMAT);
-        }
-    }
-
-    private void validateSessionReadAccess(User actor, SafetyTrainingSession session) {
-        if (actor.hasAuthority(Authority.MANAGE_SAFETY)) {
-            return;
-        }
-        if (actor.getWorkLocation() == null
-                || actor.getWorkLocation() != session.getCompanyScope()) {
-            throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_SAFETY_READ);
-        }
-    }
-
-    private boolean canSignSession(
-            User actor, SafetyTrainingSession session, SafetyTrainingAttendeeStatus myStatus) {
-        if (actor.getPosition() == Position.CEO || actor.getRole() == Role.MASTER_ADMIN) {
-            return false;
+                return SafetyTrainingSessionDetailResponseDto.builder()
+                                .sessionId(session.getId())
+                                .title(session.getTitle())
+                                .authorName(
+                                                session.getCreatedBy() == null
+                                                                ? null
+                                                                : session.getCreatedBy().getDisplayName())
+                                .createdAt(session.getCreatedAt())
+                                .educationType(session.getEducationType())
+                                .educationMethods(toMethods(session.getEducationMethodsJson()))
+                                .startAt(session.getStartAt())
+                                .endAt(session.getEndAt())
+                                .place(session.getPlace())
+                                .companyScope(session.getCompanyScope())
+                                .status(session.getStatus())
+                                .instructorUserId(
+                                                session.getInstructorUser() == null
+                                                                ? null
+                                                                : session.getInstructorUser().getId())
+                                .instructorName(session.getInstructorNameSnapshot())
+                                .instructorPosition(
+                                                session.getInstructorUser() == null
+                                                                ? null
+                                                                : session.getInstructorUser().getPosition())
+                                .instructorDepartmentName(
+                                                session.getInstructorUser() == null
+                                                                || session.getInstructorUser().getDepartment() == null
+                                                                || session.getInstructorUser().getDepartment()
+                                                                                .getName() == null
+                                                                                                ? null
+                                                                                                : session.getInstructorUser()
+                                                                                                                .getDepartment()
+                                                                                                                .getName()
+                                                                                                                .getDescription())
+                                .educationContent(session.getEducationContent())
+                                .targetCount(session.getTargetCount())
+                                .attendedCount(session.getAttendedCount())
+                                .absentCount(session.getAbsentCount())
+                                .absentReasonSummary(session.getAbsentReasonSummary())
+                                .reportFileUrl(reportFileUrl)
+                                .myAttendanceStatus(myStatus)
+                                .mySigned(
+                                                resolveMySigned(
+                                                                actor, session,
+                                                                myStatus == SafetyTrainingAttendeeStatus.SIGNED))
+                                .myCompletionStatus(completionStatus)
+                                .mySignedAt(attendee.getSignedAt())
+                                .mySignatureUrl(
+                                                attendee.getSignatureKey() == null
+                                                                ? null
+                                                                : s3Service.getPresignedViewUrl(
+                                                                                attendee.getSignatureKey()))
+                                .canSign(canSignSession(actor, session, myStatus))
+                                .prevSession(prevSession)
+                                .nextSession(nextSession)
+                                .build();
         }
 
-        if (actor.getWorkLocation() == null
-                || actor.getWorkLocation() != session.getCompanyScope()) {
-            return false;
-        }
+        @Transactional(readOnly = true)
+        public SafetyTrainingSessionAttendeesResponseDto getSessionAttendees(
+                        Long sessionId, Long userId) {
+                User actor = userRepository
+                                .findById(userId)
+                                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                validateSafetyWriteAuthority(actor);
 
-        return session.getStatus() == SafetyTrainingSessionStatus.OPEN
-                && myStatus != SafetyTrainingAttendeeStatus.SIGNED;
-    }
+                SafetyTrainingSession session = sessionRepository
+                                .findById(sessionId)
+                                .orElseThrow(
+                                                () -> new CustomException(
+                                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
 
-    private boolean canExposeMySigned(User actor) {
-        return actor.getPosition() != Position.CEO && actor.getRole() != Role.MASTER_ADMIN;
-    }
+                List<SafetyTrainingSessionAttendee> attendees = attendeeRepository
+                                .findAllBySessionIdWithUser(sessionId);
 
-    private Boolean resolveMySigned(User actor, SafetyTrainingSession session, boolean signed) {
-        if (!canExposeMySigned(actor)) {
-            return null;
-        }
-        if (actor.getWorkLocation() == null
-                || actor.getWorkLocation() != session.getCompanyScope()) {
-            return null;
-        }
-        return signed;
-    }
-
-    private SafetyTrainingCompletionStatus resolveMyCompletionStatus(
-            User actor, SafetyTrainingSession session, SafetyTrainingAttendeeStatus myStatus) {
-        if (!canExposeMySigned(actor)) {
-            return null;
-        }
-        if (actor.getWorkLocation() == null
-                || actor.getWorkLocation() != session.getCompanyScope()) {
-            return null;
-        }
-        return myStatus == SafetyTrainingAttendeeStatus.SIGNED
-                ? SafetyTrainingCompletionStatus.COMPLETED
-                : SafetyTrainingCompletionStatus.INCOMPLETE;
-    }
-
-    private List<SafetyEducationMethod> toMethods(String educationMethodsJson) {
-        if (educationMethodsJson == null || educationMethodsJson.isBlank()) {
-            return Collections.emptyList();
-        }
-        try {
-            return objectMapper.readValue(
-                    educationMethodsJson,
-                    objectMapper
-                            .getTypeFactory()
-                            .constructCollectionType(List.class, SafetyEducationMethod.class));
-        } catch (Exception e) {
-            return Collections.emptyList();
-        }
-    }
-
-    private void syncSessionCounts(SafetyTrainingSession session) {
-        long attended =
-                attendeeRepository.countBySessionIdAndStatus(
-                        session.getId(), SafetyTrainingAttendeeStatus.SIGNED);
-        long absent =
-                attendeeRepository.countBySessionIdAndStatus(
-                        session.getId(), SafetyTrainingAttendeeStatus.ABSENT);
-        session.setAttendedCount((int) attended);
-        session.setAbsentCount((int) absent);
-    }
-
-    private void syncSessionCounts(
-            SafetyTrainingSession session, List<SafetyTrainingSessionAttendee> attendees) {
-        int attendedCount =
-                (int)
-                        attendees.stream()
+                int attendedCount = (int) attendees.stream()
                                 .filter(it -> it.getStatus() == SafetyTrainingAttendeeStatus.SIGNED)
                                 .count();
-        int absentCount =
-                (int)
-                        attendees.stream()
+                int absentCount = (int) attendees.stream()
                                 .filter(it -> it.getStatus() == SafetyTrainingAttendeeStatus.ABSENT)
                                 .count();
-        session.setTargetCount(attendees.size());
-        session.setAttendedCount(attendedCount);
-        session.setAbsentCount(absentCount);
-    }
 
-    private SafetyTrainingSessionSummaryResponseDto toSummaryDto(
-            SafetyTrainingSession session, Boolean mySigned) {
-        return SafetyTrainingSessionSummaryResponseDto.builder()
-                .sessionId(session.getId())
-                .title(session.getTitle())
-                .educationType(session.getEducationType())
-                .startAt(session.getStartAt())
-                .endAt(session.getEndAt())
-                .place(session.getPlace())
-                .companyScope(session.getCompanyScope())
-                .instructorUserId(
-                        session.getInstructorUser() == null
-                                ? null
-                                : session.getInstructorUser().getId())
-                .instructorName(session.getInstructorNameSnapshot())
-                .status(session.getStatus())
-                .targetCount(session.getTargetCount())
-                .attendedCount(session.getAttendedCount())
-                .absentCount(session.getAbsentCount())
-                .mySigned(mySigned)
-                .authorName(
-                        session.getCreatedBy() == null
-                                ? null
-                                : session.getCreatedBy().getDisplayName())
-                .createdAt(session.getCreatedAt())
-                .build();
-    }
+                List<SafetyTrainingSessionAttendeesResponseDto.AttendeeItem> attendeeItems = attendees.stream()
+                                .map(
+                                                attendee -> {
+                                                        User user = attendee.getUser();
+                                                        String departmentName = user.getDepartment() == null
+                                                                        || user.getDepartment().getName() == null
+                                                                                        ? null
+                                                                                        : user.getDepartment()
+                                                                                                        .getName()
+                                                                                                        .getDescription();
+                                                        return SafetyTrainingSessionAttendeesResponseDto.AttendeeItem
+                                                                        .builder()
+                                                                        .userId(user.getId())
+                                                                        .userName(user.getNameKor())
+                                                                        .departmentName(departmentName)
+                                                                        .attendanceStatus(attendee.getStatus())
+                                                                        .completionStatus(
+                                                                                        attendee.getStatus() == SafetyTrainingAttendeeStatus.SIGNED
+                                                                                                        ? SafetyTrainingCompletionStatus.COMPLETED
+                                                                                                        : SafetyTrainingCompletionStatus.INCOMPLETE)
+                                                                        .signedAt(attendee.getSignedAt())
+                                                                        .signatureUrl(
+                                                                                        attendee.getSignatureKey() == null
+                                                                                                        ? null
+                                                                                                        : s3Service.getPresignedViewUrl(
+                                                                                                                        attendee.getSignatureKey()))
+                                                                        .build();
+                                                })
+                                .toList();
 
-    private SafetyTrainingSessionDetailResponseDto.SessionInfo findPrevSessionInfo(
-            User actor, SafetyTrainingSession current) {
-        return findNeighborSession(actor, current, true).orElse(null);
-    }
-
-    private SafetyTrainingSessionDetailResponseDto.SessionInfo findNextSessionInfo(
-            User actor, SafetyTrainingSession current) {
-        return findNeighborSession(actor, current, false).orElse(null);
-    }
-
-    private java.util.Optional<SafetyTrainingSessionDetailResponseDto.SessionInfo>
-            findNeighborSession(User actor, SafetyTrainingSession current, boolean previous) {
-        java.util.Optional<SafetyTrainingSession> neighbor;
-        if (actor.hasAuthority(Authority.MANAGE_SAFETY)) {
-            neighbor =
-                    previous
-                            ? sessionRepository.findFirstByIdGreaterThanOrderByIdAsc(
-                                    current.getId())
-                            : sessionRepository.findFirstByIdLessThanOrderByIdDesc(current.getId());
-        } else {
-            Company company = actor.getWorkLocation();
-            if (company == null) {
-                return java.util.Optional.empty();
-            }
-            neighbor =
-                    previous
-                            ? sessionRepository.findFirstByCompanyScopeAndIdGreaterThanOrderByIdAsc(
-                                    company, current.getId())
-                            : sessionRepository.findFirstByCompanyScopeAndIdLessThanOrderByIdDesc(
-                                    company, current.getId());
+                return SafetyTrainingSessionAttendeesResponseDto.builder()
+                                .sessionId(sessionId)
+                                .targetCount(attendees.size())
+                                .attendedCount(attendedCount)
+                                .absentCount(absentCount)
+                                .absentReasonSummary(session.getAbsentReasonSummary())
+                                .attendees(attendeeItems)
+                                .build();
         }
 
-        return neighbor.map(this::toSessionInfo);
-    }
+        @Transactional
+        public SafetyTrainingSessionReportResponseDto generateSessionReport(
+                        Long sessionId, Long userId) {
+                User actor = userRepository
+                                .findById(userId)
+                                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                validateSafetyWriteAuthority(actor);
 
-    private SafetyTrainingSessionDetailResponseDto.SessionInfo toSessionInfo(
-            SafetyTrainingSession session) {
-        return SafetyTrainingSessionDetailResponseDto.SessionInfo.builder()
-                .sessionId(session.getId())
-                .title(session.getTitle())
-                .authorName(
-                        session.getCreatedBy() == null
-                                ? null
-                                : session.getCreatedBy().getDisplayName())
-                .createdAt(session.getCreatedAt())
-                .build();
-    }
+                SafetyTrainingSession session = sessionRepository
+                                .findById(sessionId)
+                                .orElseThrow(
+                                                () -> new CustomException(
+                                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
+
+                List<SafetyTrainingSessionAttendee> attendees = attendeeRepository
+                                .findAllBySessionIdWithUser(sessionId);
+
+                syncSessionCounts(session, attendees);
+
+                Map<Long, byte[]> signatureImagesByUserId = new HashMap<>();
+                for (SafetyTrainingSessionAttendee attendee : attendees) {
+                        String signatureKey = attendee.getSignatureKey();
+                        if (signatureKey == null || signatureKey.isBlank()) {
+                                continue;
+                        }
+                        try {
+                                signatureImagesByUserId.put(
+                                                attendee.getUser().getId(), s3Service.downloadFile(signatureKey));
+                        } catch (Exception ignored) {
+                                // 개별 서명 다운로드 실패 시에도 보고서 생성은 계속 진행
+                        }
+                }
+
+                byte[] reportExcel = safetyTrainingExcelService.buildSessionReportExcel(
+                                session,
+                                toMethods(session.getEducationMethodsJson()),
+                                attendees,
+                                signatureImagesByUserId);
+
+                String previousReportKey = session.getReportFileKey();
+                String newReportKey = s3Service.uploadBytes(
+                                reportExcel,
+                                "safety-training-report-"
+                                                + session.getId()
+                                                + "-"
+                                                + System.currentTimeMillis()
+                                                + ".xlsx",
+                                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+                session.setReportFileKey(newReportKey);
+
+                if (previousReportKey != null && !previousReportKey.equals(newReportKey)) {
+                        try {
+                                s3Service.deleteFile(previousReportKey);
+                        } catch (Exception ignored) {
+                                // 이전 보고서 정리 실패는 현재 요청을 실패시키지 않음
+                        }
+                }
+
+                String reportFileName = buildExportFileName(session.getStartAt(), session.getTitle());
+                return SafetyTrainingSessionReportResponseDto.builder()
+                                .sessionId(session.getId())
+                                .reportFileUrl(s3Service.getPresignedDownloadUrl(newReportKey, reportFileName))
+                                .reportFileName(reportFileName)
+                                .build();
+        }
+
+        @Transactional(readOnly = true)
+        public SafetyTrainingSessionReportResponseDto getSessionReport(Long sessionId, Long userId) {
+                User actor = userRepository
+                                .findById(userId)
+                                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+                SafetyTrainingSession session = sessionRepository
+                                .findById(sessionId)
+                                .orElseThrow(
+                                                () -> new CustomException(
+                                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
+                validateSessionReadAccess(actor, session);
+
+                if (session.getReportFileKey() == null || session.getReportFileKey().isBlank()) {
+                        throw new CustomException(ErrorCode.SAFETY_TRAINING_REPORT_NOT_FOUND);
+                }
+
+                String reportFileName = buildExportFileName(session.getStartAt(), session.getTitle());
+                return SafetyTrainingSessionReportResponseDto.builder()
+                                .sessionId(session.getId())
+                                .reportFileUrl(
+                                                s3Service.getPresignedDownloadUrl(
+                                                                session.getReportFileKey(), reportFileName))
+                                .reportFileName(reportFileName)
+                                .build();
+        }
+
+        @Transactional
+        public void signAttendance(Long sessionId, Long userId, MultipartFile signatureFile)
+                        throws IOException {
+                User actor = userRepository
+                                .findById(userId)
+                                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+                SafetyTrainingSession session = sessionRepository
+                                .findById(sessionId)
+                                .orElseThrow(
+                                                () -> new CustomException(
+                                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
+
+                if (session.getStatus() != SafetyTrainingSessionStatus.OPEN) {
+                        throw new CustomException(ErrorCode.SAFETY_TRAINING_SESSION_CLOSED);
+                }
+
+                validateSessionReadAccess(actor, session);
+
+                SafetyTrainingSessionAttendee attendee = attendeeRepository
+                                .findBySessionIdAndUserId(sessionId, userId)
+                                .orElseThrow(
+                                                () -> new CustomException(
+                                                                ErrorCode.SAFETY_TRAINING_ATTENDEE_NOT_FOUND));
+
+                if (attendee.getStatus() == SafetyTrainingAttendeeStatus.SIGNED) {
+                        throw new CustomException(ErrorCode.ALREADY_MARKED_ATTENDANCE);
+                }
+
+                if (signatureFile == null || signatureFile.isEmpty()) {
+                        throw new CustomException(ErrorCode.NO_SIGNATURE_PROVIDED);
+                }
+                validatePngFormat(signatureFile);
+
+                String signatureKey = null;
+                try {
+                        signatureKey = s3Service.uploadFile(signatureFile);
+
+                        attendee.setStatus(SafetyTrainingAttendeeStatus.SIGNED);
+                        attendee.setSignedAt(LocalDateTime.now());
+                        attendee.setSignatureKey(signatureKey);
+                        attendee.setAbsentReason(null);
+
+                        syncSessionCounts(session);
+                } catch (Exception e) {
+                        safeDeleteFile(signatureKey);
+                        throw e;
+                }
+        }
+
+        @Transactional
+        public Long update(
+                        Long sessionId, Long userId, SafetyTrainingSessionUpdateRequestDto requestDto) {
+                User actor = userRepository
+                                .findById(userId)
+                                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                validateSafetyWriteAuthority(actor);
+                validateTimeRange(requestDto.getStartAt(), requestDto.getEndAt());
+
+                SafetyTrainingSession session = sessionRepository
+                                .findById(sessionId)
+                                .orElseThrow(
+                                                () -> new CustomException(
+                                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
+
+                if (session.getStatus() != SafetyTrainingSessionStatus.OPEN) {
+                        throw new CustomException(ErrorCode.SAFETY_TRAINING_SESSION_CLOSED);
+                }
+
+                long signedCount = attendeeRepository.countBySessionIdAndStatus(
+                                sessionId, SafetyTrainingAttendeeStatus.SIGNED);
+                if (signedCount > 0) {
+                        throw new CustomException(ErrorCode.SAFETY_TRAINING_SESSION_HAS_SIGNED_ATTENDEE);
+                }
+
+                User instructor = findAndValidateInstructor(requestDto.getInstructorUserId());
+                List<User> attendees = findTargetAttendees(requestDto.getCompanyScope());
+
+                session.setTitle(requestDto.getTitle().trim());
+                session.setEducationType(requestDto.getEducationType());
+                session.setEducationMethodsJson(toMethodsJson(requestDto.getEducationMethods()));
+                session.setStartAt(requestDto.getStartAt());
+                session.setEndAt(requestDto.getEndAt());
+                session.setEducationDateText(
+                                toEducationDateText(requestDto.getStartAt(), requestDto.getEndAt()));
+                session.setEducationContent(requestDto.getEducationContent());
+                session.setPlace(requestDto.getPlace().trim());
+                session.setCompanyScope(requestDto.getCompanyScope());
+                session.setInstructorUser(instructor);
+                session.setInstructorNameSnapshot(instructor.getNameKor());
+
+                attendeeRepository.deleteBySessionId(sessionId);
+                attendeeRepository.flush();
+
+                List<SafetyTrainingSessionAttendee> rows = attendees.stream()
+                                .map(
+                                                user -> SafetyTrainingSessionAttendee.builder()
+                                                                .session(session)
+                                                                .user(user)
+                                                                .status(SafetyTrainingAttendeeStatus.PENDING)
+                                                                .build())
+                                .toList();
+                attendeeRepository.saveAll(rows);
+
+                session.setTargetCount(rows.size());
+                session.setAttendedCount(0);
+                session.setAbsentCount(0);
+                session.setAbsentReasonSummary(null);
+
+                return session.getId();
+        }
+
+        @Transactional
+        public Long updateStatus(
+                        Long sessionId, Long userId, SafetyTrainingSessionStatusUpdateRequestDto requestDto) {
+                User actor = userRepository
+                                .findById(userId)
+                                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                validateSafetyWriteAuthority(actor);
+
+                SafetyTrainingSession session = sessionRepository
+                                .findById(sessionId)
+                                .orElseThrow(
+                                                () -> new CustomException(
+                                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
+                if (requestDto.getStatus() == SafetyTrainingSessionStatus.CLOSED
+                                && session.getStatus() != SafetyTrainingSessionStatus.CLOSED) {
+                        List<SafetyTrainingSessionAttendee> pendingAttendees = attendeeRepository
+                                        .findAllBySessionIdAndStatus(
+                                                        sessionId, SafetyTrainingAttendeeStatus.PENDING);
+                        for (SafetyTrainingSessionAttendee attendee : pendingAttendees) {
+                                attendee.setStatus(SafetyTrainingAttendeeStatus.ABSENT);
+                                attendee.setAbsentReason(null);
+                        }
+
+                        List<SafetyTrainingSessionAttendee> absentAttendees = attendeeRepository
+                                        .findAllBySessionIdAndStatus(
+                                                        sessionId, SafetyTrainingAttendeeStatus.ABSENT);
+                        for (SafetyTrainingSessionAttendee attendee : absentAttendees) {
+                                attendee.setAbsentReason(null);
+                        }
+                } else if (requestDto.getStatus() == SafetyTrainingSessionStatus.OPEN) {
+                        // 재공개(OPEN) 시 기존 결석 확정값을 초기화한다.
+                        // ABSENT -> PENDING 으로 복원하면 absentCount는 0으로 계산된다.
+                        List<SafetyTrainingSessionAttendee> absentAttendees = attendeeRepository
+                                        .findAllBySessionIdAndStatus(
+                                                        sessionId, SafetyTrainingAttendeeStatus.ABSENT);
+                        for (SafetyTrainingSessionAttendee attendee : absentAttendees) {
+                                attendee.setStatus(SafetyTrainingAttendeeStatus.PENDING);
+                                attendee.setAbsentReason(null);
+                        }
+                }
+
+                session.setStatus(requestDto.getStatus());
+                syncSessionCounts(session);
+
+                if (requestDto.getStatus() == SafetyTrainingSessionStatus.CLOSED) {
+                        if (session.getAbsentCount() > 0) {
+                                String absentReasonSummary = trimToNull(requestDto.getAbsentReasonSummary());
+                                if (absentReasonSummary == null) {
+                                        throw new CustomException(ErrorCode.SAFETY_TRAINING_ABSENT_REASON_REQUIRED);
+                                }
+                                session.setAbsentReasonSummary(absentReasonSummary);
+                        } else {
+                                session.setAbsentReasonSummary(null);
+                        }
+                } else {
+                        session.setAbsentReasonSummary(null);
+                }
+
+                return session.getId();
+        }
+
+        @Transactional
+        public void remindSession(Long sessionId, Long userId) {
+                userRepository
+                                .findById(userId)
+                                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+                SafetyTrainingSession session = sessionRepository
+                                .findById(sessionId)
+                                .orElseThrow(
+                                                () -> new CustomException(
+                                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
+
+                if (session.getCreatedBy() == null
+                                || !session.getCreatedBy().getId().equals(userId)) {
+                        throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_SAFETY_WRITE);
+                }
+
+                List<Long> targetUserIds = findTargetAttendees(session.getCompanyScope())
+                                .stream()
+                                .map(User::getId)
+                                .toList();
+
+                notificationService.sendSafetyTrainingSessionRemindAlertToAttendees(
+                                sessionId, session.getTitle(), targetUserIds);
+        }
+
+        @Transactional
+        public void delete(Long sessionId, Long userId) {
+                User actor = userRepository
+                                .findById(userId)
+                                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                validateSafetyWriteAuthority(actor);
+
+                SafetyTrainingSession session = sessionRepository
+                                .findById(sessionId)
+                                .orElseThrow(
+                                                () -> new CustomException(
+                                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
+
+                List<SafetyTrainingSessionAttendee> attendees = attendeeRepository
+                                .findAllBySessionIdWithUser(sessionId);
+                String reportFileKey = session.getReportFileKey();
+
+                attendeeRepository.deleteBySessionId(sessionId);
+                attendeeRepository.flush();
+                sessionRepository.delete(session);
+
+                if (reportFileKey != null && !reportFileKey.isBlank()) {
+                        safeDeleteFile(reportFileKey);
+                }
+                for (SafetyTrainingSessionAttendee attendee : attendees) {
+                        String signatureKey = attendee.getSignatureKey();
+                        if (signatureKey != null && !signatureKey.isBlank()) {
+                                safeDeleteFile(signatureKey);
+                        }
+                }
+        }
+
+        private void validateSafetyWriteAuthority(User user) {
+                if (!user.hasAuthority(Authority.MANAGE_SAFETY)) {
+                        throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_SAFETY_WRITE);
+                }
+        }
+
+        private User findAndValidateInstructor(Long instructorUserId) {
+                return userRepository
+                                .findById(instructorUserId)
+                                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        }
+
+        private List<User> findTargetAttendees(Company companyScope) {
+                return userRepository.findAllByCompanyAndStatusExcludingPosition(
+                                companyScope, Status.AVAILABLE, Position.CEO);
+        }
+
+        private void validateTimeRange(LocalDateTime startAt, LocalDateTime endAt) {
+                if (startAt == null || endAt == null || !startAt.isBefore(endAt)) {
+                        throw new CustomException(ErrorCode.INVALID_TIME_RANGE);
+                }
+        }
+
+        private String trimToNull(String value) {
+                if (value == null) {
+                        return null;
+                }
+                String trimmed = value.trim();
+                return trimmed.isEmpty() ? null : trimmed;
+        }
+
+        private String buildExportFileName(LocalDateTime startAt, String title) {
+                String datePart = (startAt == null ? LocalDate.now() : startAt.toLocalDate())
+                                .format(FILE_DATE_FORMATTER);
+                String titlePart = sanitizeFileNamePart(title);
+                return datePart + "_" + titlePart + ".xlsx";
+        }
+
+        private String sanitizeFileNamePart(String title) {
+                String value = trimToNull(title);
+                if (value == null) {
+                        return "안전보건교육";
+                }
+                String sanitized = value.replaceAll("[\\\\/:*?\"<>|]", " ")
+                                .replaceAll("\\s+", "_")
+                                .replaceAll("^_+|_+$", "");
+                if (sanitized.isBlank()) {
+                        sanitized = "안전보건교육";
+                }
+                if (sanitized.length() > 80) {
+                        sanitized = sanitized.substring(0, 80);
+                }
+                return sanitized;
+        }
+
+        private String toMethodsJson(List<SafetyEducationMethod> educationMethods) {
+                try {
+                        return objectMapper.writeValueAsString(educationMethods);
+                } catch (Exception e) {
+                        throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+                }
+        }
+
+        private String toEducationDateText(LocalDateTime startAt, LocalDateTime endAt) {
+                long minutes = Duration.between(startAt, endAt).toMinutes();
+                long hours = minutes / 60;
+                long remainMinutes = minutes % 60;
+
+                String durationText = remainMinutes == 0
+                                ? String.format("%d시간", hours)
+                                : String.format("%d시간 %d분", hours, remainMinutes);
+
+                return String.format(
+                                "%s ~ %s (%s)",
+                                startAt.format(DATE_TIME_TEXT_FORMATTER),
+                                endAt.format(DATE_TIME_TEXT_FORMATTER),
+                                durationText);
+        }
+
+        private void safeDeleteFile(String s3Key) {
+                if (s3Key == null || s3Key.isBlank()) {
+                        return;
+                }
+                try {
+                        s3Service.deleteFile(s3Key);
+                } catch (Exception ignored) {
+                        // 트랜잭션 롤백 시 S3 고아 파일 정리 실패 가능
+                }
+        }
+
+        private void validatePngFormat(MultipartFile file) {
+                String contentType = file.getContentType();
+                if (contentType == null || !contentType.equals("image/png")) {
+                        throw new CustomException(ErrorCode.INVALID_SIGNATURE_FORMAT);
+                }
+        }
+
+        private void validateSessionReadAccess(User actor, SafetyTrainingSession session) {
+                if (actor.hasAuthority(Authority.MANAGE_SAFETY)) {
+                        return;
+                }
+                if (actor.getWorkLocation() == null
+                                || actor.getWorkLocation() != session.getCompanyScope()) {
+                        throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_SAFETY_READ);
+                }
+        }
+
+        private boolean canSignSession(
+                        User actor, SafetyTrainingSession session, SafetyTrainingAttendeeStatus myStatus) {
+                if (actor.getPosition() == Position.CEO || actor.getRole() == Role.MASTER_ADMIN) {
+                        return false;
+                }
+
+                if (actor.getWorkLocation() == null
+                                || actor.getWorkLocation() != session.getCompanyScope()) {
+                        return false;
+                }
+
+                return session.getStatus() == SafetyTrainingSessionStatus.OPEN
+                                && myStatus != SafetyTrainingAttendeeStatus.SIGNED;
+        }
+
+        private boolean canExposeMySigned(User actor) {
+                return actor.getPosition() != Position.CEO && actor.getRole() != Role.MASTER_ADMIN;
+        }
+
+        private Boolean resolveMySigned(User actor, SafetyTrainingSession session, boolean signed) {
+                if (!canExposeMySigned(actor)) {
+                        return null;
+                }
+                if (actor.getWorkLocation() == null
+                                || actor.getWorkLocation() != session.getCompanyScope()) {
+                        return null;
+                }
+                return signed;
+        }
+
+        private SafetyTrainingCompletionStatus resolveMyCompletionStatus(
+                        User actor, SafetyTrainingSession session, SafetyTrainingAttendeeStatus myStatus) {
+                if (!canExposeMySigned(actor)) {
+                        return null;
+                }
+                if (actor.getWorkLocation() == null
+                                || actor.getWorkLocation() != session.getCompanyScope()) {
+                        return null;
+                }
+                return myStatus == SafetyTrainingAttendeeStatus.SIGNED
+                                ? SafetyTrainingCompletionStatus.COMPLETED
+                                : SafetyTrainingCompletionStatus.INCOMPLETE;
+        }
+
+        private List<SafetyEducationMethod> toMethods(String educationMethodsJson) {
+                if (educationMethodsJson == null || educationMethodsJson.isBlank()) {
+                        return Collections.emptyList();
+                }
+                try {
+                        return objectMapper.readValue(
+                                        educationMethodsJson,
+                                        objectMapper
+                                                        .getTypeFactory()
+                                                        .constructCollectionType(List.class,
+                                                                        SafetyEducationMethod.class));
+                } catch (Exception e) {
+                        return Collections.emptyList();
+                }
+        }
+
+        private void syncSessionCounts(SafetyTrainingSession session) {
+                long attended = attendeeRepository.countBySessionIdAndStatus(
+                                session.getId(), SafetyTrainingAttendeeStatus.SIGNED);
+                long absent = attendeeRepository.countBySessionIdAndStatus(
+                                session.getId(), SafetyTrainingAttendeeStatus.ABSENT);
+                session.setAttendedCount((int) attended);
+                session.setAbsentCount((int) absent);
+        }
+
+        private void syncSessionCounts(
+                        SafetyTrainingSession session, List<SafetyTrainingSessionAttendee> attendees) {
+                int attendedCount = (int) attendees.stream()
+                                .filter(it -> it.getStatus() == SafetyTrainingAttendeeStatus.SIGNED)
+                                .count();
+                int absentCount = (int) attendees.stream()
+                                .filter(it -> it.getStatus() == SafetyTrainingAttendeeStatus.ABSENT)
+                                .count();
+                session.setTargetCount(attendees.size());
+                session.setAttendedCount(attendedCount);
+                session.setAbsentCount(absentCount);
+        }
+
+        private SafetyTrainingSessionSummaryResponseDto toSummaryDto(
+                        SafetyTrainingSession session, Boolean mySigned) {
+                return SafetyTrainingSessionSummaryResponseDto.builder()
+                                .sessionId(session.getId())
+                                .title(session.getTitle())
+                                .educationType(session.getEducationType())
+                                .startAt(session.getStartAt())
+                                .endAt(session.getEndAt())
+                                .place(session.getPlace())
+                                .companyScope(session.getCompanyScope())
+                                .instructorUserId(
+                                                session.getInstructorUser() == null
+                                                                ? null
+                                                                : session.getInstructorUser().getId())
+                                .instructorName(session.getInstructorNameSnapshot())
+                                .status(session.getStatus())
+                                .targetCount(session.getTargetCount())
+                                .attendedCount(session.getAttendedCount())
+                                .absentCount(session.getAbsentCount())
+                                .mySigned(mySigned)
+                                .authorName(
+                                                session.getCreatedBy() == null
+                                                                ? null
+                                                                : session.getCreatedBy().getDisplayName())
+                                .createdAt(session.getCreatedAt())
+                                .build();
+        }
+
+        private SafetyTrainingSessionDetailResponseDto.SessionInfo findPrevSessionInfo(
+                        User actor, SafetyTrainingSession current) {
+                return findNeighborSession(actor, current, true).orElse(null);
+        }
+
+        private SafetyTrainingSessionDetailResponseDto.SessionInfo findNextSessionInfo(
+                        User actor, SafetyTrainingSession current) {
+                return findNeighborSession(actor, current, false).orElse(null);
+        }
+
+        private java.util.Optional<SafetyTrainingSessionDetailResponseDto.SessionInfo> findNeighborSession(User actor,
+                        SafetyTrainingSession current, boolean previous) {
+                java.util.Optional<SafetyTrainingSession> neighbor;
+                if (actor.hasAuthority(Authority.MANAGE_SAFETY)) {
+                        neighbor = previous
+                                        ? sessionRepository.findFirstByIdGreaterThanOrderByIdAsc(
+                                                        current.getId())
+                                        : sessionRepository.findFirstByIdLessThanOrderByIdDesc(current.getId());
+                } else {
+                        Company company = actor.getWorkLocation();
+                        if (company == null) {
+                                return java.util.Optional.empty();
+                        }
+                        neighbor = previous
+                                        ? sessionRepository.findFirstByCompanyScopeAndIdGreaterThanOrderByIdAsc(
+                                                        company, current.getId())
+                                        : sessionRepository.findFirstByCompanyScopeAndIdLessThanOrderByIdDesc(
+                                                        company, current.getId());
+                }
+
+                return neighbor.map(this::toSessionInfo);
+        }
+
+        private SafetyTrainingSessionDetailResponseDto.SessionInfo toSessionInfo(
+                        SafetyTrainingSession session) {
+                return SafetyTrainingSessionDetailResponseDto.SessionInfo.builder()
+                                .sessionId(session.getId())
+                                .title(session.getTitle())
+                                .authorName(
+                                                session.getCreatedBy() == null
+                                                                ? null
+                                                                : session.getCreatedBy().getDisplayName())
+                                .createdAt(session.getCreatedAt())
+                                .build();
+        }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
@@ -55,889 +55,959 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class SafetyTrainingSessionService {
 
-        private static final DateTimeFormatter DATE_TIME_TEXT_FORMATTER = DateTimeFormatter
-                        .ofPattern("yyyy년 MM월 dd일 HH시 mm분");
-        private static final DateTimeFormatter FILE_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
-
-        private final SafetyTrainingSessionRepository sessionRepository;
-        private final SafetyTrainingSessionAttendeeRepository attendeeRepository;
-        private final UserRepository userRepository;
-        private final ObjectMapper objectMapper;
-        private final SafetyTrainingExcelService safetyTrainingExcelService;
-        private final S3Service s3Service;
-        private final NotificationService notificationService;
-
-        @Transactional(readOnly = true)
-        public SafetyTrainingPreviewResponseDto preview(
-                        Long userId, SafetyTrainingSessionCreateRequestDto requestDto) {
-                User actor = userRepository
-                                .findById(userId)
-                                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-                validateSafetyWriteAuthority(actor);
-                validateTimeRange(requestDto.getStartAt(), requestDto.getEndAt());
-
-                User instructor = findAndValidateInstructor(requestDto.getInstructorUserId());
-                List<User> attendees = findTargetAttendees(requestDto.getCompanyScope());
-                String educationDateText = toEducationDateText(requestDto.getStartAt(), requestDto.getEndAt());
-
-                byte[] excelBytes = safetyTrainingExcelService.buildPreviewExcel(
-                                requestDto, educationDateText, attendees, instructor.getNameKor());
-
-                String previewFileKey = s3Service.uploadBytes(
-                                excelBytes,
-                                "safety-training-preview-" + System.currentTimeMillis() + ".xlsx",
-                                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-                String previewFileName = buildExportFileName(requestDto.getStartAt(), requestDto.getTitle());
-                String previewUrl = s3Service.getPresignedDownloadUrl(previewFileKey, previewFileName);
-
-                return SafetyTrainingPreviewResponseDto.builder()
-                                .previewFileUrl(previewUrl)
-                                .previewFileName(previewFileName)
-                                .targetCount(attendees.size())
-                                .attendedCount(0)
-                                .absentCount(0)
-                                .build();
-        }
-
-        @Transactional
-        public Long create(Long userId, SafetyTrainingSessionCreateRequestDto requestDto) {
-                User actor = userRepository
-                                .findById(userId)
-                                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-                validateSafetyWriteAuthority(actor);
-                validateTimeRange(requestDto.getStartAt(), requestDto.getEndAt());
-
-                User instructor = findAndValidateInstructor(requestDto.getInstructorUserId());
-
-                String methodsJson = toMethodsJson(requestDto.getEducationMethods());
-                String educationDateText = toEducationDateText(requestDto.getStartAt(), requestDto.getEndAt());
-
-                SafetyTrainingSession session = SafetyTrainingSession.builder()
-                                .title(requestDto.getTitle().trim())
-                                .educationType(requestDto.getEducationType())
-                                .educationMethodsJson(methodsJson)
-                                .startAt(requestDto.getStartAt())
-                                .endAt(requestDto.getEndAt())
-                                .educationDateText(educationDateText)
-                                .educationContent(requestDto.getEducationContent())
-                                .place(requestDto.getPlace().trim())
-                                .companyScope(requestDto.getCompanyScope())
-                                .instructorUser(instructor)
-                                .instructorNameSnapshot(instructor.getNameKor())
-                                .createdBy(actor)
-                                .build();
-
-                SafetyTrainingSession saved = sessionRepository.save(session);
-
-                List<User> attendees = findTargetAttendees(requestDto.getCompanyScope());
-
-                List<SafetyTrainingSessionAttendee> rows = attendees.stream()
-                                .map(
-                                                user -> SafetyTrainingSessionAttendee.builder()
-                                                                .session(saved)
-                                                                .user(user)
-                                                                .status(SafetyTrainingAttendeeStatus.PENDING)
-                                                                .build())
-                                .toList();
-
-                attendeeRepository.saveAll(rows);
-
-                saved.setTargetCount(rows.size());
-                saved.setAttendedCount(0);
-                saved.setAbsentCount(0);
-
-                // 안전보건교육 세션 생성 알림 전송
-                List<Long> attendeeIds = attendees.stream().map(User::getId).toList();
-                notificationService.sendSafetyTrainingSessionAlertToAttendees(
-                                saved.getId(), saved.getTitle(), attendeeIds);
-
-                return saved.getId();
-        }
-
-        @Transactional(readOnly = true)
-        public Page<SafetyTrainingSessionSummaryResponseDto> getSessions(
-                        Long userId, SafetyTrainingSessionSearchConditionDto condition, Pageable pageable) {
-                User actor = userRepository
-                                .findById(userId)
-                                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-                SafetyTrainingSessionSearchConditionDto filter = condition == null
-                                ? new SafetyTrainingSessionSearchConditionDto()
-                                : condition;
-
-                boolean canReadAllCompanies = actor.hasAuthority(Authority.MANAGE_SAFETY);
-                Company companyScope = canReadAllCompanies ? filter.getCompanyScope() : actor.getWorkLocation();
-                SafetyTrainingSessionStatus status = canReadAllCompanies ? filter.getStatus() : null;
-
-                if (!canReadAllCompanies && companyScope == null) {
-                        return Page.empty(pageable);
-                }
-
-                Page<SafetyTrainingSession> sessionsPage = sessionRepository.findAllByFilters(
-                                companyScope,
-                                filter.getEducationType(),
-                                status,
-                                filter.getStartAtFrom(),
-                                filter.getStartAtTo(),
-                                filter.getNormalizedTitleKeyword(),
-                                pageable);
-
-                List<Long> sessionIds = sessionsPage.getContent().stream().map(SafetyTrainingSession::getId).toList();
-                Set<Long> signedSessionIds = Collections.emptySet();
-                if (!sessionIds.isEmpty() && canExposeMySigned(actor)) {
-                        signedSessionIds = new HashSet<>(
-                                        attendeeRepository.findSignedSessionIdsByUserIdAndSessionIds(
-                                                        userId, sessionIds));
-                }
-
-                Set<Long> finalSignedSessionIds = signedSessionIds;
-                return sessionsPage.map(
-                                session -> toSummaryDto(
-                                                session,
-                                                resolveMySigned(
-                                                                actor,
-                                                                session,
-                                                                finalSignedSessionIds.contains(session.getId()))));
-        }
-
-        @Transactional(readOnly = true)
-        public SafetyTrainingSessionDetailResponseDto getSessionDetail(Long sessionId, Long userId) {
-                User actor = userRepository
-                                .findById(userId)
-                                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-                SafetyTrainingSession session = sessionRepository
-                                .findById(sessionId)
-                                .orElseThrow(
-                                                () -> new CustomException(
-                                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
-
-                validateSessionReadAccess(actor, session);
-
-                SafetyTrainingSessionAttendee attendee = attendeeRepository
-                                .findBySessionIdAndUserId(sessionId, userId)
-                                .orElse(
-                                                SafetyTrainingSessionAttendee.builder()
-                                                                .status(SafetyTrainingAttendeeStatus.PENDING)
-                                                                .build());
-
-                SafetyTrainingAttendeeStatus myStatus = attendee.getStatus();
-                SafetyTrainingCompletionStatus completionStatus = resolveMyCompletionStatus(actor, session, myStatus);
-
-                String reportFileUrl = session.getReportFileKey() == null
-                                ? null
-                                : s3Service.getPresignedDownloadUrl(
-                                                session.getReportFileKey(),
-                                                buildExportFileName(session.getStartAt(), session.getTitle()));
-
-                SafetyTrainingSessionDetailResponseDto.SessionInfo prevSession = findPrevSessionInfo(actor, session);
-                SafetyTrainingSessionDetailResponseDto.SessionInfo nextSession = findNextSessionInfo(actor, session);
-
-                return SafetyTrainingSessionDetailResponseDto.builder()
-                                .sessionId(session.getId())
-                                .title(session.getTitle())
-                                .authorName(
-                                                session.getCreatedBy() == null
-                                                                ? null
-                                                                : session.getCreatedBy().getDisplayName())
-                                .createdAt(session.getCreatedAt())
-                                .educationType(session.getEducationType())
-                                .educationMethods(toMethods(session.getEducationMethodsJson()))
-                                .startAt(session.getStartAt())
-                                .endAt(session.getEndAt())
-                                .place(session.getPlace())
-                                .companyScope(session.getCompanyScope())
-                                .status(session.getStatus())
-                                .instructorUserId(
-                                                session.getInstructorUser() == null
-                                                                ? null
-                                                                : session.getInstructorUser().getId())
-                                .instructorName(session.getInstructorNameSnapshot())
-                                .instructorPosition(
-                                                session.getInstructorUser() == null
-                                                                ? null
-                                                                : session.getInstructorUser().getPosition())
-                                .instructorDepartmentName(
-                                                session.getInstructorUser() == null
-                                                                || session.getInstructorUser().getDepartment() == null
-                                                                || session.getInstructorUser().getDepartment()
-                                                                                .getName() == null
-                                                                                                ? null
-                                                                                                : session.getInstructorUser()
-                                                                                                                .getDepartment()
-                                                                                                                .getName()
-                                                                                                                .getDescription())
-                                .educationContent(session.getEducationContent())
-                                .targetCount(session.getTargetCount())
-                                .attendedCount(session.getAttendedCount())
-                                .absentCount(session.getAbsentCount())
-                                .absentReasonSummary(session.getAbsentReasonSummary())
-                                .reportFileUrl(reportFileUrl)
-                                .myAttendanceStatus(myStatus)
-                                .mySigned(
-                                                resolveMySigned(
-                                                                actor, session,
-                                                                myStatus == SafetyTrainingAttendeeStatus.SIGNED))
-                                .myCompletionStatus(completionStatus)
-                                .mySignedAt(attendee.getSignedAt())
-                                .mySignatureUrl(
-                                                attendee.getSignatureKey() == null
-                                                                ? null
-                                                                : s3Service.getPresignedViewUrl(
-                                                                                attendee.getSignatureKey()))
-                                .canSign(canSignSession(actor, session, myStatus))
-                                .prevSession(prevSession)
-                                .nextSession(nextSession)
-                                .build();
-        }
-
-        @Transactional(readOnly = true)
-        public SafetyTrainingSessionAttendeesResponseDto getSessionAttendees(
-                        Long sessionId, Long userId) {
-                User actor = userRepository
-                                .findById(userId)
-                                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-                validateSafetyWriteAuthority(actor);
-
-                SafetyTrainingSession session = sessionRepository
-                                .findById(sessionId)
-                                .orElseThrow(
-                                                () -> new CustomException(
-                                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
-
-                List<SafetyTrainingSessionAttendee> attendees = attendeeRepository
-                                .findAllBySessionIdWithUser(sessionId);
-
-                int attendedCount = (int) attendees.stream()
-                                .filter(it -> it.getStatus() == SafetyTrainingAttendeeStatus.SIGNED)
-                                .count();
-                int absentCount = (int) attendees.stream()
-                                .filter(it -> it.getStatus() == SafetyTrainingAttendeeStatus.ABSENT)
-                                .count();
-
-                List<SafetyTrainingSessionAttendeesResponseDto.AttendeeItem> attendeeItems = attendees.stream()
-                                .map(
-                                                attendee -> {
-                                                        User user = attendee.getUser();
-                                                        String departmentName = user.getDepartment() == null
-                                                                        || user.getDepartment().getName() == null
-                                                                                        ? null
-                                                                                        : user.getDepartment()
-                                                                                                        .getName()
-                                                                                                        .getDescription();
-                                                        return SafetyTrainingSessionAttendeesResponseDto.AttendeeItem
-                                                                        .builder()
-                                                                        .userId(user.getId())
-                                                                        .userName(user.getNameKor())
-                                                                        .departmentName(departmentName)
-                                                                        .attendanceStatus(attendee.getStatus())
-                                                                        .completionStatus(
-                                                                                        attendee.getStatus() == SafetyTrainingAttendeeStatus.SIGNED
-                                                                                                        ? SafetyTrainingCompletionStatus.COMPLETED
-                                                                                                        : SafetyTrainingCompletionStatus.INCOMPLETE)
-                                                                        .signedAt(attendee.getSignedAt())
-                                                                        .signatureUrl(
-                                                                                        attendee.getSignatureKey() == null
-                                                                                                        ? null
-                                                                                                        : s3Service.getPresignedViewUrl(
-                                                                                                                        attendee.getSignatureKey()))
-                                                                        .build();
-                                                })
-                                .toList();
-
-                return SafetyTrainingSessionAttendeesResponseDto.builder()
-                                .sessionId(sessionId)
-                                .targetCount(attendees.size())
-                                .attendedCount(attendedCount)
-                                .absentCount(absentCount)
-                                .absentReasonSummary(session.getAbsentReasonSummary())
-                                .attendees(attendeeItems)
-                                .build();
-        }
-
-        @Transactional
-        public SafetyTrainingSessionReportResponseDto generateSessionReport(
-                        Long sessionId, Long userId) {
-                User actor = userRepository
-                                .findById(userId)
-                                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-                validateSafetyWriteAuthority(actor);
-
-                SafetyTrainingSession session = sessionRepository
-                                .findById(sessionId)
-                                .orElseThrow(
-                                                () -> new CustomException(
-                                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
-
-                List<SafetyTrainingSessionAttendee> attendees = attendeeRepository
-                                .findAllBySessionIdWithUser(sessionId);
-
-                syncSessionCounts(session, attendees);
-
-                Map<Long, byte[]> signatureImagesByUserId = new HashMap<>();
-                for (SafetyTrainingSessionAttendee attendee : attendees) {
-                        String signatureKey = attendee.getSignatureKey();
-                        if (signatureKey == null || signatureKey.isBlank()) {
-                                continue;
-                        }
-                        try {
-                                signatureImagesByUserId.put(
-                                                attendee.getUser().getId(), s3Service.downloadFile(signatureKey));
-                        } catch (Exception ignored) {
-                                // 개별 서명 다운로드 실패 시에도 보고서 생성은 계속 진행
-                        }
-                }
-
-                byte[] reportExcel = safetyTrainingExcelService.buildSessionReportExcel(
-                                session,
-                                toMethods(session.getEducationMethodsJson()),
-                                attendees,
-                                signatureImagesByUserId);
-
-                String previousReportKey = session.getReportFileKey();
-                String newReportKey = s3Service.uploadBytes(
-                                reportExcel,
-                                "safety-training-report-"
-                                                + session.getId()
-                                                + "-"
-                                                + System.currentTimeMillis()
-                                                + ".xlsx",
-                                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-                session.setReportFileKey(newReportKey);
-
-                if (previousReportKey != null && !previousReportKey.equals(newReportKey)) {
-                        try {
-                                s3Service.deleteFile(previousReportKey);
-                        } catch (Exception ignored) {
-                                // 이전 보고서 정리 실패는 현재 요청을 실패시키지 않음
-                        }
-                }
-
-                String reportFileName = buildExportFileName(session.getStartAt(), session.getTitle());
-                return SafetyTrainingSessionReportResponseDto.builder()
-                                .sessionId(session.getId())
-                                .reportFileUrl(s3Service.getPresignedDownloadUrl(newReportKey, reportFileName))
-                                .reportFileName(reportFileName)
-                                .build();
-        }
-
-        @Transactional(readOnly = true)
-        public SafetyTrainingSessionReportResponseDto getSessionReport(Long sessionId, Long userId) {
-                User actor = userRepository
-                                .findById(userId)
-                                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-                SafetyTrainingSession session = sessionRepository
-                                .findById(sessionId)
-                                .orElseThrow(
-                                                () -> new CustomException(
-                                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
-                validateSessionReadAccess(actor, session);
-
-                if (session.getReportFileKey() == null || session.getReportFileKey().isBlank()) {
-                        throw new CustomException(ErrorCode.SAFETY_TRAINING_REPORT_NOT_FOUND);
-                }
-
-                String reportFileName = buildExportFileName(session.getStartAt(), session.getTitle());
-                return SafetyTrainingSessionReportResponseDto.builder()
-                                .sessionId(session.getId())
-                                .reportFileUrl(
-                                                s3Service.getPresignedDownloadUrl(
-                                                                session.getReportFileKey(), reportFileName))
-                                .reportFileName(reportFileName)
-                                .build();
-        }
-
-        @Transactional
-        public void signAttendance(Long sessionId, Long userId, MultipartFile signatureFile)
-                        throws IOException {
-                User actor = userRepository
-                                .findById(userId)
-                                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-                SafetyTrainingSession session = sessionRepository
-                                .findById(sessionId)
-                                .orElseThrow(
-                                                () -> new CustomException(
-                                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
-
-                if (session.getStatus() != SafetyTrainingSessionStatus.OPEN) {
-                        throw new CustomException(ErrorCode.SAFETY_TRAINING_SESSION_CLOSED);
-                }
-
-                validateSessionReadAccess(actor, session);
-
-                SafetyTrainingSessionAttendee attendee = attendeeRepository
-                                .findBySessionIdAndUserId(sessionId, userId)
-                                .orElseThrow(
-                                                () -> new CustomException(
-                                                                ErrorCode.SAFETY_TRAINING_ATTENDEE_NOT_FOUND));
-
-                if (attendee.getStatus() == SafetyTrainingAttendeeStatus.SIGNED) {
-                        throw new CustomException(ErrorCode.ALREADY_MARKED_ATTENDANCE);
-                }
-
-                if (signatureFile == null || signatureFile.isEmpty()) {
-                        throw new CustomException(ErrorCode.NO_SIGNATURE_PROVIDED);
-                }
-                validatePngFormat(signatureFile);
-
-                String signatureKey = null;
-                try {
-                        signatureKey = s3Service.uploadFile(signatureFile);
-
-                        attendee.setStatus(SafetyTrainingAttendeeStatus.SIGNED);
-                        attendee.setSignedAt(LocalDateTime.now());
-                        attendee.setSignatureKey(signatureKey);
-                        attendee.setAbsentReason(null);
-
-                        syncSessionCounts(session);
-                } catch (Exception e) {
-                        safeDeleteFile(signatureKey);
-                        throw e;
-                }
-        }
-
-        @Transactional
-        public Long update(
-                        Long sessionId, Long userId, SafetyTrainingSessionUpdateRequestDto requestDto) {
-                User actor = userRepository
-                                .findById(userId)
-                                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-                validateSafetyWriteAuthority(actor);
-                validateTimeRange(requestDto.getStartAt(), requestDto.getEndAt());
-
-                SafetyTrainingSession session = sessionRepository
-                                .findById(sessionId)
-                                .orElseThrow(
-                                                () -> new CustomException(
-                                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
-
-                if (session.getStatus() != SafetyTrainingSessionStatus.OPEN) {
-                        throw new CustomException(ErrorCode.SAFETY_TRAINING_SESSION_CLOSED);
-                }
-
-                long signedCount = attendeeRepository.countBySessionIdAndStatus(
-                                sessionId, SafetyTrainingAttendeeStatus.SIGNED);
-                if (signedCount > 0) {
-                        throw new CustomException(ErrorCode.SAFETY_TRAINING_SESSION_HAS_SIGNED_ATTENDEE);
-                }
-
-                User instructor = findAndValidateInstructor(requestDto.getInstructorUserId());
-                List<User> attendees = findTargetAttendees(requestDto.getCompanyScope());
-
-                session.setTitle(requestDto.getTitle().trim());
-                session.setEducationType(requestDto.getEducationType());
-                session.setEducationMethodsJson(toMethodsJson(requestDto.getEducationMethods()));
-                session.setStartAt(requestDto.getStartAt());
-                session.setEndAt(requestDto.getEndAt());
-                session.setEducationDateText(
-                                toEducationDateText(requestDto.getStartAt(), requestDto.getEndAt()));
-                session.setEducationContent(requestDto.getEducationContent());
-                session.setPlace(requestDto.getPlace().trim());
-                session.setCompanyScope(requestDto.getCompanyScope());
-                session.setInstructorUser(instructor);
-                session.setInstructorNameSnapshot(instructor.getNameKor());
-
-                attendeeRepository.deleteBySessionId(sessionId);
-                attendeeRepository.flush();
-
-                List<SafetyTrainingSessionAttendee> rows = attendees.stream()
-                                .map(
-                                                user -> SafetyTrainingSessionAttendee.builder()
-                                                                .session(session)
-                                                                .user(user)
-                                                                .status(SafetyTrainingAttendeeStatus.PENDING)
-                                                                .build())
-                                .toList();
-                attendeeRepository.saveAll(rows);
-
-                session.setTargetCount(rows.size());
-                session.setAttendedCount(0);
-                session.setAbsentCount(0);
-                session.setAbsentReasonSummary(null);
-
-                return session.getId();
-        }
-
-        @Transactional
-        public Long updateStatus(
-                        Long sessionId, Long userId, SafetyTrainingSessionStatusUpdateRequestDto requestDto) {
-                User actor = userRepository
-                                .findById(userId)
-                                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-                validateSafetyWriteAuthority(actor);
-
-                SafetyTrainingSession session = sessionRepository
-                                .findById(sessionId)
-                                .orElseThrow(
-                                                () -> new CustomException(
-                                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
-                if (requestDto.getStatus() == SafetyTrainingSessionStatus.CLOSED
-                                && session.getStatus() != SafetyTrainingSessionStatus.CLOSED) {
-                        List<SafetyTrainingSessionAttendee> pendingAttendees = attendeeRepository
-                                        .findAllBySessionIdAndStatus(
-                                                        sessionId, SafetyTrainingAttendeeStatus.PENDING);
-                        for (SafetyTrainingSessionAttendee attendee : pendingAttendees) {
-                                attendee.setStatus(SafetyTrainingAttendeeStatus.ABSENT);
-                                attendee.setAbsentReason(null);
-                        }
-
-                        List<SafetyTrainingSessionAttendee> absentAttendees = attendeeRepository
-                                        .findAllBySessionIdAndStatus(
-                                                        sessionId, SafetyTrainingAttendeeStatus.ABSENT);
-                        for (SafetyTrainingSessionAttendee attendee : absentAttendees) {
-                                attendee.setAbsentReason(null);
-                        }
-                } else if (requestDto.getStatus() == SafetyTrainingSessionStatus.OPEN) {
-                        // 재공개(OPEN) 시 기존 결석 확정값을 초기화한다.
-                        // ABSENT -> PENDING 으로 복원하면 absentCount는 0으로 계산된다.
-                        List<SafetyTrainingSessionAttendee> absentAttendees = attendeeRepository
-                                        .findAllBySessionIdAndStatus(
-                                                        sessionId, SafetyTrainingAttendeeStatus.ABSENT);
-                        for (SafetyTrainingSessionAttendee attendee : absentAttendees) {
-                                attendee.setStatus(SafetyTrainingAttendeeStatus.PENDING);
-                                attendee.setAbsentReason(null);
-                        }
-                }
-
-                session.setStatus(requestDto.getStatus());
-                syncSessionCounts(session);
-
-                if (requestDto.getStatus() == SafetyTrainingSessionStatus.CLOSED) {
-                        if (session.getAbsentCount() > 0) {
-                                String absentReasonSummary = trimToNull(requestDto.getAbsentReasonSummary());
-                                if (absentReasonSummary == null) {
-                                        throw new CustomException(ErrorCode.SAFETY_TRAINING_ABSENT_REASON_REQUIRED);
-                                }
-                                session.setAbsentReasonSummary(absentReasonSummary);
-                        } else {
-                                session.setAbsentReasonSummary(null);
-                        }
-                } else {
-                        session.setAbsentReasonSummary(null);
-                }
-
-                return session.getId();
-        }
-
-        @Transactional
-        public void remindSession(Long sessionId, Long userId) {
+    private static final DateTimeFormatter DATE_TIME_TEXT_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH시 mm분");
+    private static final DateTimeFormatter FILE_DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private final SafetyTrainingSessionRepository sessionRepository;
+    private final SafetyTrainingSessionAttendeeRepository attendeeRepository;
+    private final UserRepository userRepository;
+    private final ObjectMapper objectMapper;
+    private final SafetyTrainingExcelService safetyTrainingExcelService;
+    private final S3Service s3Service;
+    private final NotificationService notificationService;
+
+    @Transactional(readOnly = true)
+    public SafetyTrainingPreviewResponseDto preview(
+            Long userId, SafetyTrainingSessionCreateRequestDto requestDto) {
+        User actor =
                 userRepository
-                                .findById(userId)
-                                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        validateSafetyWriteAuthority(actor);
+        validateTimeRange(requestDto.getStartAt(), requestDto.getEndAt());
 
-                SafetyTrainingSession session = sessionRepository
-                                .findById(sessionId)
-                                .orElseThrow(
-                                                () -> new CustomException(
-                                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
+        User instructor = findAndValidateInstructor(requestDto.getInstructorUserId());
+        List<User> attendees = findTargetAttendees(requestDto.getCompanyScope());
+        String educationDateText =
+                toEducationDateText(requestDto.getStartAt(), requestDto.getEndAt());
 
-                if (session.getCreatedBy() == null
-                                || !session.getCreatedBy().getId().equals(userId)) {
-                        throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_SAFETY_WRITE);
-                }
+        byte[] excelBytes =
+                safetyTrainingExcelService.buildPreviewExcel(
+                        requestDto, educationDateText, attendees, instructor.getNameKor());
 
-                List<Long> targetUserIds = findTargetAttendees(session.getCompanyScope())
-                                .stream()
-                                .map(User::getId)
-                                .toList();
+        String previewFileKey =
+                s3Service.uploadBytes(
+                        excelBytes,
+                        "safety-training-preview-" + System.currentTimeMillis() + ".xlsx",
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        String previewFileName =
+                buildExportFileName(requestDto.getStartAt(), requestDto.getTitle());
+        String previewUrl = s3Service.getPresignedDownloadUrl(previewFileKey, previewFileName);
 
-                notificationService.sendSafetyTrainingSessionRemindAlertToAttendees(
-                                sessionId, session.getTitle(), targetUserIds);
+        return SafetyTrainingPreviewResponseDto.builder()
+                .previewFileUrl(previewUrl)
+                .previewFileName(previewFileName)
+                .targetCount(attendees.size())
+                .attendedCount(0)
+                .absentCount(0)
+                .build();
+    }
+
+    @Transactional
+    public Long create(Long userId, SafetyTrainingSessionCreateRequestDto requestDto) {
+        User actor =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        validateSafetyWriteAuthority(actor);
+        validateTimeRange(requestDto.getStartAt(), requestDto.getEndAt());
+
+        User instructor = findAndValidateInstructor(requestDto.getInstructorUserId());
+
+        String methodsJson = toMethodsJson(requestDto.getEducationMethods());
+        String educationDateText =
+                toEducationDateText(requestDto.getStartAt(), requestDto.getEndAt());
+
+        SafetyTrainingSession session =
+                SafetyTrainingSession.builder()
+                        .title(requestDto.getTitle().trim())
+                        .educationType(requestDto.getEducationType())
+                        .educationMethodsJson(methodsJson)
+                        .startAt(requestDto.getStartAt())
+                        .endAt(requestDto.getEndAt())
+                        .educationDateText(educationDateText)
+                        .educationContent(requestDto.getEducationContent())
+                        .place(requestDto.getPlace().trim())
+                        .companyScope(requestDto.getCompanyScope())
+                        .instructorUser(instructor)
+                        .instructorNameSnapshot(instructor.getNameKor())
+                        .createdBy(actor)
+                        .build();
+
+        SafetyTrainingSession saved = sessionRepository.save(session);
+
+        List<User> attendees = findTargetAttendees(requestDto.getCompanyScope());
+
+        List<SafetyTrainingSessionAttendee> rows =
+                attendees.stream()
+                        .map(
+                                user ->
+                                        SafetyTrainingSessionAttendee.builder()
+                                                .session(saved)
+                                                .user(user)
+                                                .status(SafetyTrainingAttendeeStatus.PENDING)
+                                                .build())
+                        .toList();
+
+        attendeeRepository.saveAll(rows);
+
+        saved.setTargetCount(rows.size());
+        saved.setAttendedCount(0);
+        saved.setAbsentCount(0);
+
+        // 안전보건교육 세션 생성 알림 전송
+        List<Long> attendeeIds = attendees.stream().map(User::getId).toList();
+        notificationService.sendSafetyTrainingSessionAlertToAttendees(
+                saved.getId(), saved.getTitle(), attendeeIds);
+
+        return saved.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public Page<SafetyTrainingSessionSummaryResponseDto> getSessions(
+            Long userId, SafetyTrainingSessionSearchConditionDto condition, Pageable pageable) {
+        User actor =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        SafetyTrainingSessionSearchConditionDto filter =
+                condition == null ? new SafetyTrainingSessionSearchConditionDto() : condition;
+
+        boolean canReadAllCompanies = actor.hasAuthority(Authority.MANAGE_SAFETY);
+        Company companyScope =
+                canReadAllCompanies ? filter.getCompanyScope() : actor.getWorkLocation();
+        SafetyTrainingSessionStatus status = canReadAllCompanies ? filter.getStatus() : null;
+
+        if (!canReadAllCompanies && companyScope == null) {
+            return Page.empty(pageable);
         }
 
-        @Transactional
-        public void delete(Long sessionId, Long userId) {
-                User actor = userRepository
-                                .findById(userId)
-                                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-                validateSafetyWriteAuthority(actor);
+        Page<SafetyTrainingSession> sessionsPage =
+                sessionRepository.findAllByFilters(
+                        companyScope,
+                        filter.getEducationType(),
+                        status,
+                        filter.getStartAtFrom(),
+                        filter.getStartAtTo(),
+                        filter.getNormalizedTitleKeyword(),
+                        pageable);
 
-                SafetyTrainingSession session = sessionRepository
-                                .findById(sessionId)
-                                .orElseThrow(
-                                                () -> new CustomException(
-                                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
-
-                List<SafetyTrainingSessionAttendee> attendees = attendeeRepository
-                                .findAllBySessionIdWithUser(sessionId);
-                String reportFileKey = session.getReportFileKey();
-
-                attendeeRepository.deleteBySessionId(sessionId);
-                attendeeRepository.flush();
-                sessionRepository.delete(session);
-
-                if (reportFileKey != null && !reportFileKey.isBlank()) {
-                        safeDeleteFile(reportFileKey);
-                }
-                for (SafetyTrainingSessionAttendee attendee : attendees) {
-                        String signatureKey = attendee.getSignatureKey();
-                        if (signatureKey != null && !signatureKey.isBlank()) {
-                                safeDeleteFile(signatureKey);
-                        }
-                }
+        List<Long> sessionIds =
+                sessionsPage.getContent().stream().map(SafetyTrainingSession::getId).toList();
+        Set<Long> signedSessionIds = Collections.emptySet();
+        if (!sessionIds.isEmpty() && canExposeMySigned(actor)) {
+            signedSessionIds =
+                    new HashSet<>(
+                            attendeeRepository.findSignedSessionIdsByUserIdAndSessionIds(
+                                    userId, sessionIds));
         }
 
-        private void validateSafetyWriteAuthority(User user) {
-                if (!user.hasAuthority(Authority.MANAGE_SAFETY)) {
-                        throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_SAFETY_WRITE);
-                }
-        }
+        Set<Long> finalSignedSessionIds = signedSessionIds;
+        return sessionsPage.map(
+                session ->
+                        toSummaryDto(
+                                session,
+                                resolveMySigned(
+                                        actor,
+                                        session,
+                                        finalSignedSessionIds.contains(session.getId()))));
+    }
 
-        private User findAndValidateInstructor(Long instructorUserId) {
-                return userRepository
-                                .findById(instructorUserId)
-                                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        }
+    @Transactional(readOnly = true)
+    public SafetyTrainingSessionDetailResponseDto getSessionDetail(Long sessionId, Long userId) {
+        User actor =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        private List<User> findTargetAttendees(Company companyScope) {
-                return userRepository.findAllByCompanyAndStatusExcludingPosition(
-                                companyScope, Status.AVAILABLE, Position.CEO);
-        }
+        SafetyTrainingSession session =
+                sessionRepository
+                        .findById(sessionId)
+                        .orElseThrow(
+                                () ->
+                                        new CustomException(
+                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
 
-        private void validateTimeRange(LocalDateTime startAt, LocalDateTime endAt) {
-                if (startAt == null || endAt == null || !startAt.isBefore(endAt)) {
-                        throw new CustomException(ErrorCode.INVALID_TIME_RANGE);
-                }
-        }
+        validateSessionReadAccess(actor, session);
 
-        private String trimToNull(String value) {
-                if (value == null) {
-                        return null;
-                }
-                String trimmed = value.trim();
-                return trimmed.isEmpty() ? null : trimmed;
-        }
+        SafetyTrainingSessionAttendee attendee =
+                attendeeRepository
+                        .findBySessionIdAndUserId(sessionId, userId)
+                        .orElse(
+                                SafetyTrainingSessionAttendee.builder()
+                                        .status(SafetyTrainingAttendeeStatus.PENDING)
+                                        .build());
 
-        private String buildExportFileName(LocalDateTime startAt, String title) {
-                String datePart = (startAt == null ? LocalDate.now() : startAt.toLocalDate())
-                                .format(FILE_DATE_FORMATTER);
-                String titlePart = sanitizeFileNamePart(title);
-                return datePart + "_" + titlePart + ".xlsx";
-        }
+        SafetyTrainingAttendeeStatus myStatus = attendee.getStatus();
+        SafetyTrainingCompletionStatus completionStatus =
+                resolveMyCompletionStatus(actor, session, myStatus);
 
-        private String sanitizeFileNamePart(String title) {
-                String value = trimToNull(title);
-                if (value == null) {
-                        return "안전보건교육";
-                }
-                String sanitized = value.replaceAll("[\\\\/:*?\"<>|]", " ")
-                                .replaceAll("\\s+", "_")
-                                .replaceAll("^_+|_+$", "");
-                if (sanitized.isBlank()) {
-                        sanitized = "안전보건교육";
-                }
-                if (sanitized.length() > 80) {
-                        sanitized = sanitized.substring(0, 80);
-                }
-                return sanitized;
-        }
+        String reportFileUrl =
+                session.getReportFileKey() == null
+                        ? null
+                        : s3Service.getPresignedDownloadUrl(
+                                session.getReportFileKey(),
+                                buildExportFileName(session.getStartAt(), session.getTitle()));
 
-        private String toMethodsJson(List<SafetyEducationMethod> educationMethods) {
-                try {
-                        return objectMapper.writeValueAsString(educationMethods);
-                } catch (Exception e) {
-                        throw new CustomException(ErrorCode.INVALID_ARGUMENT);
-                }
-        }
+        SafetyTrainingSessionDetailResponseDto.SessionInfo prevSession =
+                findPrevSessionInfo(actor, session);
+        SafetyTrainingSessionDetailResponseDto.SessionInfo nextSession =
+                findNextSessionInfo(actor, session);
 
-        private String toEducationDateText(LocalDateTime startAt, LocalDateTime endAt) {
-                long minutes = Duration.between(startAt, endAt).toMinutes();
-                long hours = minutes / 60;
-                long remainMinutes = minutes % 60;
+        return SafetyTrainingSessionDetailResponseDto.builder()
+                .sessionId(session.getId())
+                .title(session.getTitle())
+                .authorName(
+                        session.getCreatedBy() == null
+                                ? null
+                                : session.getCreatedBy().getDisplayName())
+                .createdAt(session.getCreatedAt())
+                .educationType(session.getEducationType())
+                .educationMethods(toMethods(session.getEducationMethodsJson()))
+                .startAt(session.getStartAt())
+                .endAt(session.getEndAt())
+                .place(session.getPlace())
+                .companyScope(session.getCompanyScope())
+                .status(session.getStatus())
+                .instructorUserId(
+                        session.getInstructorUser() == null
+                                ? null
+                                : session.getInstructorUser().getId())
+                .instructorName(session.getInstructorNameSnapshot())
+                .instructorPosition(
+                        session.getInstructorUser() == null
+                                ? null
+                                : session.getInstructorUser().getPosition())
+                .instructorDepartmentName(
+                        session.getInstructorUser() == null
+                                        || session.getInstructorUser().getDepartment() == null
+                                        || session.getInstructorUser().getDepartment().getName()
+                                                == null
+                                ? null
+                                : session.getInstructorUser()
+                                        .getDepartment()
+                                        .getName()
+                                        .getDescription())
+                .educationContent(session.getEducationContent())
+                .targetCount(session.getTargetCount())
+                .attendedCount(session.getAttendedCount())
+                .absentCount(session.getAbsentCount())
+                .absentReasonSummary(session.getAbsentReasonSummary())
+                .reportFileUrl(reportFileUrl)
+                .myAttendanceStatus(myStatus)
+                .mySigned(
+                        resolveMySigned(
+                                actor, session, myStatus == SafetyTrainingAttendeeStatus.SIGNED))
+                .myCompletionStatus(completionStatus)
+                .mySignedAt(attendee.getSignedAt())
+                .mySignatureUrl(
+                        attendee.getSignatureKey() == null
+                                ? null
+                                : s3Service.getPresignedViewUrl(attendee.getSignatureKey()))
+                .canSign(canSignSession(actor, session, myStatus))
+                .prevSession(prevSession)
+                .nextSession(nextSession)
+                .build();
+    }
 
-                String durationText = remainMinutes == 0
-                                ? String.format("%d시간", hours)
-                                : String.format("%d시간 %d분", hours, remainMinutes);
+    @Transactional(readOnly = true)
+    public SafetyTrainingSessionAttendeesResponseDto getSessionAttendees(
+            Long sessionId, Long userId) {
+        User actor =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        validateSafetyWriteAuthority(actor);
 
-                return String.format(
-                                "%s ~ %s (%s)",
-                                startAt.format(DATE_TIME_TEXT_FORMATTER),
-                                endAt.format(DATE_TIME_TEXT_FORMATTER),
-                                durationText);
-        }
+        SafetyTrainingSession session =
+                sessionRepository
+                        .findById(sessionId)
+                        .orElseThrow(
+                                () ->
+                                        new CustomException(
+                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
 
-        private void safeDeleteFile(String s3Key) {
-                if (s3Key == null || s3Key.isBlank()) {
-                        return;
-                }
-                try {
-                        s3Service.deleteFile(s3Key);
-                } catch (Exception ignored) {
-                        // 트랜잭션 롤백 시 S3 고아 파일 정리 실패 가능
-                }
-        }
+        List<SafetyTrainingSessionAttendee> attendees =
+                attendeeRepository.findAllBySessionIdWithUser(sessionId);
 
-        private void validatePngFormat(MultipartFile file) {
-                String contentType = file.getContentType();
-                if (contentType == null || !contentType.equals("image/png")) {
-                        throw new CustomException(ErrorCode.INVALID_SIGNATURE_FORMAT);
-                }
-        }
-
-        private void validateSessionReadAccess(User actor, SafetyTrainingSession session) {
-                if (actor.hasAuthority(Authority.MANAGE_SAFETY)) {
-                        return;
-                }
-                if (actor.getWorkLocation() == null
-                                || actor.getWorkLocation() != session.getCompanyScope()) {
-                        throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_SAFETY_READ);
-                }
-        }
-
-        private boolean canSignSession(
-                        User actor, SafetyTrainingSession session, SafetyTrainingAttendeeStatus myStatus) {
-                if (actor.getPosition() == Position.CEO || actor.getRole() == Role.MASTER_ADMIN) {
-                        return false;
-                }
-
-                if (actor.getWorkLocation() == null
-                                || actor.getWorkLocation() != session.getCompanyScope()) {
-                        return false;
-                }
-
-                return session.getStatus() == SafetyTrainingSessionStatus.OPEN
-                                && myStatus != SafetyTrainingAttendeeStatus.SIGNED;
-        }
-
-        private boolean canExposeMySigned(User actor) {
-                return actor.getPosition() != Position.CEO && actor.getRole() != Role.MASTER_ADMIN;
-        }
-
-        private Boolean resolveMySigned(User actor, SafetyTrainingSession session, boolean signed) {
-                if (!canExposeMySigned(actor)) {
-                        return null;
-                }
-                if (actor.getWorkLocation() == null
-                                || actor.getWorkLocation() != session.getCompanyScope()) {
-                        return null;
-                }
-                return signed;
-        }
-
-        private SafetyTrainingCompletionStatus resolveMyCompletionStatus(
-                        User actor, SafetyTrainingSession session, SafetyTrainingAttendeeStatus myStatus) {
-                if (!canExposeMySigned(actor)) {
-                        return null;
-                }
-                if (actor.getWorkLocation() == null
-                                || actor.getWorkLocation() != session.getCompanyScope()) {
-                        return null;
-                }
-                return myStatus == SafetyTrainingAttendeeStatus.SIGNED
-                                ? SafetyTrainingCompletionStatus.COMPLETED
-                                : SafetyTrainingCompletionStatus.INCOMPLETE;
-        }
-
-        private List<SafetyEducationMethod> toMethods(String educationMethodsJson) {
-                if (educationMethodsJson == null || educationMethodsJson.isBlank()) {
-                        return Collections.emptyList();
-                }
-                try {
-                        return objectMapper.readValue(
-                                        educationMethodsJson,
-                                        objectMapper
-                                                        .getTypeFactory()
-                                                        .constructCollectionType(List.class,
-                                                                        SafetyEducationMethod.class));
-                } catch (Exception e) {
-                        return Collections.emptyList();
-                }
-        }
-
-        private void syncSessionCounts(SafetyTrainingSession session) {
-                long attended = attendeeRepository.countBySessionIdAndStatus(
-                                session.getId(), SafetyTrainingAttendeeStatus.SIGNED);
-                long absent = attendeeRepository.countBySessionIdAndStatus(
-                                session.getId(), SafetyTrainingAttendeeStatus.ABSENT);
-                session.setAttendedCount((int) attended);
-                session.setAbsentCount((int) absent);
-        }
-
-        private void syncSessionCounts(
-                        SafetyTrainingSession session, List<SafetyTrainingSessionAttendee> attendees) {
-                int attendedCount = (int) attendees.stream()
+        int attendedCount =
+                (int)
+                        attendees.stream()
                                 .filter(it -> it.getStatus() == SafetyTrainingAttendeeStatus.SIGNED)
                                 .count();
-                int absentCount = (int) attendees.stream()
+        int absentCount =
+                (int)
+                        attendees.stream()
                                 .filter(it -> it.getStatus() == SafetyTrainingAttendeeStatus.ABSENT)
                                 .count();
-                session.setTargetCount(attendees.size());
-                session.setAttendedCount(attendedCount);
-                session.setAbsentCount(absentCount);
+
+        List<SafetyTrainingSessionAttendeesResponseDto.AttendeeItem> attendeeItems =
+                attendees.stream()
+                        .map(
+                                attendee -> {
+                                    User user = attendee.getUser();
+                                    String departmentName =
+                                            user.getDepartment() == null
+                                                            || user.getDepartment().getName()
+                                                                    == null
+                                                    ? null
+                                                    : user.getDepartment()
+                                                            .getName()
+                                                            .getDescription();
+                                    return SafetyTrainingSessionAttendeesResponseDto.AttendeeItem
+                                            .builder()
+                                            .userId(user.getId())
+                                            .userName(user.getNameKor())
+                                            .departmentName(departmentName)
+                                            .attendanceStatus(attendee.getStatus())
+                                            .completionStatus(
+                                                    attendee.getStatus()
+                                                                    == SafetyTrainingAttendeeStatus
+                                                                            .SIGNED
+                                                            ? SafetyTrainingCompletionStatus
+                                                                    .COMPLETED
+                                                            : SafetyTrainingCompletionStatus
+                                                                    .INCOMPLETE)
+                                            .signedAt(attendee.getSignedAt())
+                                            .signatureUrl(
+                                                    attendee.getSignatureKey() == null
+                                                            ? null
+                                                            : s3Service.getPresignedViewUrl(
+                                                                    attendee.getSignatureKey()))
+                                            .build();
+                                })
+                        .toList();
+
+        return SafetyTrainingSessionAttendeesResponseDto.builder()
+                .sessionId(sessionId)
+                .targetCount(attendees.size())
+                .attendedCount(attendedCount)
+                .absentCount(absentCount)
+                .absentReasonSummary(session.getAbsentReasonSummary())
+                .attendees(attendeeItems)
+                .build();
+    }
+
+    @Transactional
+    public SafetyTrainingSessionReportResponseDto generateSessionReport(
+            Long sessionId, Long userId) {
+        User actor =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        validateSafetyWriteAuthority(actor);
+
+        SafetyTrainingSession session =
+                sessionRepository
+                        .findById(sessionId)
+                        .orElseThrow(
+                                () ->
+                                        new CustomException(
+                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
+
+        List<SafetyTrainingSessionAttendee> attendees =
+                attendeeRepository.findAllBySessionIdWithUser(sessionId);
+
+        syncSessionCounts(session, attendees);
+
+        Map<Long, byte[]> signatureImagesByUserId = new HashMap<>();
+        for (SafetyTrainingSessionAttendee attendee : attendees) {
+            String signatureKey = attendee.getSignatureKey();
+            if (signatureKey == null || signatureKey.isBlank()) {
+                continue;
+            }
+            try {
+                signatureImagesByUserId.put(
+                        attendee.getUser().getId(), s3Service.downloadFile(signatureKey));
+            } catch (Exception ignored) {
+                // 개별 서명 다운로드 실패 시에도 보고서 생성은 계속 진행
+            }
         }
 
-        private SafetyTrainingSessionSummaryResponseDto toSummaryDto(
-                        SafetyTrainingSession session, Boolean mySigned) {
-                return SafetyTrainingSessionSummaryResponseDto.builder()
-                                .sessionId(session.getId())
-                                .title(session.getTitle())
-                                .educationType(session.getEducationType())
-                                .startAt(session.getStartAt())
-                                .endAt(session.getEndAt())
-                                .place(session.getPlace())
-                                .companyScope(session.getCompanyScope())
-                                .instructorUserId(
-                                                session.getInstructorUser() == null
-                                                                ? null
-                                                                : session.getInstructorUser().getId())
-                                .instructorName(session.getInstructorNameSnapshot())
-                                .status(session.getStatus())
-                                .targetCount(session.getTargetCount())
-                                .attendedCount(session.getAttendedCount())
-                                .absentCount(session.getAbsentCount())
-                                .mySigned(mySigned)
-                                .authorName(
-                                                session.getCreatedBy() == null
-                                                                ? null
-                                                                : session.getCreatedBy().getDisplayName())
-                                .createdAt(session.getCreatedAt())
-                                .build();
+        byte[] reportExcel =
+                safetyTrainingExcelService.buildSessionReportExcel(
+                        session,
+                        toMethods(session.getEducationMethodsJson()),
+                        attendees,
+                        signatureImagesByUserId);
+
+        String previousReportKey = session.getReportFileKey();
+        String newReportKey =
+                s3Service.uploadBytes(
+                        reportExcel,
+                        "safety-training-report-"
+                                + session.getId()
+                                + "-"
+                                + System.currentTimeMillis()
+                                + ".xlsx",
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        session.setReportFileKey(newReportKey);
+
+        if (previousReportKey != null && !previousReportKey.equals(newReportKey)) {
+            try {
+                s3Service.deleteFile(previousReportKey);
+            } catch (Exception ignored) {
+                // 이전 보고서 정리 실패는 현재 요청을 실패시키지 않음
+            }
         }
 
-        private SafetyTrainingSessionDetailResponseDto.SessionInfo findPrevSessionInfo(
-                        User actor, SafetyTrainingSession current) {
-                return findNeighborSession(actor, current, true).orElse(null);
+        String reportFileName = buildExportFileName(session.getStartAt(), session.getTitle());
+        return SafetyTrainingSessionReportResponseDto.builder()
+                .sessionId(session.getId())
+                .reportFileUrl(s3Service.getPresignedDownloadUrl(newReportKey, reportFileName))
+                .reportFileName(reportFileName)
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public SafetyTrainingSessionReportResponseDto getSessionReport(Long sessionId, Long userId) {
+        User actor =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        SafetyTrainingSession session =
+                sessionRepository
+                        .findById(sessionId)
+                        .orElseThrow(
+                                () ->
+                                        new CustomException(
+                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
+        validateSessionReadAccess(actor, session);
+
+        if (session.getReportFileKey() == null || session.getReportFileKey().isBlank()) {
+            throw new CustomException(ErrorCode.SAFETY_TRAINING_REPORT_NOT_FOUND);
         }
 
-        private SafetyTrainingSessionDetailResponseDto.SessionInfo findNextSessionInfo(
-                        User actor, SafetyTrainingSession current) {
-                return findNeighborSession(actor, current, false).orElse(null);
+        String reportFileName = buildExportFileName(session.getStartAt(), session.getTitle());
+        return SafetyTrainingSessionReportResponseDto.builder()
+                .sessionId(session.getId())
+                .reportFileUrl(
+                        s3Service.getPresignedDownloadUrl(
+                                session.getReportFileKey(), reportFileName))
+                .reportFileName(reportFileName)
+                .build();
+    }
+
+    @Transactional
+    public void signAttendance(Long sessionId, Long userId, MultipartFile signatureFile)
+            throws IOException {
+        User actor =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        SafetyTrainingSession session =
+                sessionRepository
+                        .findById(sessionId)
+                        .orElseThrow(
+                                () ->
+                                        new CustomException(
+                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
+
+        if (session.getStatus() != SafetyTrainingSessionStatus.OPEN) {
+            throw new CustomException(ErrorCode.SAFETY_TRAINING_SESSION_CLOSED);
         }
 
-        private java.util.Optional<SafetyTrainingSessionDetailResponseDto.SessionInfo> findNeighborSession(User actor,
-                        SafetyTrainingSession current, boolean previous) {
-                java.util.Optional<SafetyTrainingSession> neighbor;
-                if (actor.hasAuthority(Authority.MANAGE_SAFETY)) {
-                        neighbor = previous
-                                        ? sessionRepository.findFirstByIdGreaterThanOrderByIdAsc(
-                                                        current.getId())
-                                        : sessionRepository.findFirstByIdLessThanOrderByIdDesc(current.getId());
-                } else {
-                        Company company = actor.getWorkLocation();
-                        if (company == null) {
-                                return java.util.Optional.empty();
-                        }
-                        neighbor = previous
-                                        ? sessionRepository.findFirstByCompanyScopeAndIdGreaterThanOrderByIdAsc(
-                                                        company, current.getId())
-                                        : sessionRepository.findFirstByCompanyScopeAndIdLessThanOrderByIdDesc(
-                                                        company, current.getId());
+        validateSessionReadAccess(actor, session);
+
+        SafetyTrainingSessionAttendee attendee =
+                attendeeRepository
+                        .findBySessionIdAndUserId(sessionId, userId)
+                        .orElseThrow(
+                                () ->
+                                        new CustomException(
+                                                ErrorCode.SAFETY_TRAINING_ATTENDEE_NOT_FOUND));
+
+        if (attendee.getStatus() == SafetyTrainingAttendeeStatus.SIGNED) {
+            throw new CustomException(ErrorCode.ALREADY_MARKED_ATTENDANCE);
+        }
+
+        if (signatureFile == null || signatureFile.isEmpty()) {
+            throw new CustomException(ErrorCode.NO_SIGNATURE_PROVIDED);
+        }
+        validatePngFormat(signatureFile);
+
+        String signatureKey = null;
+        try {
+            signatureKey = s3Service.uploadFile(signatureFile);
+
+            attendee.setStatus(SafetyTrainingAttendeeStatus.SIGNED);
+            attendee.setSignedAt(LocalDateTime.now());
+            attendee.setSignatureKey(signatureKey);
+            attendee.setAbsentReason(null);
+
+            syncSessionCounts(session);
+        } catch (Exception e) {
+            safeDeleteFile(signatureKey);
+            throw e;
+        }
+    }
+
+    @Transactional
+    public Long update(
+            Long sessionId, Long userId, SafetyTrainingSessionUpdateRequestDto requestDto) {
+        User actor =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        validateSafetyWriteAuthority(actor);
+        validateTimeRange(requestDto.getStartAt(), requestDto.getEndAt());
+
+        SafetyTrainingSession session =
+                sessionRepository
+                        .findById(sessionId)
+                        .orElseThrow(
+                                () ->
+                                        new CustomException(
+                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
+
+        if (session.getStatus() != SafetyTrainingSessionStatus.OPEN) {
+            throw new CustomException(ErrorCode.SAFETY_TRAINING_SESSION_CLOSED);
+        }
+
+        long signedCount =
+                attendeeRepository.countBySessionIdAndStatus(
+                        sessionId, SafetyTrainingAttendeeStatus.SIGNED);
+        if (signedCount > 0) {
+            throw new CustomException(ErrorCode.SAFETY_TRAINING_SESSION_HAS_SIGNED_ATTENDEE);
+        }
+
+        User instructor = findAndValidateInstructor(requestDto.getInstructorUserId());
+        List<User> attendees = findTargetAttendees(requestDto.getCompanyScope());
+
+        session.setTitle(requestDto.getTitle().trim());
+        session.setEducationType(requestDto.getEducationType());
+        session.setEducationMethodsJson(toMethodsJson(requestDto.getEducationMethods()));
+        session.setStartAt(requestDto.getStartAt());
+        session.setEndAt(requestDto.getEndAt());
+        session.setEducationDateText(
+                toEducationDateText(requestDto.getStartAt(), requestDto.getEndAt()));
+        session.setEducationContent(requestDto.getEducationContent());
+        session.setPlace(requestDto.getPlace().trim());
+        session.setCompanyScope(requestDto.getCompanyScope());
+        session.setInstructorUser(instructor);
+        session.setInstructorNameSnapshot(instructor.getNameKor());
+
+        attendeeRepository.deleteBySessionId(sessionId);
+        attendeeRepository.flush();
+
+        List<SafetyTrainingSessionAttendee> rows =
+                attendees.stream()
+                        .map(
+                                user ->
+                                        SafetyTrainingSessionAttendee.builder()
+                                                .session(session)
+                                                .user(user)
+                                                .status(SafetyTrainingAttendeeStatus.PENDING)
+                                                .build())
+                        .toList();
+        attendeeRepository.saveAll(rows);
+
+        session.setTargetCount(rows.size());
+        session.setAttendedCount(0);
+        session.setAbsentCount(0);
+        session.setAbsentReasonSummary(null);
+
+        return session.getId();
+    }
+
+    @Transactional
+    public Long updateStatus(
+            Long sessionId, Long userId, SafetyTrainingSessionStatusUpdateRequestDto requestDto) {
+        User actor =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        validateSafetyWriteAuthority(actor);
+
+        SafetyTrainingSession session =
+                sessionRepository
+                        .findById(sessionId)
+                        .orElseThrow(
+                                () ->
+                                        new CustomException(
+                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
+        if (requestDto.getStatus() == SafetyTrainingSessionStatus.CLOSED
+                && session.getStatus() != SafetyTrainingSessionStatus.CLOSED) {
+            List<SafetyTrainingSessionAttendee> pendingAttendees =
+                    attendeeRepository.findAllBySessionIdAndStatus(
+                            sessionId, SafetyTrainingAttendeeStatus.PENDING);
+            for (SafetyTrainingSessionAttendee attendee : pendingAttendees) {
+                attendee.setStatus(SafetyTrainingAttendeeStatus.ABSENT);
+                attendee.setAbsentReason(null);
+            }
+
+            List<SafetyTrainingSessionAttendee> absentAttendees =
+                    attendeeRepository.findAllBySessionIdAndStatus(
+                            sessionId, SafetyTrainingAttendeeStatus.ABSENT);
+            for (SafetyTrainingSessionAttendee attendee : absentAttendees) {
+                attendee.setAbsentReason(null);
+            }
+        } else if (requestDto.getStatus() == SafetyTrainingSessionStatus.OPEN) {
+            // 재공개(OPEN) 시 기존 결석 확정값을 초기화한다.
+            // ABSENT -> PENDING 으로 복원하면 absentCount는 0으로 계산된다.
+            List<SafetyTrainingSessionAttendee> absentAttendees =
+                    attendeeRepository.findAllBySessionIdAndStatus(
+                            sessionId, SafetyTrainingAttendeeStatus.ABSENT);
+            for (SafetyTrainingSessionAttendee attendee : absentAttendees) {
+                attendee.setStatus(SafetyTrainingAttendeeStatus.PENDING);
+                attendee.setAbsentReason(null);
+            }
+        }
+
+        session.setStatus(requestDto.getStatus());
+        syncSessionCounts(session);
+
+        if (requestDto.getStatus() == SafetyTrainingSessionStatus.CLOSED) {
+            if (session.getAbsentCount() > 0) {
+                String absentReasonSummary = trimToNull(requestDto.getAbsentReasonSummary());
+                if (absentReasonSummary == null) {
+                    throw new CustomException(ErrorCode.SAFETY_TRAINING_ABSENT_REASON_REQUIRED);
                 }
-
-                return neighbor.map(this::toSessionInfo);
+                session.setAbsentReasonSummary(absentReasonSummary);
+            } else {
+                session.setAbsentReasonSummary(null);
+            }
+        } else {
+            session.setAbsentReasonSummary(null);
         }
 
-        private SafetyTrainingSessionDetailResponseDto.SessionInfo toSessionInfo(
-                        SafetyTrainingSession session) {
-                return SafetyTrainingSessionDetailResponseDto.SessionInfo.builder()
-                                .sessionId(session.getId())
-                                .title(session.getTitle())
-                                .authorName(
-                                                session.getCreatedBy() == null
-                                                                ? null
-                                                                : session.getCreatedBy().getDisplayName())
-                                .createdAt(session.getCreatedAt())
-                                .build();
+        return session.getId();
+    }
+
+    @Transactional
+    public void remindSession(Long sessionId, Long userId) {
+        userRepository
+                .findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        SafetyTrainingSession session =
+                sessionRepository
+                        .findById(sessionId)
+                        .orElseThrow(
+                                () ->
+                                        new CustomException(
+                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
+
+        if (session.getCreatedBy() == null || !session.getCreatedBy().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_SAFETY_WRITE);
         }
+
+        List<Long> targetUserIds =
+                findTargetAttendees(session.getCompanyScope()).stream().map(User::getId).toList();
+
+        notificationService.sendSafetyTrainingSessionRemindAlertToAttendees(
+                sessionId, session.getTitle(), targetUserIds);
+    }
+
+    @Transactional
+    public void delete(Long sessionId, Long userId) {
+        User actor =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        validateSafetyWriteAuthority(actor);
+
+        SafetyTrainingSession session =
+                sessionRepository
+                        .findById(sessionId)
+                        .orElseThrow(
+                                () ->
+                                        new CustomException(
+                                                ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND));
+
+        List<SafetyTrainingSessionAttendee> attendees =
+                attendeeRepository.findAllBySessionIdWithUser(sessionId);
+        String reportFileKey = session.getReportFileKey();
+
+        attendeeRepository.deleteBySessionId(sessionId);
+        attendeeRepository.flush();
+        sessionRepository.delete(session);
+
+        if (reportFileKey != null && !reportFileKey.isBlank()) {
+            safeDeleteFile(reportFileKey);
+        }
+        for (SafetyTrainingSessionAttendee attendee : attendees) {
+            String signatureKey = attendee.getSignatureKey();
+            if (signatureKey != null && !signatureKey.isBlank()) {
+                safeDeleteFile(signatureKey);
+            }
+        }
+    }
+
+    private void validateSafetyWriteAuthority(User user) {
+        if (!user.hasAuthority(Authority.MANAGE_SAFETY)) {
+            throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_SAFETY_WRITE);
+        }
+    }
+
+    private User findAndValidateInstructor(Long instructorUserId) {
+        return userRepository
+                .findById(instructorUserId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private List<User> findTargetAttendees(Company companyScope) {
+        return userRepository.findAllByCompanyAndStatusExcludingPosition(
+                companyScope, Status.AVAILABLE, Position.CEO);
+    }
+
+    private void validateTimeRange(LocalDateTime startAt, LocalDateTime endAt) {
+        if (startAt == null || endAt == null || !startAt.isBefore(endAt)) {
+            throw new CustomException(ErrorCode.INVALID_TIME_RANGE);
+        }
+    }
+
+    private String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private String buildExportFileName(LocalDateTime startAt, String title) {
+        String datePart =
+                (startAt == null ? LocalDate.now() : startAt.toLocalDate())
+                        .format(FILE_DATE_FORMATTER);
+        String titlePart = sanitizeFileNamePart(title);
+        return datePart + "_" + titlePart + ".xlsx";
+    }
+
+    private String sanitizeFileNamePart(String title) {
+        String value = trimToNull(title);
+        if (value == null) {
+            return "안전보건교육";
+        }
+        String sanitized =
+                value.replaceAll("[\\\\/:*?\"<>|]", " ")
+                        .replaceAll("\\s+", "_")
+                        .replaceAll("^_+|_+$", "");
+        if (sanitized.isBlank()) {
+            sanitized = "안전보건교육";
+        }
+        if (sanitized.length() > 80) {
+            sanitized = sanitized.substring(0, 80);
+        }
+        return sanitized;
+    }
+
+    private String toMethodsJson(List<SafetyEducationMethod> educationMethods) {
+        try {
+            return objectMapper.writeValueAsString(educationMethods);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+        }
+    }
+
+    private String toEducationDateText(LocalDateTime startAt, LocalDateTime endAt) {
+        long minutes = Duration.between(startAt, endAt).toMinutes();
+        long hours = minutes / 60;
+        long remainMinutes = minutes % 60;
+
+        String durationText =
+                remainMinutes == 0
+                        ? String.format("%d시간", hours)
+                        : String.format("%d시간 %d분", hours, remainMinutes);
+
+        return String.format(
+                "%s ~ %s (%s)",
+                startAt.format(DATE_TIME_TEXT_FORMATTER),
+                endAt.format(DATE_TIME_TEXT_FORMATTER),
+                durationText);
+    }
+
+    private void safeDeleteFile(String s3Key) {
+        if (s3Key == null || s3Key.isBlank()) {
+            return;
+        }
+        try {
+            s3Service.deleteFile(s3Key);
+        } catch (Exception ignored) {
+            // 트랜잭션 롤백 시 S3 고아 파일 정리 실패 가능
+        }
+    }
+
+    private void validatePngFormat(MultipartFile file) {
+        String contentType = file.getContentType();
+        if (contentType == null || !contentType.equals("image/png")) {
+            throw new CustomException(ErrorCode.INVALID_SIGNATURE_FORMAT);
+        }
+    }
+
+    private void validateSessionReadAccess(User actor, SafetyTrainingSession session) {
+        if (actor.hasAuthority(Authority.MANAGE_SAFETY)) {
+            return;
+        }
+        if (actor.getWorkLocation() == null
+                || actor.getWorkLocation() != session.getCompanyScope()) {
+            throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_SAFETY_READ);
+        }
+    }
+
+    private boolean canSignSession(
+            User actor, SafetyTrainingSession session, SafetyTrainingAttendeeStatus myStatus) {
+        if (actor.getPosition() == Position.CEO || actor.getRole() == Role.MASTER_ADMIN) {
+            return false;
+        }
+
+        if (actor.getWorkLocation() == null
+                || actor.getWorkLocation() != session.getCompanyScope()) {
+            return false;
+        }
+
+        return session.getStatus() == SafetyTrainingSessionStatus.OPEN
+                && myStatus != SafetyTrainingAttendeeStatus.SIGNED;
+    }
+
+    private boolean canExposeMySigned(User actor) {
+        return actor.getPosition() != Position.CEO && actor.getRole() != Role.MASTER_ADMIN;
+    }
+
+    private Boolean resolveMySigned(User actor, SafetyTrainingSession session, boolean signed) {
+        if (!canExposeMySigned(actor)) {
+            return null;
+        }
+        if (actor.getWorkLocation() == null
+                || actor.getWorkLocation() != session.getCompanyScope()) {
+            return null;
+        }
+        return signed;
+    }
+
+    private SafetyTrainingCompletionStatus resolveMyCompletionStatus(
+            User actor, SafetyTrainingSession session, SafetyTrainingAttendeeStatus myStatus) {
+        if (!canExposeMySigned(actor)) {
+            return null;
+        }
+        if (actor.getWorkLocation() == null
+                || actor.getWorkLocation() != session.getCompanyScope()) {
+            return null;
+        }
+        return myStatus == SafetyTrainingAttendeeStatus.SIGNED
+                ? SafetyTrainingCompletionStatus.COMPLETED
+                : SafetyTrainingCompletionStatus.INCOMPLETE;
+    }
+
+    private List<SafetyEducationMethod> toMethods(String educationMethodsJson) {
+        if (educationMethodsJson == null || educationMethodsJson.isBlank()) {
+            return Collections.emptyList();
+        }
+        try {
+            return objectMapper.readValue(
+                    educationMethodsJson,
+                    objectMapper
+                            .getTypeFactory()
+                            .constructCollectionType(List.class, SafetyEducationMethod.class));
+        } catch (Exception e) {
+            return Collections.emptyList();
+        }
+    }
+
+    private void syncSessionCounts(SafetyTrainingSession session) {
+        long attended =
+                attendeeRepository.countBySessionIdAndStatus(
+                        session.getId(), SafetyTrainingAttendeeStatus.SIGNED);
+        long absent =
+                attendeeRepository.countBySessionIdAndStatus(
+                        session.getId(), SafetyTrainingAttendeeStatus.ABSENT);
+        session.setAttendedCount((int) attended);
+        session.setAbsentCount((int) absent);
+    }
+
+    private void syncSessionCounts(
+            SafetyTrainingSession session, List<SafetyTrainingSessionAttendee> attendees) {
+        int attendedCount =
+                (int)
+                        attendees.stream()
+                                .filter(it -> it.getStatus() == SafetyTrainingAttendeeStatus.SIGNED)
+                                .count();
+        int absentCount =
+                (int)
+                        attendees.stream()
+                                .filter(it -> it.getStatus() == SafetyTrainingAttendeeStatus.ABSENT)
+                                .count();
+        session.setTargetCount(attendees.size());
+        session.setAttendedCount(attendedCount);
+        session.setAbsentCount(absentCount);
+    }
+
+    private SafetyTrainingSessionSummaryResponseDto toSummaryDto(
+            SafetyTrainingSession session, Boolean mySigned) {
+        return SafetyTrainingSessionSummaryResponseDto.builder()
+                .sessionId(session.getId())
+                .title(session.getTitle())
+                .educationType(session.getEducationType())
+                .startAt(session.getStartAt())
+                .endAt(session.getEndAt())
+                .place(session.getPlace())
+                .companyScope(session.getCompanyScope())
+                .instructorUserId(
+                        session.getInstructorUser() == null
+                                ? null
+                                : session.getInstructorUser().getId())
+                .instructorName(session.getInstructorNameSnapshot())
+                .status(session.getStatus())
+                .targetCount(session.getTargetCount())
+                .attendedCount(session.getAttendedCount())
+                .absentCount(session.getAbsentCount())
+                .mySigned(mySigned)
+                .authorName(
+                        session.getCreatedBy() == null
+                                ? null
+                                : session.getCreatedBy().getDisplayName())
+                .createdAt(session.getCreatedAt())
+                .build();
+    }
+
+    private SafetyTrainingSessionDetailResponseDto.SessionInfo findPrevSessionInfo(
+            User actor, SafetyTrainingSession current) {
+        return findNeighborSession(actor, current, true).orElse(null);
+    }
+
+    private SafetyTrainingSessionDetailResponseDto.SessionInfo findNextSessionInfo(
+            User actor, SafetyTrainingSession current) {
+        return findNeighborSession(actor, current, false).orElse(null);
+    }
+
+    private java.util.Optional<SafetyTrainingSessionDetailResponseDto.SessionInfo>
+            findNeighborSession(User actor, SafetyTrainingSession current, boolean previous) {
+        java.util.Optional<SafetyTrainingSession> neighbor;
+        if (actor.hasAuthority(Authority.MANAGE_SAFETY)) {
+            neighbor =
+                    previous
+                            ? sessionRepository.findFirstByIdGreaterThanOrderByIdAsc(
+                                    current.getId())
+                            : sessionRepository.findFirstByIdLessThanOrderByIdDesc(current.getId());
+        } else {
+            Company company = actor.getWorkLocation();
+            if (company == null) {
+                return java.util.Optional.empty();
+            }
+            neighbor =
+                    previous
+                            ? sessionRepository.findFirstByCompanyScopeAndIdGreaterThanOrderByIdAsc(
+                                    company, current.getId())
+                            : sessionRepository.findFirstByCompanyScopeAndIdLessThanOrderByIdDesc(
+                                    company, current.getId());
+        }
+
+        return neighbor.map(this::toSessionInfo);
+    }
+
+    private SafetyTrainingSessionDetailResponseDto.SessionInfo toSessionInfo(
+            SafetyTrainingSession session) {
+        return SafetyTrainingSessionDetailResponseDto.SessionInfo.builder()
+                .sessionId(session.getId())
+                .title(session.getTitle())
+                .authorName(
+                        session.getCreatedBy() == null
+                                ? null
+                                : session.getCreatedBy().getDisplayName())
+                .createdAt(session.getCreatedAt())
+                .build();
+    }
 }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
@@ -2099,12 +2099,13 @@ public class EduReportServiceTest {
         void remindEduReport_throwsWhenCreatedByIsNull() {
             // given
             User user = createNormalUser();
-            EduReport report = EduReport.builder()
-                    .id(10L)
-                    .eduType(EduType.SAFETY)
-                    .title("안전 교육")
-                    .createdBy(null)
-                    .build();
+            EduReport report =
+                    EduReport.builder()
+                            .id(10L)
+                            .eduType(EduType.SAFETY)
+                            .title("안전 교육")
+                            .createdBy(null)
+                            .build();
 
             when(userRepository.findById(1L)).thenReturn(Optional.of(user));
             when(eduReportRepository.findById(10L)).thenReturn(Optional.of(report));
@@ -2121,14 +2122,15 @@ public class EduReportServiceTest {
         void remindEduReport_throwsWhenNotCreator() {
             // given
             User requestUser = createNormalUser(); // id = 1L
-            User anotherUser = createAdminUser();  // id = 99L
+            User anotherUser = createAdminUser(); // id = 99L
 
-            EduReport report = EduReport.builder()
-                    .id(10L)
-                    .eduType(EduType.SAFETY)
-                    .title("안전 교육")
-                    .createdBy(anotherUser)
-                    .build();
+            EduReport report =
+                    EduReport.builder()
+                            .id(10L)
+                            .eduType(EduType.SAFETY)
+                            .title("안전 교육")
+                            .createdBy(anotherUser)
+                            .build();
 
             when(userRepository.findById(1L)).thenReturn(Optional.of(requestUser));
             when(eduReportRepository.findById(10L)).thenReturn(Optional.of(report));
@@ -2145,13 +2147,14 @@ public class EduReportServiceTest {
         void remindEduReport_psmType_companyNull_callsFindAllActiveUserIds() {
             // given
             User user = createNormalUser();
-            EduReport report = EduReport.builder()
-                    .id(10L)
-                    .eduType(EduType.PSM)
-                    .title("PSM 교육")
-                    .company(null)
-                    .createdBy(user)
-                    .build();
+            EduReport report =
+                    EduReport.builder()
+                            .id(10L)
+                            .eduType(EduType.PSM)
+                            .title("PSM 교육")
+                            .company(null)
+                            .createdBy(user)
+                            .build();
 
             List<Long> targetIds = List.of(1L, 2L, 3L);
             when(userRepository.findById(1L)).thenReturn(Optional.of(user));
@@ -2174,13 +2177,14 @@ public class EduReportServiceTest {
         void remindEduReport_psmType_withCompany_callsFindAllIdsByCompany() {
             // given
             User user = createNormalUser();
-            EduReport report = EduReport.builder()
-                    .id(10L)
-                    .eduType(EduType.PSM)
-                    .title("PSM 교육")
-                    .company(Company.AWESOME)
-                    .createdBy(user)
-                    .build();
+            EduReport report =
+                    EduReport.builder()
+                            .id(10L)
+                            .eduType(EduType.PSM)
+                            .title("PSM 교육")
+                            .company(Company.AWESOME)
+                            .createdBy(user)
+                            .build();
 
             List<Long> targetIds = List.of(1L, 2L);
             when(userRepository.findById(1L)).thenReturn(Optional.of(user));
@@ -2203,13 +2207,14 @@ public class EduReportServiceTest {
         void remindEduReport_safetyType_metadataContainsDetailTypeGeneral() {
             // given
             User user = createNormalUser();
-            EduReport report = EduReport.builder()
-                    .id(10L)
-                    .eduType(EduType.SAFETY)
-                    .title("안전 보건 교육")
-                    .company(null)
-                    .createdBy(user)
-                    .build();
+            EduReport report =
+                    EduReport.builder()
+                            .id(10L)
+                            .eduType(EduType.SAFETY)
+                            .title("안전 보건 교육")
+                            .company(null)
+                            .createdBy(user)
+                            .build();
 
             when(userRepository.findById(1L)).thenReturn(Optional.of(user));
             when(eduReportRepository.findById(10L)).thenReturn(Optional.of(report));
@@ -2233,18 +2238,20 @@ public class EduReportServiceTest {
         void remindEduReport_departmentType_withDepartment_callsFindAllIdsByDepartmentId() {
             // given
             User user = createNormalUser();
-            EduReport report = EduReport.builder()
-                    .id(10L)
-                    .eduType(EduType.DEPARTMENT)
-                    .title("부서 교육")
-                    .department(defaultDept)
-                    .createdBy(user)
-                    .build();
+            EduReport report =
+                    EduReport.builder()
+                            .id(10L)
+                            .eduType(EduType.DEPARTMENT)
+                            .title("부서 교육")
+                            .department(defaultDept)
+                            .createdBy(user)
+                            .build();
 
             List<Long> targetIds = List.of(1L, 2L);
             when(userRepository.findById(1L)).thenReturn(Optional.of(user));
             when(eduReportRepository.findById(10L)).thenReturn(Optional.of(report));
-            when(userRepository.findAllIdsByDepartmentId(defaultDept.getId())).thenReturn(targetIds);
+            when(userRepository.findAllIdsByDepartmentId(defaultDept.getId()))
+                    .thenReturn(targetIds);
 
             // when
             eduReportService.remindEduReport(10L, 1L);
@@ -2261,13 +2268,14 @@ public class EduReportServiceTest {
         void remindEduReport_callsNotificationServiceWithCorrectArgs() {
             // given
             User user = createNormalUser();
-            EduReport report = EduReport.builder()
-                    .id(10L)
-                    .eduType(EduType.PSM)
-                    .title("PSM 교육 제목")
-                    .company(null)
-                    .createdBy(user)
-                    .build();
+            EduReport report =
+                    EduReport.builder()
+                            .id(10L)
+                            .eduType(EduType.PSM)
+                            .title("PSM 교육 제목")
+                            .company(null)
+                            .createdBy(user)
+                            .build();
 
             List<Long> targetIds = List.of(1L, 2L, 3L);
             when(userRepository.findById(1L)).thenReturn(Optional.of(user));

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
@@ -2061,4 +2061,241 @@ public class EduReportServiceTest {
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.EDU_REPORT_CLOSED);
         verify(eduAttendanceRepository, never()).save(any());
     }
+
+    @org.junit.jupiter.api.Nested
+    @DisplayName("remindEduReport")
+    class RemindEduReport {
+
+        @Test
+        @DisplayName("리마인드 실패 - 사용자 없음")
+        void remindEduReport_throwsWhenUserNotFound() {
+            // given
+            when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> eduReportService.remindEduReport(10L, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.USER_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("리마인드 실패 - 교육 보고서 없음")
+        void remindEduReport_throwsWhenEduReportNotFound() {
+            // given
+            User user = createNormalUser();
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(eduReportRepository.findById(10L)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> eduReportService.remindEduReport(10L, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.EDU_REPORT_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("리마인드 실패 - 권한 없음 (createdBy가 null)")
+        void remindEduReport_throwsWhenCreatedByIsNull() {
+            // given
+            User user = createNormalUser();
+            EduReport report = EduReport.builder()
+                    .id(10L)
+                    .eduType(EduType.SAFETY)
+                    .title("안전 교육")
+                    .createdBy(null)
+                    .build();
+
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(eduReportRepository.findById(10L)).thenReturn(Optional.of(report));
+
+            // when & then
+            assertThatThrownBy(() -> eduReportService.remindEduReport(10L, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.NO_AUTHORITY_FOR_EDU_REPORT);
+        }
+
+        @Test
+        @DisplayName("리마인드 실패 - 권한 없음 (다른 사용자가 작성한 보고서)")
+        void remindEduReport_throwsWhenNotCreator() {
+            // given
+            User requestUser = createNormalUser(); // id = 1L
+            User anotherUser = createAdminUser();  // id = 99L
+
+            EduReport report = EduReport.builder()
+                    .id(10L)
+                    .eduType(EduType.SAFETY)
+                    .title("안전 교육")
+                    .createdBy(anotherUser)
+                    .build();
+
+            when(userRepository.findById(1L)).thenReturn(Optional.of(requestUser));
+            when(eduReportRepository.findById(10L)).thenReturn(Optional.of(report));
+
+            // when & then
+            assertThatThrownBy(() -> eduReportService.remindEduReport(10L, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.NO_AUTHORITY_FOR_EDU_REPORT);
+        }
+
+        @Test
+        @DisplayName("PSM 타입 - company가 null이면 findAllActiveUserIds 호출")
+        void remindEduReport_psmType_companyNull_callsFindAllActiveUserIds() {
+            // given
+            User user = createNormalUser();
+            EduReport report = EduReport.builder()
+                    .id(10L)
+                    .eduType(EduType.PSM)
+                    .title("PSM 교육")
+                    .company(null)
+                    .createdBy(user)
+                    .build();
+
+            List<Long> targetIds = List.of(1L, 2L, 3L);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(eduReportRepository.findById(10L)).thenReturn(Optional.of(report));
+            when(userRepository.findAllActiveUserIds()).thenReturn(targetIds);
+
+            // when
+            eduReportService.remindEduReport(10L, 1L);
+
+            // then
+            verify(userRepository, times(1)).findAllActiveUserIds();
+            verify(userRepository, never()).findAllIdsByCompany(any());
+            verify(notificationService, times(1))
+                    .sendEduReportRemindAlertToTargets(
+                            anyString(), anyString(), anyLong(), any(), any(Map.class));
+        }
+
+        @Test
+        @DisplayName("PSM 타입 - company가 있으면 findAllIdsByCompany 호출")
+        void remindEduReport_psmType_withCompany_callsFindAllIdsByCompany() {
+            // given
+            User user = createNormalUser();
+            EduReport report = EduReport.builder()
+                    .id(10L)
+                    .eduType(EduType.PSM)
+                    .title("PSM 교육")
+                    .company(Company.AWESOME)
+                    .createdBy(user)
+                    .build();
+
+            List<Long> targetIds = List.of(1L, 2L);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(eduReportRepository.findById(10L)).thenReturn(Optional.of(report));
+            when(userRepository.findAllIdsByCompany(Company.AWESOME)).thenReturn(targetIds);
+
+            // when
+            eduReportService.remindEduReport(10L, 1L);
+
+            // then
+            verify(userRepository, times(1)).findAllIdsByCompany(Company.AWESOME);
+            verify(userRepository, never()).findAllActiveUserIds();
+            verify(notificationService, times(1))
+                    .sendEduReportRemindAlertToTargets(
+                            anyString(), anyString(), anyLong(), any(), any(Map.class));
+        }
+
+        @Test
+        @DisplayName("SAFETY 타입 - metadata에 detailType=GENERAL 포함")
+        void remindEduReport_safetyType_metadataContainsDetailTypeGeneral() {
+            // given
+            User user = createNormalUser();
+            EduReport report = EduReport.builder()
+                    .id(10L)
+                    .eduType(EduType.SAFETY)
+                    .title("안전 보건 교육")
+                    .company(null)
+                    .createdBy(user)
+                    .build();
+
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(eduReportRepository.findById(10L)).thenReturn(Optional.of(report));
+            when(userRepository.findAllActiveUserIds()).thenReturn(List.of(1L));
+
+            // when
+            eduReportService.remindEduReport(10L, 1L);
+
+            // then
+            ArgumentCaptor<Map> metadataCaptor = ArgumentCaptor.forClass(Map.class);
+            verify(notificationService, times(1))
+                    .sendEduReportRemindAlertToTargets(
+                            anyString(), anyString(), anyLong(), any(), metadataCaptor.capture());
+            Map<String, Object> capturedMetadata = metadataCaptor.getValue();
+            assertThat(capturedMetadata.get("detailType")).isEqualTo("GENERAL");
+            assertThat(capturedMetadata.get("educationType")).isEqualTo("SAFETY");
+        }
+
+        @Test
+        @DisplayName("DEPARTMENT 타입 - department가 있으면 findAllIdsByDepartmentId 호출")
+        void remindEduReport_departmentType_withDepartment_callsFindAllIdsByDepartmentId() {
+            // given
+            User user = createNormalUser();
+            EduReport report = EduReport.builder()
+                    .id(10L)
+                    .eduType(EduType.DEPARTMENT)
+                    .title("부서 교육")
+                    .department(defaultDept)
+                    .createdBy(user)
+                    .build();
+
+            List<Long> targetIds = List.of(1L, 2L);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(eduReportRepository.findById(10L)).thenReturn(Optional.of(report));
+            when(userRepository.findAllIdsByDepartmentId(defaultDept.getId())).thenReturn(targetIds);
+
+            // when
+            eduReportService.remindEduReport(10L, 1L);
+
+            // then
+            verify(userRepository, times(1)).findAllIdsByDepartmentId(defaultDept.getId());
+            verify(notificationService, times(1))
+                    .sendEduReportRemindAlertToTargets(
+                            anyString(), anyString(), anyLong(), any(), any(Map.class));
+        }
+
+        @Test
+        @DisplayName("sendEduReportRemindAlertToTargets 호출 검증 - 올바른 인자 전달")
+        void remindEduReport_callsNotificationServiceWithCorrectArgs() {
+            // given
+            User user = createNormalUser();
+            EduReport report = EduReport.builder()
+                    .id(10L)
+                    .eduType(EduType.PSM)
+                    .title("PSM 교육 제목")
+                    .company(null)
+                    .createdBy(user)
+                    .build();
+
+            List<Long> targetIds = List.of(1L, 2L, 3L);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(eduReportRepository.findById(10L)).thenReturn(Optional.of(report));
+            when(userRepository.findAllActiveUserIds()).thenReturn(targetIds);
+
+            // when
+            eduReportService.remindEduReport(10L, 1L);
+
+            // then
+            ArgumentCaptor<String> eduTypeLabelCaptor = ArgumentCaptor.forClass(String.class);
+            ArgumentCaptor<String> eduTitleCaptor = ArgumentCaptor.forClass(String.class);
+            ArgumentCaptor<Long> reportIdCaptor = ArgumentCaptor.forClass(Long.class);
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<List<Long>> targetIdsCaptor = ArgumentCaptor.forClass(List.class);
+            ArgumentCaptor<Map> metadataCaptor = ArgumentCaptor.forClass(Map.class);
+
+            verify(notificationService, times(1))
+                    .sendEduReportRemindAlertToTargets(
+                            eduTypeLabelCaptor.capture(),
+                            eduTitleCaptor.capture(),
+                            reportIdCaptor.capture(),
+                            targetIdsCaptor.capture(),
+                            metadataCaptor.capture());
+
+            assertThat(eduTitleCaptor.getValue()).isEqualTo("PSM 교육 제목");
+            assertThat(reportIdCaptor.getValue()).isEqualTo(10L);
+            assertThat(targetIdsCaptor.getValue()).isEqualTo(targetIds);
+        }
+    }
 }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/notification/NotificationServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/notification/NotificationServiceTest.java
@@ -337,8 +337,7 @@ class NotificationServiceTest {
         @DisplayName("정상 케이스 - title에 [리마인드] 접두사가 붙어 저장된다")
         void sendEduReportRemindAlertToTargets_success_titleHasRemindPrefix() {
             // given
-            String expectedTitle =
-                    "[리마인드] " + NotificationMessage.EDU_REPORT_CREATED.getTitle();
+            String expectedTitle = "[리마인드] " + NotificationMessage.EDU_REPORT_CREATED.getTitle();
 
             // when
             notificationService.sendEduReportRemindAlertToTargets(
@@ -347,8 +346,7 @@ class NotificationServiceTest {
             // then
             ArgumentCaptor<Notification> captor = forClass(Notification.class);
             verify(notificationRepository, times(2)).save(captor.capture());
-            captor.getAllValues()
-                    .forEach(n -> assertThat(n.getTitle()).isEqualTo(expectedTitle));
+            captor.getAllValues().forEach(n -> assertThat(n.getTitle()).isEqualTo(expectedTitle));
         }
 
         @Test
@@ -423,8 +421,7 @@ class NotificationServiceTest {
         @DisplayName("정상 케이스 - metadata 포함 5인자 호출 시 title에 [리마인드] 접두사가 붙어 저장된다")
         void sendEduReportRemindAlertToTargets_withMetadata_titleHasRemindPrefix() {
             // given
-            String expectedTitle =
-                    "[리마인드] " + NotificationMessage.EDU_REPORT_CREATED.getTitle();
+            String expectedTitle = "[리마인드] " + NotificationMessage.EDU_REPORT_CREATED.getTitle();
             Map<String, Object> metadata = Map.of("reportId", 10);
 
             // when
@@ -451,8 +448,7 @@ class NotificationServiceTest {
         void sendSafetyTrainingSessionRemindAlertToAttendees_success_titleHasRemindPrefix() {
             // given
             String expectedTitle =
-                    "[리마인드] "
-                            + NotificationMessage.SAFETY_TRAINING_SESSION_CREATED.getTitle();
+                    "[리마인드] " + NotificationMessage.SAFETY_TRAINING_SESSION_CREATED.getTitle();
 
             // when
             notificationService.sendSafetyTrainingSessionRemindAlertToAttendees(
@@ -461,8 +457,7 @@ class NotificationServiceTest {
             // then
             ArgumentCaptor<Notification> captor = forClass(Notification.class);
             verify(notificationRepository, times(2)).save(captor.capture());
-            captor.getAllValues()
-                    .forEach(n -> assertThat(n.getTitle()).isEqualTo(expectedTitle));
+            captor.getAllValues().forEach(n -> assertThat(n.getTitle()).isEqualTo(expectedTitle));
         }
 
         @Test
@@ -470,8 +465,7 @@ class NotificationServiceTest {
         void sendSafetyTrainingSessionRemindAlertToAttendees_success_contentHasNoPrefix() {
             // given
             String expectedContent =
-                    NotificationMessage.SAFETY_TRAINING_SESSION_CREATED.formatContent(
-                            "안전보건교육 세션");
+                    NotificationMessage.SAFETY_TRAINING_SESSION_CREATED.formatContent("안전보건교육 세션");
 
             // when
             notificationService.sendSafetyTrainingSessionRemindAlertToAttendees(
@@ -499,7 +493,8 @@ class NotificationServiceTest {
 
         @Test
         @DisplayName("정상 케이스 - metadata에 educationType=SAFETY, detailType=SESSION이 저장된다")
-        void sendSafetyTrainingSessionRemindAlertToAttendees_success_metadataContainsExpectedKeys() {
+        void
+                sendSafetyTrainingSessionRemindAlertToAttendees_success_metadataContainsExpectedKeys() {
             // when
             notificationService.sendSafetyTrainingSessionRemindAlertToAttendees(
                     200L, "안전보건교육 세션", List.of(1L));
@@ -537,7 +532,8 @@ class NotificationServiceTest {
 
         @Test
         @DisplayName("정상 케이스 - messageType이 SAFETY_TRAINING_SESSION_CREATED로 저장된다")
-        void sendSafetyTrainingSessionRemindAlertToAttendees_success_messageTypeIsSafetyTrainingSessionCreated() {
+        void
+                sendSafetyTrainingSessionRemindAlertToAttendees_success_messageTypeIsSafetyTrainingSessionCreated() {
             // when
             notificationService.sendSafetyTrainingSessionRemindAlertToAttendees(
                     200L, "안전보건교육 세션", List.of(1L));

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/notification/NotificationServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/notification/NotificationServiceTest.java
@@ -325,6 +325,231 @@ class NotificationServiceTest {
         }
     }
 
+    // -------------------------------------------------------------------------
+    // sendEduReportRemindAlertToTargets 테스트
+    // -------------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("sendEduReportRemindAlertToTargets")
+    class SendEduReportRemindAlertToTargets {
+
+        @Test
+        @DisplayName("정상 케이스 - title에 [리마인드] 접두사가 붙어 저장된다")
+        void sendEduReportRemindAlertToTargets_success_titleHasRemindPrefix() {
+            // given
+            String expectedTitle =
+                    "[리마인드] " + NotificationMessage.EDU_REPORT_CREATED.getTitle();
+
+            // when
+            notificationService.sendEduReportRemindAlertToTargets(
+                    "SAFETY", "안전교육 제목", 10L, List.of(1L, 2L));
+
+            // then
+            ArgumentCaptor<Notification> captor = forClass(Notification.class);
+            verify(notificationRepository, times(2)).save(captor.capture());
+            captor.getAllValues()
+                    .forEach(n -> assertThat(n.getTitle()).isEqualTo(expectedTitle));
+        }
+
+        @Test
+        @DisplayName("정상 케이스 - content에 prefix 없이 formatContent 결과가 그대로 저장된다")
+        void sendEduReportRemindAlertToTargets_success_contentHasNoPrefix() {
+            // given
+            String expectedContent =
+                    NotificationMessage.EDU_REPORT_CREATED.formatContent("SAFETY", "안전교육 제목");
+
+            // when
+            notificationService.sendEduReportRemindAlertToTargets(
+                    "SAFETY", "안전교육 제목", 10L, List.of(1L));
+
+            // then
+            ArgumentCaptor<Notification> captor = forClass(Notification.class);
+            verify(notificationRepository).save(captor.capture());
+            assertThat(captor.getValue().getContent()).isEqualTo(expectedContent);
+        }
+
+        @Test
+        @DisplayName("정상 케이스 - domainType이 EDUCATION으로 저장된다")
+        void sendEduReportRemindAlertToTargets_success_domainTypeIsEducation() {
+            // when
+            notificationService.sendEduReportRemindAlertToTargets(
+                    "SAFETY", "안전교육 제목", 10L, List.of(1L));
+
+            // then
+            ArgumentCaptor<Notification> captor = forClass(Notification.class);
+            verify(notificationRepository).save(captor.capture());
+            assertThat(captor.getValue().getDomainType())
+                    .isEqualTo(NotificationDomainType.EDUCATION);
+        }
+
+        @Test
+        @DisplayName("정상 케이스 - messageType이 EDU_REPORT_CREATED로 저장된다")
+        void sendEduReportRemindAlertToTargets_success_messageTypeIsEduReportCreated() {
+            // when
+            notificationService.sendEduReportRemindAlertToTargets(
+                    "SAFETY", "안전교육 제목", 10L, List.of(1L));
+
+            // then
+            ArgumentCaptor<Notification> captor = forClass(Notification.class);
+            verify(notificationRepository).save(captor.capture());
+            assertThat(captor.getValue().getMessageType())
+                    .isEqualTo(NotificationMessage.EDU_REPORT_CREATED);
+        }
+
+        @Test
+        @DisplayName("예외 케이스 - 대상 목록이 비어 있으면 저장과 FCM 이벤트 발행이 수행되지 않는다")
+        void sendEduReportRemindAlertToTargets_emptyTargets_nothingHappens() {
+            // when
+            notificationService.sendEduReportRemindAlertToTargets(
+                    "SAFETY", "안전교육 제목", 10L, List.of());
+
+            // then
+            verify(notificationRepository, times(0)).save(any());
+            verify(eventPublisher, times(0)).publishEvent(any());
+        }
+
+        @Test
+        @DisplayName("정상 케이스 - FCM 이벤트가 대상 수만큼 발행된다")
+        void sendEduReportRemindAlertToTargets_success_fcmEventPublished() {
+            // when
+            notificationService.sendEduReportRemindAlertToTargets(
+                    "SAFETY", "안전교육 제목", 10L, List.of(1L, 2L));
+
+            // then
+            verify(eventPublisher, times(2)).publishEvent(any(FcmSendEvent.class));
+        }
+
+        @Test
+        @DisplayName("정상 케이스 - metadata 포함 5인자 호출 시 title에 [리마인드] 접두사가 붙어 저장된다")
+        void sendEduReportRemindAlertToTargets_withMetadata_titleHasRemindPrefix() {
+            // given
+            String expectedTitle =
+                    "[리마인드] " + NotificationMessage.EDU_REPORT_CREATED.getTitle();
+            Map<String, Object> metadata = Map.of("reportId", 10);
+
+            // when
+            notificationService.sendEduReportRemindAlertToTargets(
+                    "SAFETY", "안전교육 제목", 10L, List.of(1L), metadata);
+
+            // then
+            ArgumentCaptor<Notification> captor = forClass(Notification.class);
+            verify(notificationRepository).save(captor.capture());
+            assertThat(captor.getValue().getTitle()).isEqualTo(expectedTitle);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // sendSafetyTrainingSessionRemindAlertToAttendees 테스트
+    // -------------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("sendSafetyTrainingSessionRemindAlertToAttendees")
+    class SendSafetyTrainingSessionRemindAlertToAttendees {
+
+        @Test
+        @DisplayName("정상 케이스 - title에 [리마인드] 접두사가 붙어 저장된다")
+        void sendSafetyTrainingSessionRemindAlertToAttendees_success_titleHasRemindPrefix() {
+            // given
+            String expectedTitle =
+                    "[리마인드] "
+                            + NotificationMessage.SAFETY_TRAINING_SESSION_CREATED.getTitle();
+
+            // when
+            notificationService.sendSafetyTrainingSessionRemindAlertToAttendees(
+                    200L, "안전보건교육 세션", List.of(1L, 2L));
+
+            // then
+            ArgumentCaptor<Notification> captor = forClass(Notification.class);
+            verify(notificationRepository, times(2)).save(captor.capture());
+            captor.getAllValues()
+                    .forEach(n -> assertThat(n.getTitle()).isEqualTo(expectedTitle));
+        }
+
+        @Test
+        @DisplayName("정상 케이스 - content에 prefix 없이 formatContent 결과가 그대로 저장된다")
+        void sendSafetyTrainingSessionRemindAlertToAttendees_success_contentHasNoPrefix() {
+            // given
+            String expectedContent =
+                    NotificationMessage.SAFETY_TRAINING_SESSION_CREATED.formatContent(
+                            "안전보건교육 세션");
+
+            // when
+            notificationService.sendSafetyTrainingSessionRemindAlertToAttendees(
+                    200L, "안전보건교육 세션", List.of(1L));
+
+            // then
+            ArgumentCaptor<Notification> captor = forClass(Notification.class);
+            verify(notificationRepository).save(captor.capture());
+            assertThat(captor.getValue().getContent()).isEqualTo(expectedContent);
+        }
+
+        @Test
+        @DisplayName("정상 케이스 - domainType이 SAFETY_TRAINING으로 저장된다")
+        void sendSafetyTrainingSessionRemindAlertToAttendees_success_domainTypeIsSafetyTraining() {
+            // when
+            notificationService.sendSafetyTrainingSessionRemindAlertToAttendees(
+                    200L, "안전보건교육 세션", List.of(1L));
+
+            // then
+            ArgumentCaptor<Notification> captor = forClass(Notification.class);
+            verify(notificationRepository).save(captor.capture());
+            assertThat(captor.getValue().getDomainType())
+                    .isEqualTo(NotificationDomainType.SAFETY_TRAINING);
+        }
+
+        @Test
+        @DisplayName("정상 케이스 - metadata에 educationType=SAFETY, detailType=SESSION이 저장된다")
+        void sendSafetyTrainingSessionRemindAlertToAttendees_success_metadataContainsExpectedKeys() {
+            // when
+            notificationService.sendSafetyTrainingSessionRemindAlertToAttendees(
+                    200L, "안전보건교육 세션", List.of(1L));
+
+            // then
+            ArgumentCaptor<Notification> captor = forClass(Notification.class);
+            verify(notificationRepository).save(captor.capture());
+            Map<String, Object> metadata = captor.getValue().getMetadata();
+            assertThat(metadata).containsEntry("educationType", "SAFETY");
+            assertThat(metadata).containsEntry("detailType", "SESSION");
+        }
+
+        @Test
+        @DisplayName("예외 케이스 - 대상 목록이 비어 있으면 저장과 FCM 이벤트 발행이 수행되지 않는다")
+        void sendSafetyTrainingSessionRemindAlertToAttendees_emptyTargets_nothingHappens() {
+            // when
+            notificationService.sendSafetyTrainingSessionRemindAlertToAttendees(
+                    200L, "안전보건교육 세션", List.of());
+
+            // then
+            verify(notificationRepository, times(0)).save(any());
+            verify(eventPublisher, times(0)).publishEvent(any());
+        }
+
+        @Test
+        @DisplayName("정상 케이스 - FCM 이벤트가 대상 수만큼 발행된다")
+        void sendSafetyTrainingSessionRemindAlertToAttendees_success_fcmEventPublished() {
+            // when
+            notificationService.sendSafetyTrainingSessionRemindAlertToAttendees(
+                    200L, "안전보건교육 세션", List.of(1L, 2L));
+
+            // then
+            verify(eventPublisher, times(2)).publishEvent(any(FcmSendEvent.class));
+        }
+
+        @Test
+        @DisplayName("정상 케이스 - messageType이 SAFETY_TRAINING_SESSION_CREATED로 저장된다")
+        void sendSafetyTrainingSessionRemindAlertToAttendees_success_messageTypeIsSafetyTrainingSessionCreated() {
+            // when
+            notificationService.sendSafetyTrainingSessionRemindAlertToAttendees(
+                    200L, "안전보건교육 세션", List.of(1L));
+
+            // then
+            ArgumentCaptor<Notification> captor = forClass(Notification.class);
+            verify(notificationRepository).save(captor.capture());
+            assertThat(captor.getValue().getMessageType())
+                    .isEqualTo(NotificationMessage.SAFETY_TRAINING_SESSION_CREATED);
+        }
+    }
+
     @Test
     @DisplayName("sendAlertToAdmins - metadata 포함 시 모든 관리자에게 metadata가 저장된다")
     void sendAlertToAdmins_withMetadata_savesMetadataForEachAdmin() {

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/SafetyTrainingSessionServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/SafetyTrainingSessionServiceTest.java
@@ -1,7 +1,6 @@
 package kr.co.awesomelead.groupware_backend.domain.safetytraining;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -45,7 +44,12 @@ class SafetyTrainingSessionServiceTest {
     @Mock private UserRepository userRepository;
     @Mock private NotificationService notificationService;
     @Mock private com.fasterxml.jackson.databind.ObjectMapper objectMapper;
-    @Mock private kr.co.awesomelead.groupware_backend.domain.safetytraining.service.SafetyTrainingExcelService safetyTrainingExcelService;
+
+    @Mock
+    private kr.co.awesomelead.groupware_backend.domain.safetytraining.service
+                    .SafetyTrainingExcelService
+            safetyTrainingExcelService;
+
     @Mock private kr.co.awesomelead.groupware_backend.global.infra.s3.service.S3Service s3Service;
 
     @InjectMocks private SafetyTrainingSessionService safetyTrainingSessionService;
@@ -59,17 +63,15 @@ class SafetyTrainingSessionServiceTest {
 
     @BeforeEach
     void setUp() {
-        actor = User.builder()
-                .id(USER_ID)
-                .nameKor("작성자")
-                .build();
+        actor = User.builder().id(USER_ID).nameKor("작성자").build();
 
-        session = SafetyTrainingSession.builder()
-                .id(SESSION_ID)
-                .title("2024년 안전보건교육")
-                .companyScope(Company.AWESOME)
-                .createdBy(actor)
-                .build();
+        session =
+                SafetyTrainingSession.builder()
+                        .id(SESSION_ID)
+                        .title("2024년 안전보건교육")
+                        .companyScope(Company.AWESOME)
+                        .createdBy(actor)
+                        .build();
     }
 
     @Nested
@@ -83,13 +85,15 @@ class SafetyTrainingSessionServiceTest {
             when(userRepository.findById(USER_ID)).thenReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> safetyTrainingSessionService.remindSession(SESSION_ID, USER_ID))
+            assertThatThrownBy(
+                            () -> safetyTrainingSessionService.remindSession(SESSION_ID, USER_ID))
                     .isInstanceOf(CustomException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
 
             verify(sessionRepository, never()).findById(anyLong());
             verify(notificationService, never())
-                    .sendSafetyTrainingSessionRemindAlertToAttendees(anyLong(), anyString(), anyList());
+                    .sendSafetyTrainingSessionRemindAlertToAttendees(
+                            anyLong(), anyString(), anyList());
         }
 
         @Test
@@ -100,35 +104,43 @@ class SafetyTrainingSessionServiceTest {
             when(sessionRepository.findById(SESSION_ID)).thenReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> safetyTrainingSessionService.remindSession(SESSION_ID, USER_ID))
+            assertThatThrownBy(
+                            () -> safetyTrainingSessionService.remindSession(SESSION_ID, USER_ID))
                     .isInstanceOf(CustomException.class)
-                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND);
+                    .hasFieldOrPropertyWithValue(
+                            "errorCode", ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND);
 
             verify(notificationService, never())
-                    .sendSafetyTrainingSessionRemindAlertToAttendees(anyLong(), anyString(), anyList());
+                    .sendSafetyTrainingSessionRemindAlertToAttendees(
+                            anyLong(), anyString(), anyList());
         }
 
         @Test
         @DisplayName("세션의 createdBy가 null이면 NO_AUTHORITY_FOR_SAFETY_WRITE 예외가 발생한다")
         void remindSession_throwsWhenCreatedByIsNull() {
             // given
-            SafetyTrainingSession sessionWithNullCreator = SafetyTrainingSession.builder()
-                    .id(SESSION_ID)
-                    .title("2024년 안전보건교육")
-                    .companyScope(Company.AWESOME)
-                    .createdBy(null)
-                    .build();
+            SafetyTrainingSession sessionWithNullCreator =
+                    SafetyTrainingSession.builder()
+                            .id(SESSION_ID)
+                            .title("2024년 안전보건교육")
+                            .companyScope(Company.AWESOME)
+                            .createdBy(null)
+                            .build();
 
             when(userRepository.findById(USER_ID)).thenReturn(Optional.of(actor));
-            when(sessionRepository.findById(SESSION_ID)).thenReturn(Optional.of(sessionWithNullCreator));
+            when(sessionRepository.findById(SESSION_ID))
+                    .thenReturn(Optional.of(sessionWithNullCreator));
 
             // when & then
-            assertThatThrownBy(() -> safetyTrainingSessionService.remindSession(SESSION_ID, USER_ID))
+            assertThatThrownBy(
+                            () -> safetyTrainingSessionService.remindSession(SESSION_ID, USER_ID))
                     .isInstanceOf(CustomException.class)
-                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NO_AUTHORITY_FOR_SAFETY_WRITE);
+                    .hasFieldOrPropertyWithValue(
+                            "errorCode", ErrorCode.NO_AUTHORITY_FOR_SAFETY_WRITE);
 
             verify(notificationService, never())
-                    .sendSafetyTrainingSessionRemindAlertToAttendees(anyLong(), anyString(), anyList());
+                    .sendSafetyTrainingSessionRemindAlertToAttendees(
+                            anyLong(), anyString(), anyList());
         }
 
         @Test
@@ -136,23 +148,28 @@ class SafetyTrainingSessionServiceTest {
         void remindSession_throwsWhenCreatedByMismatch() {
             // given
             User anotherUser = User.builder().id(OTHER_USER_ID).nameKor("다른사람").build();
-            SafetyTrainingSession sessionOwnedByOther = SafetyTrainingSession.builder()
-                    .id(SESSION_ID)
-                    .title("2024년 안전보건교육")
-                    .companyScope(Company.AWESOME)
-                    .createdBy(anotherUser)
-                    .build();
+            SafetyTrainingSession sessionOwnedByOther =
+                    SafetyTrainingSession.builder()
+                            .id(SESSION_ID)
+                            .title("2024년 안전보건교육")
+                            .companyScope(Company.AWESOME)
+                            .createdBy(anotherUser)
+                            .build();
 
             when(userRepository.findById(USER_ID)).thenReturn(Optional.of(actor));
-            when(sessionRepository.findById(SESSION_ID)).thenReturn(Optional.of(sessionOwnedByOther));
+            when(sessionRepository.findById(SESSION_ID))
+                    .thenReturn(Optional.of(sessionOwnedByOther));
 
             // when & then
-            assertThatThrownBy(() -> safetyTrainingSessionService.remindSession(SESSION_ID, USER_ID))
+            assertThatThrownBy(
+                            () -> safetyTrainingSessionService.remindSession(SESSION_ID, USER_ID))
                     .isInstanceOf(CustomException.class)
-                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NO_AUTHORITY_FOR_SAFETY_WRITE);
+                    .hasFieldOrPropertyWithValue(
+                            "errorCode", ErrorCode.NO_AUTHORITY_FOR_SAFETY_WRITE);
 
             verify(notificationService, never())
-                    .sendSafetyTrainingSessionRemindAlertToAttendees(anyLong(), anyString(), anyList());
+                    .sendSafetyTrainingSessionRemindAlertToAttendees(
+                            anyLong(), anyString(), anyList());
         }
 
         @Test
@@ -166,19 +183,19 @@ class SafetyTrainingSessionServiceTest {
             when(userRepository.findById(USER_ID)).thenReturn(Optional.of(actor));
             when(sessionRepository.findById(SESSION_ID)).thenReturn(Optional.of(session));
             when(userRepository.findAllByCompanyAndStatusExcludingPosition(
-                    Company.AWESOME, Status.AVAILABLE, Position.CEO))
+                            Company.AWESOME, Status.AVAILABLE, Position.CEO))
                     .thenReturn(targetUsers);
 
             // when
             safetyTrainingSessionService.remindSession(SESSION_ID, USER_ID);
 
             // then
-            verify(userRepository).findAllByCompanyAndStatusExcludingPosition(
-                    Company.AWESOME, Status.AVAILABLE, Position.CEO);
-            verify(notificationService).sendSafetyTrainingSessionRemindAlertToAttendees(
-                    eq(SESSION_ID),
-                    eq("2024년 안전보건교육"),
-                    eq(List.of(101L, 102L)));
+            verify(userRepository)
+                    .findAllByCompanyAndStatusExcludingPosition(
+                            Company.AWESOME, Status.AVAILABLE, Position.CEO);
+            verify(notificationService)
+                    .sendSafetyTrainingSessionRemindAlertToAttendees(
+                            eq(SESSION_ID), eq("2024년 안전보건교육"), eq(List.of(101L, 102L)));
         }
     }
 }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/SafetyTrainingSessionServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/SafetyTrainingSessionServiceTest.java
@@ -1,0 +1,184 @@
+package kr.co.awesomelead.groupware_backend.domain.safetytraining;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
+import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
+import kr.co.awesomelead.groupware_backend.domain.safetytraining.entity.SafetyTrainingSession;
+import kr.co.awesomelead.groupware_backend.domain.safetytraining.repository.SafetyTrainingSessionAttendeeRepository;
+import kr.co.awesomelead.groupware_backend.domain.safetytraining.repository.SafetyTrainingSessionRepository;
+import kr.co.awesomelead.groupware_backend.domain.safetytraining.service.SafetyTrainingSessionService;
+import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
+import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
+import kr.co.awesomelead.groupware_backend.global.error.CustomException;
+import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Optional;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+class SafetyTrainingSessionServiceTest {
+
+    @Mock private SafetyTrainingSessionRepository sessionRepository;
+    @Mock private SafetyTrainingSessionAttendeeRepository attendeeRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private NotificationService notificationService;
+    @Mock private com.fasterxml.jackson.databind.ObjectMapper objectMapper;
+    @Mock private kr.co.awesomelead.groupware_backend.domain.safetytraining.service.SafetyTrainingExcelService safetyTrainingExcelService;
+    @Mock private kr.co.awesomelead.groupware_backend.global.infra.s3.service.S3Service s3Service;
+
+    @InjectMocks private SafetyTrainingSessionService safetyTrainingSessionService;
+
+    private static final Long SESSION_ID = 1L;
+    private static final Long USER_ID = 10L;
+    private static final Long OTHER_USER_ID = 99L;
+
+    private User actor;
+    private SafetyTrainingSession session;
+
+    @BeforeEach
+    void setUp() {
+        actor = User.builder()
+                .id(USER_ID)
+                .nameKor("작성자")
+                .build();
+
+        session = SafetyTrainingSession.builder()
+                .id(SESSION_ID)
+                .title("2024년 안전보건교육")
+                .companyScope(Company.AWESOME)
+                .createdBy(actor)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("remindSession - 안전보건교육 세션 리마인드 알림 전송")
+    class RemindSession {
+
+        @Test
+        @DisplayName("userId에 해당하는 유저가 없으면 USER_NOT_FOUND 예외가 발생한다")
+        void remindSession_throwsWhenUserNotFound() {
+            // given
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> safetyTrainingSessionService.remindSession(SESSION_ID, USER_ID))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+
+            verify(sessionRepository, never()).findById(anyLong());
+            verify(notificationService, never())
+                    .sendSafetyTrainingSessionRemindAlertToAttendees(anyLong(), anyString(), anyList());
+        }
+
+        @Test
+        @DisplayName("sessionId에 해당하는 세션이 없으면 SAFETY_TRAINING_SESSION_NOT_FOUND 예외가 발생한다")
+        void remindSession_throwsWhenSessionNotFound() {
+            // given
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(actor));
+            when(sessionRepository.findById(SESSION_ID)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> safetyTrainingSessionService.remindSession(SESSION_ID, USER_ID))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.SAFETY_TRAINING_SESSION_NOT_FOUND);
+
+            verify(notificationService, never())
+                    .sendSafetyTrainingSessionRemindAlertToAttendees(anyLong(), anyString(), anyList());
+        }
+
+        @Test
+        @DisplayName("세션의 createdBy가 null이면 NO_AUTHORITY_FOR_SAFETY_WRITE 예외가 발생한다")
+        void remindSession_throwsWhenCreatedByIsNull() {
+            // given
+            SafetyTrainingSession sessionWithNullCreator = SafetyTrainingSession.builder()
+                    .id(SESSION_ID)
+                    .title("2024년 안전보건교육")
+                    .companyScope(Company.AWESOME)
+                    .createdBy(null)
+                    .build();
+
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(actor));
+            when(sessionRepository.findById(SESSION_ID)).thenReturn(Optional.of(sessionWithNullCreator));
+
+            // when & then
+            assertThatThrownBy(() -> safetyTrainingSessionService.remindSession(SESSION_ID, USER_ID))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NO_AUTHORITY_FOR_SAFETY_WRITE);
+
+            verify(notificationService, never())
+                    .sendSafetyTrainingSessionRemindAlertToAttendees(anyLong(), anyString(), anyList());
+        }
+
+        @Test
+        @DisplayName("세션의 createdBy가 요청 userId와 다르면 NO_AUTHORITY_FOR_SAFETY_WRITE 예외가 발생한다")
+        void remindSession_throwsWhenCreatedByMismatch() {
+            // given
+            User anotherUser = User.builder().id(OTHER_USER_ID).nameKor("다른사람").build();
+            SafetyTrainingSession sessionOwnedByOther = SafetyTrainingSession.builder()
+                    .id(SESSION_ID)
+                    .title("2024년 안전보건교육")
+                    .companyScope(Company.AWESOME)
+                    .createdBy(anotherUser)
+                    .build();
+
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(actor));
+            when(sessionRepository.findById(SESSION_ID)).thenReturn(Optional.of(sessionOwnedByOther));
+
+            // when & then
+            assertThatThrownBy(() -> safetyTrainingSessionService.remindSession(SESSION_ID, USER_ID))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NO_AUTHORITY_FOR_SAFETY_WRITE);
+
+            verify(notificationService, never())
+                    .sendSafetyTrainingSessionRemindAlertToAttendees(anyLong(), anyString(), anyList());
+        }
+
+        @Test
+        @DisplayName("정상 흐름: 대상자 조회 후 리마인드 알림을 전송한다")
+        void remindSession_success() {
+            // given
+            User attendee1 = User.builder().id(101L).nameKor("직원1").build();
+            User attendee2 = User.builder().id(102L).nameKor("직원2").build();
+            List<User> targetUsers = List.of(attendee1, attendee2);
+
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(actor));
+            when(sessionRepository.findById(SESSION_ID)).thenReturn(Optional.of(session));
+            when(userRepository.findAllByCompanyAndStatusExcludingPosition(
+                    Company.AWESOME, Status.AVAILABLE, Position.CEO))
+                    .thenReturn(targetUsers);
+
+            // when
+            safetyTrainingSessionService.remindSession(SESSION_ID, USER_ID);
+
+            // then
+            verify(userRepository).findAllByCompanyAndStatusExcludingPosition(
+                    Company.AWESOME, Status.AVAILABLE, Position.CEO);
+            verify(notificationService).sendSafetyTrainingSessionRemindAlertToAttendees(
+                    eq(SESSION_ID),
+                    eq("2024년 안전보건교육"),
+                    eq(List.of(101L, 102L)));
+        }
+    }
+}


### PR DESCRIPTION
## 연관 이슈
closes #368

## 작업 내용
- `NotificationService`: `sendEduReportRemindAlertToTargets` (4인자 오버로드 + 5인자 구현), `sendSafetyTrainingSessionRemindAlertToAttendees` 추가
  - 리마인드 알림 title: `[리마인드] ` prefix 추가, content는 기존과 동일
- `EduReportService`: `remindEduReport(Long, Long)` 추가 — 권한 검증, eduType별 대상자 재조회, 리마인드 알림 전송
- `SafetyTrainingSessionService`: `remindSession(Long, Long)` 추가 — 권한 검증, companyScope 기준 대상자 재조회, 리마인드 알림 전송
- `EduReportController`: `POST /api/educations/{educationId}/remind` 엔드포인트 추가
- `SafetyTrainingSessionController`: `POST /api/safety-trainings/{sessionId}/remind` 엔드포인트 추가

## 테스트 여부
- [x] 단위 테스트: `NotificationServiceTest` 14개, `EduReportServiceTest` 9개, `SafetyTrainingSessionServiceTest` 5개 — 총 28개 통과
- [x] API 테스트 (로컬):
  - `POST /api/educations/{educationId}/remind` — 200 ✅ / 403 ✅ / 404 ✅
  - `POST /api/safety-trainings/{sessionId}/remind` — 200 ✅ / 403 ✅ / 404 ✅

## 리뷰 요구사항
- X