### PR TITLE
feat(371): 제증명 신청 삭제 API 추가 및 알림 버그 수정

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/dto/response/NotificationResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notification/dto/response/NotificationResponseDto.java
@@ -79,7 +79,8 @@ public class NotificationResponseDto {
         // 승인 요청형 알림은 requiresApproval 해제 시점(승인/반려 처리 완료)을 완료로 간주
         if (messageType == NotificationMessage.VISIT_LONG_TERM_PRE
                 || messageType == NotificationMessage.SIGNUP_ADMIN_ALERT
-                || messageType == NotificationMessage.MY_INFO_UPDATE_REQUEST_ADMIN) {
+                || messageType == NotificationMessage.MY_INFO_UPDATE_REQUEST_ADMIN
+                || messageType == NotificationMessage.REQUEST_HISTORY_CREATED) {
             return !notification.isRequiresApproval();
         }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/controller/RequestHistoryController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/controller/RequestHistoryController.java
@@ -21,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -157,5 +158,57 @@ public class RequestHistoryController {
                     Long requestId) {
         requestHistoryService.cancelMyRequest(userDetails.getId(), requestId);
         return ResponseEntity.ok(ApiResponse.onSuccess("신청이 취소되었습니다."));
+    }
+
+    @Operation(
+            summary = "내 제증명 발급 신청 삭제",
+            description = "PENDING 상태인 본인의 신청만 삭제할 수 있습니다.")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "신청이 삭제되었습니다."),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "400",
+                        description = "삭제 불가 상태",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
+                                {
+                                  "isSuccess": false,
+                                  "code": "REQUEST_HISTORY_NOT_DELETABLE",
+                                  "message": "해당 제증명 발급 신청은 삭제할 수 없습니다.",
+                                  "result": null
+                                }
+                                """))),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "404",
+                        description = "신청 없음",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
+                                {
+                                  "isSuccess": false,
+                                  "code": "REQUEST_HISTORY_NOT_FOUND",
+                                  "message": "해당 제증명 발급 신청 내역을 찾을 수 없습니다.",
+                                  "result": null
+                                }
+                                """)))
+            })
+    @DeleteMapping("/{requestId}")
+    public ResponseEntity<ApiResponse<String>> deleteMyRequest(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "삭제할 신청 ID", example = "1", required = true) @PathVariable
+                    Long requestId) {
+        requestHistoryService.deleteMyRequest(userDetails.getId(), requestId);
+        return ResponseEntity.ok(ApiResponse.onSuccess("신청이 삭제되었습니다."));
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/controller/RequestHistoryController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/controller/RequestHistoryController.java
@@ -160,9 +160,7 @@ public class RequestHistoryController {
         return ResponseEntity.ok(ApiResponse.onSuccess("신청이 취소되었습니다."));
     }
 
-    @Operation(
-            summary = "내 제증명 발급 신청 삭제",
-            description = "PENDING 상태인 본인의 신청만 삭제할 수 있습니다.")
+    @Operation(summary = "내 제증명 발급 신청 삭제", description = "PENDING 상태인 본인의 신청만 삭제할 수 있습니다.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/service/RequestHistoryService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/service/RequestHistoryService.java
@@ -63,10 +63,11 @@ public class RequestHistoryService {
 
         Long requestId = requestHistoryRepository.save(requestHistory).getId();
 
-        notificationService.sendAlertToAdmins(
+        notificationService.sendAlertToAdminsRequiringApproval(
                 NotificationMessage.REQUEST_HISTORY_CREATED,
                 NotificationDomainType.REQUEST_HISTORY,
                 requestId,
+                null,
                 user.getNameKor());
 
         return requestId;
@@ -118,6 +119,27 @@ public class RequestHistoryService {
 
         notificationRepository.deleteByDomainTypeAndDomainId(
                 NotificationDomainType.REQUEST_HISTORY, requestId);
+    }
+
+    @Transactional
+    public void deleteMyRequest(Long userId, Long requestId) {
+        userRepository
+                .findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        RequestHistory requestHistory =
+                requestHistoryRepository
+                        .findByIdAndUserId(requestId, userId)
+                        .orElseThrow(
+                                () -> new CustomException(ErrorCode.REQUEST_HISTORY_NOT_FOUND));
+
+        if (requestHistory.getApprovalStatus() != RequestHistoryStatus.PENDING) {
+            throw new CustomException(ErrorCode.REQUEST_HISTORY_NOT_DELETABLE);
+        }
+
+        notificationRepository.deleteByDomainTypeAndDomainId(
+                NotificationDomainType.REQUEST_HISTORY, requestId);
+        requestHistoryRepository.delete(requestHistory);
     }
 
     @Transactional(readOnly = true)
@@ -181,6 +203,8 @@ public class RequestHistoryService {
                 NotificationDomainType.REQUEST_HISTORY,
                 requestId,
                 requestHistory.getRequestType().getDescription());
+
+        notificationService.resolveRequiresApproval(NotificationDomainType.REQUEST_HISTORY, requestId);
     }
 
     @Transactional
@@ -217,6 +241,8 @@ public class RequestHistoryService {
                 requestId,
                 requestHistory.getRequestType().getDescription(),
                 reason.trim());
+
+        notificationService.resolveRequiresApproval(NotificationDomainType.REQUEST_HISTORY, requestId);
     }
 
     private void validateAdminAuthority(User admin) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/service/RequestHistoryService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/service/RequestHistoryService.java
@@ -204,7 +204,8 @@ public class RequestHistoryService {
                 requestId,
                 requestHistory.getRequestType().getDescription());
 
-        notificationService.resolveRequiresApproval(NotificationDomainType.REQUEST_HISTORY, requestId);
+        notificationService.resolveRequiresApproval(
+                NotificationDomainType.REQUEST_HISTORY, requestId);
     }
 
     @Transactional
@@ -242,7 +243,8 @@ public class RequestHistoryService {
                 requestHistory.getRequestType().getDescription(),
                 reason.trim());
 
-        notificationService.resolveRequiresApproval(NotificationDomainType.REQUEST_HISTORY, requestId);
+        notificationService.resolveRequiresApproval(
+                NotificationDomainType.REQUEST_HISTORY, requestId);
     }
 
     private void validateAdminAuthority(User admin) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
@@ -118,6 +118,7 @@ public enum ErrorCode {
     NOTICE_ATTACHMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 공지사항 첨부파일을 찾을 수 없습니다."),
     REQUEST_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 제증명 발급 신청 내역을 찾을 수 없습니다."),
     REQUEST_HISTORY_NOT_CANCELABLE(HttpStatus.BAD_REQUEST, "대기 상태 요청만 취소할 수 있습니다."),
+    REQUEST_HISTORY_NOT_DELETABLE(HttpStatus.BAD_REQUEST, "PENDING 상태 요청만 삭제할 수 있습니다."),
     PAYSLIP_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 급여명세서를 찾을 수 없습니다."),
     EDUCATION_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 교육 카테고리를 찾을 수 없습니다."),
     RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 방문기록을 찾을 수 없습니다."),

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/RequestHistoryServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/RequestHistoryServiceTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.verify;
 
 import kr.co.awesomelead.groupware_backend.domain.notification.dto.response.NotificationResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.notification.entity.Notification;
-
 import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationDomainType;
 import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationMessage;
 import kr.co.awesomelead.groupware_backend.domain.notification.repository.NotificationRepository;
@@ -478,8 +477,7 @@ class RequestHistoryServiceTest {
             ReflectionTestUtils.setField(user, "id", 1L);
 
             given(userRepository.findById(1L)).willReturn(Optional.of(user));
-            given(requestHistoryRepository.findByIdAndUserId(10L, 1L))
-                    .willReturn(Optional.empty());
+            given(requestHistoryRepository.findByIdAndUserId(10L, 1L)).willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() -> requestHistoryService.deleteMyRequest(1L, 10L))
@@ -490,7 +488,8 @@ class RequestHistoryServiceTest {
     }
 
     @Nested
-    @DisplayName("NotificationResponseDto.isApprovalOrRejectionCompleted — REQUEST_HISTORY_CREATED 분기")
+    @DisplayName(
+            "NotificationResponseDto.isApprovalOrRejectionCompleted — REQUEST_HISTORY_CREATED 분기")
     class Describe_isApprovalOrRejectionCompleted_requestHistoryCreated {
 
         @Test

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/RequestHistoryServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/RequestHistoryServiceTest.java
@@ -6,6 +6,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import kr.co.awesomelead.groupware_backend.domain.notification.dto.response.NotificationResponseDto;
+import kr.co.awesomelead.groupware_backend.domain.notification.entity.Notification;
+
 import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationDomainType;
 import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationMessage;
 import kr.co.awesomelead.groupware_backend.domain.notification.repository.NotificationRepository;
@@ -85,10 +88,11 @@ class RequestHistoryServiceTest {
             // then
             assertThat(result).isEqualTo(100L);
             verify(notificationService)
-                    .sendAlertToAdmins(
+                    .sendAlertToAdminsRequiringApproval(
                             NotificationMessage.REQUEST_HISTORY_CREATED,
                             NotificationDomainType.REQUEST_HISTORY,
                             100L,
+                            null,
                             "홍길동");
         }
     }
@@ -366,6 +370,36 @@ class RequestHistoryServiceTest {
         }
 
         @Test
+        @DisplayName("발급 처리 후 resolveRequiresApproval을 호출한다")
+        void issueRequest_resolvesRequiresApproval() {
+            // given
+            User admin = new User();
+            ReflectionTestUtils.setField(admin, "id", 100L);
+            admin.addAuthority(Authority.MANAGE_CERTIFICATE_REQUEST);
+
+            User requester = new User();
+            ReflectionTestUtils.setField(requester, "id", 200L);
+
+            RequestHistory requestHistory = new RequestHistory();
+            ReflectionTestUtils.setField(requestHistory, "user", requester);
+            ReflectionTestUtils.setField(
+                    requestHistory, "requestType", RequestType.EMPLOYMENT_CERTIFICATE);
+            ReflectionTestUtils.setField(
+                    requestHistory, "approvalStatus", RequestHistoryStatus.PENDING);
+
+            given(userRepository.findById(100L)).willReturn(Optional.of(admin));
+            given(requestHistoryRepository.findByIdWithUserAndDepartment(101L))
+                    .willReturn(Optional.of(requestHistory));
+
+            // when
+            requestHistoryService.issueRequest(100L, 101L);
+
+            // then
+            verify(notificationService)
+                    .resolveRequiresApproval(NotificationDomainType.REQUEST_HISTORY, 101L);
+        }
+
+        @Test
         @DisplayName("발급 대기 상태가 아니면 REQUEST_HISTORY_NOT_ISSUABLE 예외를 던진다")
         void it_throws_when_request_not_pending() {
             // given
@@ -386,6 +420,121 @@ class RequestHistoryServiceTest {
                     .isInstanceOf(CustomException.class)
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.REQUEST_HISTORY_NOT_ISSUABLE);
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteMyRequest 메서드는")
+    class Describe_deleteMyRequest {
+
+        @Test
+        @DisplayName("PENDING 상태인 본인 요청을 삭제한다")
+        void deleteMyRequest_success() {
+            // given
+            User user = new User();
+            ReflectionTestUtils.setField(user, "id", 1L);
+            RequestHistory requestHistory = new RequestHistory();
+            ReflectionTestUtils.setField(requestHistory, "id", 10L);
+            ReflectionTestUtils.setField(
+                    requestHistory, "approvalStatus", RequestHistoryStatus.PENDING);
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+            given(requestHistoryRepository.findByIdAndUserId(10L, 1L))
+                    .willReturn(Optional.of(requestHistory));
+
+            // when
+            requestHistoryService.deleteMyRequest(1L, 10L);
+
+            // then
+            verify(requestHistoryRepository).delete(requestHistory);
+        }
+
+        @Test
+        @DisplayName("PENDING 상태가 아니면 REQUEST_HISTORY_NOT_DELETABLE 예외를 던진다")
+        void deleteMyRequest_throwsWhenNotPending() {
+            // given
+            User user = new User();
+            ReflectionTestUtils.setField(user, "id", 1L);
+            RequestHistory requestHistory = new RequestHistory();
+            ReflectionTestUtils.setField(
+                    requestHistory, "approvalStatus", RequestHistoryStatus.ISSUED);
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+            given(requestHistoryRepository.findByIdAndUserId(10L, 1L))
+                    .willReturn(Optional.of(requestHistory));
+
+            // when & then
+            assertThatThrownBy(() -> requestHistoryService.deleteMyRequest(1L, 10L))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.REQUEST_HISTORY_NOT_DELETABLE);
+        }
+
+        @Test
+        @DisplayName("요청이 존재하지 않으면 REQUEST_HISTORY_NOT_FOUND 예외를 던진다")
+        void deleteMyRequest_throwsWhenNotFound() {
+            // given
+            User user = new User();
+            ReflectionTestUtils.setField(user, "id", 1L);
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+            given(requestHistoryRepository.findByIdAndUserId(10L, 1L))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> requestHistoryService.deleteMyRequest(1L, 10L))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.REQUEST_HISTORY_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("NotificationResponseDto.isApprovalOrRejectionCompleted — REQUEST_HISTORY_CREATED 분기")
+    class Describe_isApprovalOrRejectionCompleted_requestHistoryCreated {
+
+        @Test
+        @DisplayName("REQUEST_HISTORY_CREATED 타입이고 requiresApproval=false 이면 true를 반환한다")
+        void isApprovalOrRejectionCompleted_returnsTrueWhenRequiresApprovalFalse() {
+            // given
+            Notification notification =
+                    Notification.of(
+                            1L,
+                            "제목",
+                            "내용",
+                            NotificationDomainType.REQUEST_HISTORY,
+                            10L,
+                            null,
+                            false,
+                            NotificationMessage.REQUEST_HISTORY_CREATED);
+
+            // when
+            NotificationResponseDto dto = NotificationResponseDto.from(notification);
+
+            // then
+            assertThat(dto.isApprovalOrRejectionCompleted()).isTrue();
+        }
+
+        @Test
+        @DisplayName("REQUEST_HISTORY_CREATED 타입이고 requiresApproval=true 이면 false를 반환한다")
+        void isApprovalOrRejectionCompleted_returnsFalseWhenRequiresApprovalTrue() {
+            // given
+            Notification notification =
+                    Notification.of(
+                            1L,
+                            "제목",
+                            "내용",
+                            NotificationDomainType.REQUEST_HISTORY,
+                            10L,
+                            null,
+                            true,
+                            NotificationMessage.REQUEST_HISTORY_CREATED);
+
+            // when
+            NotificationResponseDto dto = NotificationResponseDto.from(notification);
+
+            // then
+            assertThat(dto.isApprovalOrRejectionCompleted()).isFalse();
         }
     }
 
@@ -431,6 +580,36 @@ class RequestHistoryServiceTest {
                             101L,
                             RequestType.EMPLOYMENT_CERTIFICATE.getDescription(),
                             "정보가 불충분합니다.");
+        }
+
+        @Test
+        @DisplayName("반려 처리 후 resolveRequiresApproval을 호출한다")
+        void rejectRequest_resolvesRequiresApproval() {
+            // given
+            User admin = new User();
+            ReflectionTestUtils.setField(admin, "id", 100L);
+            admin.addAuthority(Authority.MANAGE_CERTIFICATE_REQUEST);
+
+            User requester = new User();
+            ReflectionTestUtils.setField(requester, "id", 200L);
+
+            RequestHistory requestHistory = new RequestHistory();
+            ReflectionTestUtils.setField(requestHistory, "user", requester);
+            ReflectionTestUtils.setField(
+                    requestHistory, "requestType", RequestType.EMPLOYMENT_CERTIFICATE);
+            ReflectionTestUtils.setField(
+                    requestHistory, "approvalStatus", RequestHistoryStatus.PENDING);
+
+            given(userRepository.findById(100L)).willReturn(Optional.of(admin));
+            given(requestHistoryRepository.findByIdWithUserAndDepartment(101L))
+                    .willReturn(Optional.of(requestHistory));
+
+            // when
+            requestHistoryService.rejectRequest(100L, 101L, "정보가 불충분합니다.");
+
+            // then
+            verify(notificationService)
+                    .resolveRequiresApproval(NotificationDomainType.REQUEST_HISTORY, 101L);
         }
 
         @Test


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

closes #371

## 📝작업 내용

- `DELETE /api/users/request-histories/{requestId}` 엔드포인트 추가
  - PENDING 상태인 본인 신청만 Hard Delete 가능
  - 연결된 notifications 레코드도 함께 삭제
  - `REQUEST_HISTORY_NOT_DELETABLE` 에러 코드 추가 (400)
- 제증명 신청 알림 `approvalOrRejectionCompleted` 미반영 버그 수정
  - `createRequest()`에서 `sendAlertToAdminsRequiringApproval()`로 변경
  - `issueRequest()` / `rejectRequest()` 완료 후 `resolveRequiresApproval()` 호출 추가
  - `NotificationResponseDto.isApprovalOrRejectionCompleted()`에 `REQUEST_HISTORY_CREATED` 케이스 추가

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

> 단위 테스트 5개 추가 (deleteMyRequest 3개, resolveRequiresApproval 2개)  
> API 테스트: 정상 삭제(200), 없는 ID(404), 이미 삭제(404), 비PENDING(400) 모두 통과
