### PR TITLE
fix: 안전보건 교육일지 엑셀 파일 확장자 xls로 수정

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingPreviewResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingPreviewResponseDto.java
@@ -13,7 +13,7 @@ public class SafetyTrainingPreviewResponseDto {
     @Schema(description = "미리보기 파일 URL", example = "https://...presigned-url")
     private String previewFileUrl;
 
-    @Schema(description = "미리보기 다운로드 파일명", example = "20260324_정기_안전보건교육.xlsx")
+    @Schema(description = "미리보기 다운로드 파일명", example = "20260324_정기_안전보건교육.xls")
     private String previewFileName;
 
     @Schema(description = "교육 대상 인원 수", example = "49")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingSessionReportResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingSessionReportResponseDto.java
@@ -16,6 +16,6 @@ public class SafetyTrainingSessionReportResponseDto {
     @Schema(description = "엑셀 파일 URL", example = "https://...presigned-url")
     private String reportFileUrl;
 
-    @Schema(description = "엑셀 파일명", example = "20260324_정기_안전보건교육.xlsx")
+    @Schema(description = "엑셀 파일명", example = "20260324_정기_안전보건교육.xls")
     private String reportFileName;
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
@@ -59,6 +59,7 @@ public class SafetyTrainingSessionService {
             DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH시 mm분");
     private static final DateTimeFormatter FILE_DATE_FORMATTER =
             DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final String EXCEL_FILE_EXTENSION = ".xls";
 
     private final SafetyTrainingSessionRepository sessionRepository;
     private final SafetyTrainingSessionAttendeeRepository attendeeRepository;
@@ -90,7 +91,9 @@ public class SafetyTrainingSessionService {
         String previewFileKey =
                 s3Service.uploadBytes(
                         excelBytes,
-                        "safety-training-preview-" + System.currentTimeMillis() + ".xlsx",
+                        "safety-training-preview-"
+                                + System.currentTimeMillis()
+                                + EXCEL_FILE_EXTENSION,
                         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
         String previewFileName =
                 buildExportFileName(requestDto.getStartAt(), requestDto.getTitle());
@@ -441,7 +444,7 @@ public class SafetyTrainingSessionService {
                                 + session.getId()
                                 + "-"
                                 + System.currentTimeMillis()
-                                + ".xlsx",
+                                + EXCEL_FILE_EXTENSION,
                         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
         session.setReportFileKey(newReportKey);
 
@@ -774,7 +777,7 @@ public class SafetyTrainingSessionService {
                 (startAt == null ? LocalDate.now() : startAt.toLocalDate())
                         .format(FILE_DATE_FORMATTER);
         String titlePart = sanitizeFileNamePart(title);
-        return datePart + "_" + titlePart + ".xlsx";
+        return datePart + "_" + titlePart + EXCEL_FILE_EXTENSION;
     }
 
     private String sanitizeFileNamePart(String title) {


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #374 

## 📝작업 내용
- fix: 교육일지 엑셀 미리보기랑 엑셀 보고서 생성 파일 확장자 xls로 수정했습니다.

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
x