### PR TITLE
feat(379): Visit 도메인 복수 담당자 및 환경안전부 조건부 알림 구현

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
@@ -1399,13 +1399,12 @@ public class EduReportController {
                 content =
                         @Content(
                                 mediaType = "application/json",
-                                examples =
-                                        {
-                                            @ExampleObject(
-                                                    name = "DEPARTMENT_NO_AUTHORITY",
-                                                    summary = "부서 교육 권한 없음",
-                                                    value =
-                                                            """
+                                examples = {
+                                    @ExampleObject(
+                                            name = "DEPARTMENT_NO_AUTHORITY",
+                                            summary = "부서 교육 권한 없음",
+                                            value =
+                                                    """
                                         {
                                           "isSuccess": false,
                                           "code": "NO_AUTHORITY_FOR_EDU_REPORT",
@@ -1413,11 +1412,11 @@ public class EduReportController {
                                           "result": null
                                         }
                                         """),
-                                            @ExampleObject(
-                                                    name = "PSM_NO_AUTHORITY",
-                                                    summary = "PSM 권한 없음",
-                                                    value =
-                                                            """
+                                    @ExampleObject(
+                                            name = "PSM_NO_AUTHORITY",
+                                            summary = "PSM 권한 없음",
+                                            value =
+                                                    """
                                         {
                                           "isSuccess": false,
                                           "code": "NO_AUTHORITY_FOR_PSM_MANAGE",
@@ -1425,11 +1424,11 @@ public class EduReportController {
                                           "result": null
                                         }
                                         """),
-                                            @ExampleObject(
-                                                    name = "SAFETY_NO_AUTHORITY",
-                                                    summary = "안전보건 권한 없음",
-                                                    value =
-                                                            """
+                                    @ExampleObject(
+                                            name = "SAFETY_NO_AUTHORITY",
+                                            summary = "안전보건 권한 없음",
+                                            value =
+                                                    """
                                         {
                                           "isSuccess": false,
                                           "code": "NO_AUTHORITY_FOR_SAFETY_WRITE",
@@ -1437,7 +1436,7 @@ public class EduReportController {
                                           "result": null
                                         }
                                         """)
-                                        })),
+                                })),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "404",
                 description = "교육 게시물 없음",

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -1165,8 +1165,8 @@ public class EduReportService {
     public void remindEduReport(Long eduReportId, Long userId) {
         User user =
                 userRepository
-                .findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         EduReport report =
                 eduReportRepository

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/entity/User.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/entity/User.java
@@ -34,7 +34,6 @@ import kr.co.awesomelead.groupware_backend.domain.user.enums.JobType;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
-import kr.co.awesomelead.groupware_backend.domain.visit.entity.Visit;
 import kr.co.awesomelead.groupware_backend.global.encryption.Encryptor;
 
 import lombok.AllArgsConstructor;
@@ -154,11 +153,6 @@ public class User {
             fetch = FetchType.LAZY)
     @JsonManagedReference
     private AnnualLeave annualLeave;
-
-    @Builder.Default
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
-    @JsonManagedReference
-    private List<Visit> visits = new ArrayList<>();
 
     @Builder.Default
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/mapper/UserMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/mapper/UserMapper.java
@@ -29,7 +29,6 @@ public interface UserMapper {
 
     // 연관관계 필드들
     @Mapping(target = "annualLeave", ignore = true)
-    @Mapping(target = "visits", ignore = true)
     @Mapping(target = "checkSheets", ignore = true)
     @Mapping(target = "payslips", ignore = true)
     @Mapping(target = "sentMessages", ignore = true)

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/controller/VisitController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/controller/VisitController.java
@@ -238,7 +238,14 @@ public class VisitController {
                             "id": 1,
                             "visitorCompany": "어썸테크",
                             "visitorName": "홍길동",
-                            "hostDepartmentName": "경영지원부",
+                            "hosts": [
+                              {
+                                "userId": 1,
+                                "name": "김철수",
+                                "position": "과장",
+                                "departmentName": "경영지원부"
+                              }
+                            ],
                             "startDate": "2026-07-01",
                             "endDate": "2026-07-01",
                             "status": "방문 중"

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/request/LongTermVisitRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/request/LongTermVisitRequestDto.java
@@ -3,6 +3,7 @@ package kr.co.awesomelead.groupware_backend.domain.visit.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -17,6 +18,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -63,9 +65,9 @@ public class LongTermVisitRequestDto implements VisitRequest {
     @Schema(description = "기타 허가 요구사항 (필요 시 작성)", example = "화기 사용 허가 필요")
     private String permissionDetail;
 
-    @NotNull(message = "담당자 선택은 필수입니다.")
-    @Schema(description = "담당 직원 ID", example = "1")
-    private Long hostId;
+    @NotEmpty(message = "담당자는 1명 이상 선택해야 합니다.")
+    @Schema(description = "담당 직원 ID 목록", example = "[1, 2]")
+    private List<Long> hostIds;
 
     @NotBlank(message = "비밀번호는 필수입니다.")
     @Size(min = 4, max = 4, message = "비밀번호는 숫자 4자리여야 합니다.")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/request/MyVisitUpdateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/request/MyVisitUpdateRequestDto.java
@@ -16,6 +16,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 @Getter
 @Builder
@@ -63,6 +64,6 @@ public class MyVisitUpdateRequestDto implements VisitRequest {
     @Schema(description = "차량 번호", example = "12가3456")
     private String carNumber;
 
-    @Schema(description = "담당자 직원 ID", example = "1")
-    private Long hostId;
+    @Schema(description = "담당 직원 ID 목록", example = "[1, 2]")
+    private List<Long> hostIds;
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/request/OnSiteVisitRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/request/OnSiteVisitRequestDto.java
@@ -3,6 +3,7 @@ package kr.co.awesomelead.groupware_backend.domain.visit.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -17,6 +18,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Getter
 @Setter
@@ -54,9 +57,9 @@ public class OnSiteVisitRequestDto implements VisitRequest {
     @Schema(description = "기타 허가 요구사항 (필요 시 작성)", example = "화기 사용 허가 필요")
     private String permissionDetail;
 
-    @NotNull(message = "담당자 선택은 필수입니다.")
-    @Schema(description = "담당 직원 ID", example = "1")
-    private Long hostId;
+    @NotEmpty(message = "담당자는 1명 이상 선택해야 합니다.")
+    @Schema(description = "담당 직원 ID 목록", example = "[1, 2]")
+    private List<Long> hostIds;
 
     @NotBlank(message = "비밀번호는 필수입니다.")
     @Size(min = 4, max = 4, message = "비밀번호는 숫자 4자리여야 합니다.")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/request/OneDayVisitRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/request/OneDayVisitRequestDto.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -19,6 +20,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -67,9 +69,9 @@ public class OneDayVisitRequestDto implements VisitRequest {
     @Schema(description = "기타 허가 요구사항 (필요 시 작성)", example = "화기 사용 허가 필요")
     private String permissionDetail;
 
-    @NotNull(message = "담당자 선택은 필수입니다.")
-    @Schema(description = "담당 직원 ID", example = "1")
-    private Long hostId;
+    @NotEmpty(message = "담당자는 1명 이상 선택해야 합니다.")
+    @Schema(description = "담당 직원 ID 목록", example = "[1, 2]")
+    private List<Long> hostIds;
 
     @NotBlank(message = "비밀번호는 필수입니다.")
     @Size(min = 4, max = 4, message = "비밀번호는 숫자 4자리여야 합니다.")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/request/VisitRequest.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/request/VisitRequest.java
@@ -3,6 +3,8 @@ package kr.co.awesomelead.groupware_backend.domain.visit.dto.request;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.AdditionalPermissionType;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitPurpose;
 
+import java.util.List;
+
 public interface VisitRequest {
 
     String getVisitorName();
@@ -19,7 +21,7 @@ public interface VisitRequest {
 
     String getPermissionDetail();
 
-    Long getHostId();
+    List<Long> getHostIds();
 
     String getPassword();
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/response/MyVisitDetailResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/response/MyVisitDetailResponseDto.java
@@ -2,8 +2,6 @@ package kr.co.awesomelead.groupware_backend.domain.visit.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
-import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.AdditionalPermissionType;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitCategory;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitPurpose;
@@ -38,17 +36,8 @@ public class MyVisitDetailResponseDto {
     @Schema(description = "방문 목적", example = "고객 검수")
     private VisitPurpose purpose;
 
-    @Schema(description = "담당 직원 ID", example = "1")
-    private Long hostId;
-
-    @Schema(description = "담당 직원 이름", example = "김철수")
-    private String hostName;
-
-    @Schema(description = "담당 직원 직급", example = "과장")
-    private Position hostPosition;
-
-    @Schema(description = "담당 부서명", example = "환경안전부")
-    private DepartmentName departmentName;
+    @Schema(description = "담당자 목록")
+    private List<VisitHostResponseDto> hosts;
 
     @Schema(description = "방문 상태", example = "방문 전")
     private VisitStatus status;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/response/MyVisitListResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/response/MyVisitListResponseDto.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @Builder
@@ -33,4 +34,7 @@ public class MyVisitListResponseDto {
 
     @Schema(description = "방문 종료일", example = "2024-07-01")
     private LocalDate endDate;
+
+    @Schema(description = "담당자 목록")
+    private List<VisitHostResponseDto> hosts;
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/response/VisitDetailResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/response/VisitDetailResponseDto.java
@@ -2,7 +2,6 @@ package kr.co.awesomelead.groupware_backend.domain.visit.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.AdditionalPermissionType;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitCategory;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitPurpose;
@@ -39,11 +38,8 @@ public class VisitDetailResponseDto {
     @Schema(description = "기타 허가 요구사항", example = "특수 장비 반입 필요")
     private String permissionDetail;
 
-    @Schema(description = "담당 부서", example = "경영지원부")
-    private DepartmentName hostDepartmentName;
-
-    @Schema(description = "담당자 이름", example = "이순신")
-    private String hostName;
+    @Schema(description = "담당자 목록")
+    private List<VisitHostResponseDto> hosts;
 
     @Schema(description = "내방객 전화번호", example = "01012345678")
     private String visitorPhoneNumber;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/response/VisitHostResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/response/VisitHostResponseDto.java
@@ -1,0 +1,29 @@
+package kr.co.awesomelead.groupware_backend.domain.visit.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@Schema(description = "방문 담당자 정보")
+public class VisitHostResponseDto {
+
+    @Schema(description = "담당자 ID", example = "1")
+    private Long userId;
+
+    @Schema(description = "담당자 이름", example = "김철수")
+    private String name;
+
+    @Schema(description = "담당자 직급", example = "과장")
+    private Position position;
+
+    @Schema(description = "담당 부서명", example = "경영지원부")
+    private DepartmentName departmentName;
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/response/VisitListResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/response/VisitListResponseDto.java
@@ -2,7 +2,6 @@ package kr.co.awesomelead.groupware_backend.domain.visit.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitStatus;
 
 import lombok.AllArgsConstructor;
@@ -10,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @Builder
@@ -26,8 +26,8 @@ public class VisitListResponseDto {
     @Schema(description = "내방객 이름", example = "홍길동")
     private String visitorName;
 
-    @Schema(description = "담당 부서", example = "경영지원부")
-    private DepartmentName hostDepartmentName;
+    @Schema(description = "담당자 목록")
+    private List<VisitHostResponseDto> hosts;
 
     @Schema(description = "방문 시작일", example = "2026-02-01")
     private LocalDate startDate;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/entity/Visit.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/entity/Visit.java
@@ -1,6 +1,5 @@
 package kr.co.awesomelead.groupware_backend.domain.visit.entity;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 
 import jakarta.persistence.CascadeType;
@@ -9,20 +8,16 @@ import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
-import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.AdditionalPermissionType;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitCategory;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitPurpose;
@@ -119,10 +114,9 @@ public class Visit {
     @Column(nullable = false)
     private boolean visited; // 방문 여부 (하루인 경우에만 유효)
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    @JsonBackReference
-    private User user; // 담당 직원
+    @Builder.Default
+    @OneToMany(mappedBy = "visit", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<VisitHost> hosts = new ArrayList<>();
 
     @Column(nullable = false, length = 60) // 4자리 비밀번호 가정
     private String password;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/entity/VisitHost.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/entity/VisitHost.java
@@ -1,0 +1,39 @@
+package kr.co.awesomelead.groupware_backend.domain.visit.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "visit_host")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class VisitHost {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "visit_id")
+    private Visit visit;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/mapper/VisitMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/mapper/VisitMapper.java
@@ -1,6 +1,6 @@
 package kr.co.awesomelead.groupware_backend.domain.visit.mapper;
 
-import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
+import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.request.LongTermVisitRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.request.MyVisitUpdateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.request.OnSiteVisitRequestDto;
@@ -8,9 +8,11 @@ import kr.co.awesomelead.groupware_backend.domain.visit.dto.request.OneDayVisitR
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.response.MyVisitDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.response.MyVisitListResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.response.VisitDetailResponseDto;
+import kr.co.awesomelead.groupware_backend.domain.visit.dto.response.VisitHostResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.response.VisitListResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.response.VisitRecordResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.entity.Visit;
+import kr.co.awesomelead.groupware_backend.domain.visit.entity.VisitHost;
 import kr.co.awesomelead.groupware_backend.domain.visit.entity.VisitRecord;
 
 import org.mapstruct.Mapper;
@@ -25,19 +27,19 @@ import java.util.List;
 @Mapper(
         componentModel = "spring",
         unmappedTargetPolicy = ReportingPolicy.IGNORE,
-        nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE) // null은 무시!
+        nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
 public interface VisitMapper {
 
-    @Mapping(target = "id", ignore = true) // 생성 시 ID는 자동 생성되므로 무시
+    @Mapping(target = "id", ignore = true)
     @Mapping(target = "visitorName", source = "dto.visitorName")
     @Mapping(target = "visitorPhoneNumber", source = "dto.visitorPhoneNumber")
     @Mapping(target = "visitorCompany", source = "dto.visitorCompany")
-    @Mapping(target = "hostCompany", source = "host.workLocation")
+    @Mapping(target = "hostCompany", source = "hostCompany")
     @Mapping(target = "carNumber", source = "dto.carNumber")
-    @Mapping(target = "user", source = "host") // 파라미터로 받은 User 객체를 매핑
-    @Mapping(target = "password", source = "encodedPassword") // 암호화된 비밀번호 매핑
-    @Mapping(target = "startDate", source = "dto.visitDate") // 시작일 = 방문일
-    @Mapping(target = "endDate", source = "dto.visitDate") // 종료일 = 방문일
+    @Mapping(target = "hosts", ignore = true)
+    @Mapping(target = "password", source = "encodedPassword")
+    @Mapping(target = "startDate", source = "dto.visitDate")
+    @Mapping(target = "endDate", source = "dto.visitDate")
     @Mapping(target = "plannedEntryTime", source = "dto.plannedEntryTime")
     @Mapping(target = "plannedExitTime", source = "dto.plannedExitTime")
     @Mapping(
@@ -54,13 +56,12 @@ public interface VisitMapper {
     @Mapping(target = "permissionType", ignore = true)
     @Mapping(target = "permissionDetail", ignore = true)
     @Mapping(target = "purpose", ignore = true)
-    Visit toOneDayVisit(OneDayVisitRequestDto dto, User host, String encodedPassword);
+    Visit toOneDayVisit(OneDayVisitRequestDto dto, Company hostCompany, String encodedPassword);
 
     @Mapping(target = "id", ignore = true)
-    @Mapping(target = "user", source = "host")
+    @Mapping(target = "hosts", ignore = true)
     @Mapping(target = "password", source = "encodedPassword")
-    @Mapping(target = "hostCompany", source = "host.workLocation")
-    // 장기 방문은 예정 시간이 없으므로 매핑에서 제외 (null로 들어감)
+    @Mapping(target = "hostCompany", source = "hostCompany")
     @Mapping(target = "plannedEntryTime", ignore = true)
     @Mapping(target = "plannedExitTime", ignore = true)
     @Mapping(
@@ -75,10 +76,10 @@ public interface VisitMapper {
     @Mapping(target = "phoneNumberHash", ignore = true)
     @Mapping(target = "visited", constant = "false")
     @Mapping(target = "purpose", ignore = true)
-    Visit toLongTermVisit(LongTermVisitRequestDto dto, User host, String encodedPassword);
+    Visit toLongTermVisit(LongTermVisitRequestDto dto, Company hostCompany, String encodedPassword);
 
     @Mapping(target = "id", ignore = true)
-    @Mapping(target = "user", source = "host")
+    @Mapping(target = "hosts", ignore = true)
     @Mapping(target = "password", source = "encodedPassword")
     @Mapping(
             target = "visitCategory",
@@ -88,94 +89,81 @@ public interface VisitMapper {
             target = "status",
             expression =
                     "java(kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitStatus.IN_PROGRESS)")
-    @Mapping(target = "visited", constant = "true") // 즉시 방문 처리
+    @Mapping(target = "visited", constant = "true")
     @Mapping(target = "startDate", expression = "java(java.time.LocalDate.now())")
     @Mapping(target = "endDate", expression = "java(java.time.LocalDate.now())")
     @Mapping(target = "plannedEntryTime", expression = "java(java.time.LocalTime.now())")
-    @Mapping(target = "plannedExitTime", ignore = true) // 추가
-    @Mapping(target = "hostCompany", source = "host.workLocation")
+    @Mapping(target = "plannedExitTime", ignore = true)
+    @Mapping(target = "hostCompany", source = "hostCompany")
     @Mapping(target = "records", ignore = true)
     @Mapping(target = "phoneNumberHash", ignore = true)
     @Mapping(target = "purpose", ignore = true)
     @Mapping(target = "permissionType", ignore = true)
     @Mapping(target = "permissionDetail", ignore = true)
-    Visit toOnSiteVisit(OnSiteVisitRequestDto dto, User host, String encodedPassword);
+    Visit toOnSiteVisit(OnSiteVisitRequestDto dto, Company hostCompany, String encodedPassword);
 
-    // MyVisitListResponseDto 매핑
+    @Mapping(target = "userId", source = "user.id")
+    @Mapping(target = "name", expression = "java(visitHost.getUser().getDisplayName())")
+    @Mapping(target = "position", source = "user.position")
+    @Mapping(target = "departmentName", source = "user.department.name")
+    VisitHostResponseDto toVisitHostResponseDto(VisitHost visitHost);
+
+    List<VisitHostResponseDto> toVisitHostResponseDtoList(List<VisitHost> visitHosts);
+
     @Mapping(target = "visitId", source = "id")
     MyVisitListResponseDto toMyVisitListResponseDto(Visit visit);
 
     List<MyVisitListResponseDto> toMyVisitListResponseDtoList(List<Visit> visits);
 
-    // MyVisitDetailResponseDto 매핑
     @Mapping(target = "visitId", source = "id")
-    @Mapping(target = "hostId", source = "user.id")
-    @Mapping(target = "hostName", expression = "java(visit.getUser().getDisplayName())")
-    @Mapping(target = "hostPosition", source = "user.position")
-    @Mapping(target = "departmentName", source = "user.department.name")
+    @Mapping(target = "hosts", source = "hosts")
     @Mapping(target = "entryTime", expression = "java(getEntryTimeLogic(visit))")
     @Mapping(target = "exitTime", expression = "java(getExitTimeLogic(visit))")
     @Mapping(target = "records", source = "records")
     @Mapping(target = "rejectionReason", source = "rejectionReason")
     MyVisitDetailResponseDto toMyVisitDetailResponseDto(Visit visit);
 
-    // VisitMapper.java
-
     default LocalDateTime getEntryTimeLogic(Visit visit) {
-        // 1. 실제 입실 기록이 있으면 그 시간을 최우선 사용
         if (visit.getRecords() != null && !visit.getRecords().isEmpty()) {
             if (visit.getRecords().get(0).getEntryTime() != null) {
                 return visit.getRecords().get(0).getEntryTime();
             }
         }
-
-        // 2. 예정 시간이 없으면 (장기 방문 등) null 혹은 날짜만 반환
         if (visit.getPlannedEntryTime() == null) {
-            // 장기 방문이라면 시작 날짜의 정각(00:00)을 줄 수도 있고, null을 줄 수도 있습니다.
-            // 여기서는 안전하게 null을 반환하고 프론트에서 처리하게 하겠습니다.
             return null;
         }
-
-        // 3. 예정 시간이 있으면 날짜와 합쳐서 반환
         return LocalDateTime.of(visit.getStartDate(), visit.getPlannedEntryTime());
     }
 
     default LocalDateTime getExitTimeLogic(Visit visit) {
-        // 1. 실제 퇴실 기록이 있으면 최우선 사용
         if (visit.getRecords() != null && !visit.getRecords().isEmpty()) {
             if (visit.getRecords().get(0).getExitTime() != null) {
                 return visit.getRecords().get(0).getExitTime();
             }
         }
-
-        // 2. 예정 퇴실 시간이 없으면 null 반환
         if (visit.getPlannedExitTime() == null) {
             return null;
         }
-
         return LocalDateTime.of(visit.getStartDate(), visit.getPlannedExitTime());
     }
 
-    @Mapping(target = "hostDepartmentName", source = "user.department.name")
+    @Mapping(target = "hosts", source = "hosts")
     VisitListResponseDto toVisitListResponseDto(Visit visit);
 
-    @Mapping(target = "hostDepartmentName", source = "user.department.name")
-    @Mapping(target = "hostName", source = "user.nameKor")
+    @Mapping(target = "hosts", source = "hosts")
     @Mapping(target = "records", source = "records")
-    // VisitRecord -> VisitRecordResponseDto 변환 필요
     VisitDetailResponseDto toVisitDetailResponseDto(Visit visit);
 
     @Mapping(target = "signatureUrl", source = "signatureKey")
-    // 키값을 URL로 변환하는 로직은 서비스나 커스텀 매퍼에서 처리 가능
     VisitRecordResponseDto toRecordResponseDto(VisitRecord record);
 
     List<VisitListResponseDto> toVisitListResponseDtos(List<Visit> visits);
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "password", ignore = true)
-    @Mapping(target = "status", ignore = true) // 상태는 서비스 로직에서 직접 변경하므로 무시
-    @Mapping(target = "user", ignore = true) // user는 서비스 로직에서 직접 변경하므로 무시
-    @Mapping(target = "visitorPhoneNumber", ignore = true) // 전화번호는 서비스 로직에서 hash와 함께 처리
+    @Mapping(target = "status", ignore = true)
+    @Mapping(target = "hosts", ignore = true)
+    @Mapping(target = "visitorPhoneNumber", ignore = true)
     @Mapping(target = "phoneNumberHash", ignore = true)
     @Mapping(target = "startDate", source = "startDate")
     @Mapping(target = "endDate", source = "endDate")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/repository/VisitRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/repository/VisitRepository.java
@@ -4,6 +4,7 @@ import kr.co.awesomelead.groupware_backend.domain.visit.entity.Visit;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitCategory;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitStatus;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
@@ -11,6 +12,7 @@ import java.util.List;
 
 public interface VisitRepository extends JpaRepository<Visit, Long> {
 
+    @EntityGraph(attributePaths = {"hosts", "hosts.user", "hosts.user.department"})
     List<Visit> findByVisitorNameAndPhoneNumberHashOrderByIdDesc(
             String name, String inputPhoneHash);
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/repository/querydsl/VisitQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/repository/querydsl/VisitQueryRepository.java
@@ -80,9 +80,12 @@ public class VisitQueryRepository {
         List<Visit> content =
                 queryFactory
                         .selectFrom(visit)
-                        .leftJoin(visit.hosts, qVisitHost).fetchJoin()
-                        .leftJoin(qVisitHost.user, qUser).fetchJoin()
-                        .leftJoin(qUser.department).fetchJoin()
+                        .leftJoin(visit.hosts, qVisitHost)
+                        .fetchJoin()
+                        .leftJoin(qVisitHost.user, qUser)
+                        .fetchJoin()
+                        .leftJoin(qUser.department)
+                        .fetchJoin()
                         .where(visit.id.in(visitIds))
                         .orderBy(visit.id.desc())
                         .fetch();

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/repository/querydsl/VisitQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/repository/querydsl/VisitQueryRepository.java
@@ -5,6 +5,8 @@ import static kr.co.awesomelead.groupware_backend.domain.visit.entity.QVisit.vis
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import kr.co.awesomelead.groupware_backend.domain.user.entity.QUser;
+import kr.co.awesomelead.groupware_backend.domain.visit.entity.QVisitHost;
 import kr.co.awesomelead.groupware_backend.domain.visit.entity.Visit;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitStatus;
 
@@ -32,15 +34,40 @@ public class VisitQueryRepository {
             LocalDate endDate,
             Pageable pageable) {
 
-        List<Visit> content =
+        QVisitHost qVisitHost = QVisitHost.visitHost;
+        QUser qUser = QUser.user;
+
+        // Count distinct visits (avoid duplicates from hosts join)
+        long total =
+                Optional.ofNullable(
+                                queryFactory
+                                        .select(visit.id.countDistinct())
+                                        .from(visit)
+                                        .leftJoin(visit.hosts, qVisitHost)
+                                        .leftJoin(qVisitHost.user, qUser)
+                                        .leftJoin(qUser.department)
+                                        .where(
+                                                departmentIdEq(qVisitHost, departmentId),
+                                                statusEq(status),
+                                                endDateGoe(startDate),
+                                                startDateLoe(endDate))
+                                        .fetchOne())
+                        .orElse(0L);
+
+        if (total == 0) {
+            return new PageImpl<>(List.of(), pageable, 0);
+        }
+
+        // Get page of distinct visit IDs
+        List<Long> visitIds =
                 queryFactory
-                        .selectFrom(visit)
-                        .join(visit.user)
-                        .fetchJoin()
-                        .join(visit.user.department)
-                        .fetchJoin()
+                        .selectDistinct(visit.id)
+                        .from(visit)
+                        .leftJoin(visit.hosts, qVisitHost)
+                        .leftJoin(qVisitHost.user, qUser)
+                        .leftJoin(qUser.department)
                         .where(
-                                departmentIdEq(departmentId),
+                                departmentIdEq(qVisitHost, departmentId),
                                 statusEq(status),
                                 endDateGoe(startDate),
                                 startDateLoe(endDate))
@@ -49,26 +76,22 @@ public class VisitQueryRepository {
                         .limit(pageable.getPageSize())
                         .fetch();
 
-        long total =
-                Optional.ofNullable(
-                                queryFactory
-                                        .select(visit.count())
-                                        .from(visit)
-                                        .join(visit.user)
-                                        .join(visit.user.department)
-                                        .where(
-                                                departmentIdEq(departmentId),
-                                                statusEq(status),
-                                                endDateGoe(startDate),
-                                                startDateLoe(endDate))
-                                        .fetchOne())
-                        .orElse(0L);
+        // Fetch full Visit entities with hosts eagerly loaded
+        List<Visit> content =
+                queryFactory
+                        .selectFrom(visit)
+                        .leftJoin(visit.hosts, qVisitHost).fetchJoin()
+                        .leftJoin(qVisitHost.user, qUser).fetchJoin()
+                        .leftJoin(qUser.department).fetchJoin()
+                        .where(visit.id.in(visitIds))
+                        .orderBy(visit.id.desc())
+                        .fetch();
 
         return new PageImpl<>(content, pageable, total);
     }
 
-    private BooleanExpression departmentIdEq(Long departmentId) {
-        return departmentId != null ? visit.user.department.id.eq(departmentId) : null;
+    private BooleanExpression departmentIdEq(QVisitHost qVisitHost, Long departmentId) {
+        return departmentId != null ? qVisitHost.user.department.id.eq(departmentId) : null;
     }
 
     private BooleanExpression statusEq(VisitStatus status) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
@@ -2,7 +2,6 @@ package kr.co.awesomelead.groupware_backend.domain.visit.service;
 
 import static kr.co.awesomelead.groupware_backend.domain.visit.entity.Visit.hashValue;
 
-import kr.co.awesomelead.groupware_backend.domain.department.entity.Department;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
 import kr.co.awesomelead.groupware_backend.domain.department.repository.DepartmentRepository;
 import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationDomainType;
@@ -85,7 +84,8 @@ public class VisitService {
         List<User> hosts = findUsersByIds(dto.getHostIds());
         String encodedPassword = passwordEncoder.encode(dto.getPassword());
 
-        Visit visit = visitMapper.toOneDayVisit(dto, hosts.get(0).getWorkLocation(), encodedPassword);
+        Visit visit =
+                visitMapper.toOneDayVisit(dto, hosts.get(0).getWorkLocation(), encodedPassword);
         syncAndValidatePermissions(visit, dto);
         addHostsToVisit(visit, hosts);
 
@@ -121,7 +121,8 @@ public class VisitService {
         List<User> hosts = findUsersByIds(dto.getHostIds());
         String encodedPassword = passwordEncoder.encode(dto.getPassword());
 
-        Visit visit = visitMapper.toLongTermVisit(dto, hosts.get(0).getWorkLocation(), encodedPassword);
+        Visit visit =
+                visitMapper.toLongTermVisit(dto, hosts.get(0).getWorkLocation(), encodedPassword);
         syncAndValidatePermissions(visit, dto);
         addHostsToVisit(visit, hosts);
 
@@ -154,7 +155,8 @@ public class VisitService {
         String encodedPassword = passwordEncoder.encode(dto.getPassword());
         String signatureKey = s3Service.uploadFile(dto.getSignatureFile());
 
-        Visit visit = visitMapper.toOnSiteVisit(dto, hosts.get(0).getWorkLocation(), encodedPassword);
+        Visit visit =
+                visitMapper.toOnSiteVisit(dto, hosts.get(0).getWorkLocation(), encodedPassword);
         syncAndValidatePermissions(visit, dto);
         addHostsToVisit(visit, hosts);
 
@@ -322,9 +324,7 @@ public class VisitService {
 
         return visits.stream()
                 .filter(visit -> StringUtils.hasText(visit.getPassword()))
-                .filter(
-                        visit ->
-                                passwordEncoder.matches(dto.getPassword(), visit.getPassword()))
+                .filter(visit -> passwordEncoder.matches(dto.getPassword(), visit.getPassword()))
                 .map(visitMapper::toMyVisitListResponseDto)
                 .toList();
     }
@@ -534,15 +534,15 @@ public class VisitService {
                                 userRepository
                                         .findById(id)
                                         .orElseThrow(
-                                                () -> new CustomException(ErrorCode.USER_NOT_FOUND)))
+                                                () ->
+                                                        new CustomException(
+                                                                ErrorCode.USER_NOT_FOUND)))
                 .toList();
     }
 
     private void addHostsToVisit(Visit visit, List<User> hostUsers) {
         hostUsers.forEach(
-                user ->
-                        visit.getHosts()
-                                .add(VisitHost.builder().visit(visit).user(user).build()));
+                user -> visit.getHosts().add(VisitHost.builder().visit(visit).user(user).build()));
     }
 
     private void sendVisitAlertToHostDepartments(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
@@ -2,6 +2,8 @@ package kr.co.awesomelead.groupware_backend.domain.visit.service;
 
 import static kr.co.awesomelead.groupware_backend.domain.visit.entity.Visit.hashValue;
 
+import kr.co.awesomelead.groupware_backend.domain.department.entity.Department;
+import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
 import kr.co.awesomelead.groupware_backend.domain.department.repository.DepartmentRepository;
 import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationDomainType;
 import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationMessage;
@@ -22,6 +24,7 @@ import kr.co.awesomelead.groupware_backend.domain.visit.dto.response.MyVisitDeta
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.response.MyVisitListResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.response.VisitListResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.entity.Visit;
+import kr.co.awesomelead.groupware_backend.domain.visit.entity.VisitHost;
 import kr.co.awesomelead.groupware_backend.domain.visit.entity.VisitRecord;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.AdditionalPermissionType;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitCategory;
@@ -49,8 +52,11 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -58,6 +64,12 @@ import java.util.Map;
 public class VisitService {
     private static final DateTimeFormatter NOTIFICATION_TIME_FORMATTER =
             DateTimeFormatter.ofPattern("HH:mm:ss");
+
+    private static final Set<VisitPurpose> ENVIRONMENT_SAFETY_REQUIRED_PURPOSES =
+            EnumSet.of(
+                    VisitPurpose.CUSTOMER_INSPECTION,
+                    VisitPurpose.HAZARDOUS_SUBSTANCE,
+                    VisitPurpose.FACILITY_CONSTRUCTION);
 
     private final VisitRepository visitRepository;
     private final VisitQueryRepository visitQueryRepository;
@@ -70,92 +82,88 @@ public class VisitService {
 
     @Transactional
     public Long registerOneDayPreVisit(OneDayVisitRequestDto dto) {
-
-        User host =
-                userRepository
-                        .findById(dto.getHostId())
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-        Long hostDeptId = host.getDepartment() != null ? host.getDepartment().getId() : null;
-        String hostName = host.getDisplayName();
+        List<User> hosts = findUsersByIds(dto.getHostIds());
         String encodedPassword = passwordEncoder.encode(dto.getPassword());
 
-        Visit visit = visitMapper.toOneDayVisit(dto, host, encodedPassword);
+        Visit visit = visitMapper.toOneDayVisit(dto, hosts.get(0).getWorkLocation(), encodedPassword);
         syncAndValidatePermissions(visit, dto);
+        addHostsToVisit(visit, hosts);
 
         Long visitId = visitRepository.save(visit).getId();
 
-        // 담당 부서 소속 전원에게 방문 예정 알림
-        if (hostDeptId != null) {
-            notificationService.sendVisitAlertToDepartment(
-                    NotificationMessage.VISIT_ONE_DAY_PRE,
-                    visitId,
-                    hostDeptId,
-                    Map.of("isApprovalTarget", false, "status", VisitStatus.PENDING.name()),
-                    visit.getVisitorName(),
-                    visit.getStartDate(),
-                    dto.getPlannedEntryTime(),
-                    hostName);
-        }
+        sendVisitAlertToHostDepartments(
+                NotificationMessage.VISIT_ONE_DAY_PRE,
+                visitId,
+                hosts,
+                Map.of("isApprovalTarget", false, "status", VisitStatus.PENDING.name()),
+                visit.getVisitorName(),
+                visit.getStartDate(),
+                dto.getPlannedEntryTime(),
+                hosts.get(0).getDisplayName());
+
+        sendEnvironmentSafetyAlertIfRequired(
+                visit.getPurpose(),
+                NotificationMessage.VISIT_ONE_DAY_PRE,
+                visitId,
+                Map.of("isApprovalTarget", false, "status", VisitStatus.PENDING.name()),
+                visit.getVisitorName(),
+                visit.getStartDate(),
+                dto.getPlannedEntryTime(),
+                hosts.get(0).getDisplayName());
 
         return visitId;
     }
 
     @Transactional
     public Long registerLongTermPreVisit(LongTermVisitRequestDto dto) {
-
         validateLongTermPeriod(dto.getStartDate(), dto.getEndDate());
 
-        User host =
-                userRepository
-                        .findById(dto.getHostId())
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-        Long hostDeptId = host.getDepartment() != null ? host.getDepartment().getId() : null;
+        List<User> hosts = findUsersByIds(dto.getHostIds());
         String encodedPassword = passwordEncoder.encode(dto.getPassword());
 
-        Visit visit = visitMapper.toLongTermVisit(dto, host, encodedPassword);
+        Visit visit = visitMapper.toLongTermVisit(dto, hosts.get(0).getWorkLocation(), encodedPassword);
         syncAndValidatePermissions(visit, dto);
+        addHostsToVisit(visit, hosts);
 
         Long visitId = visitRepository.save(visit).getId();
 
-        // 담당 부서 소속 전원에게 장기 방문 승인 요청 알림
-        if (hostDeptId != null) {
-            notificationService.sendVisitAlertToDepartment(
-                    NotificationMessage.VISIT_LONG_TERM_PRE,
-                    visitId,
-                    hostDeptId,
-                    Map.of("status", VisitStatus.PENDING.name(), "isApprovalTarget", true),
-                    visit.getVisitorName(),
-                    dto.getStartDate(),
-                    dto.getEndDate());
-        }
+        sendVisitAlertToHostDepartments(
+                NotificationMessage.VISIT_LONG_TERM_PRE,
+                visitId,
+                hosts,
+                Map.of("status", VisitStatus.PENDING.name(), "isApprovalTarget", true),
+                visit.getVisitorName(),
+                dto.getStartDate(),
+                dto.getEndDate());
+
+        sendEnvironmentSafetyAlertIfRequired(
+                visit.getPurpose(),
+                NotificationMessage.VISIT_LONG_TERM_PRE,
+                visitId,
+                Map.of("status", VisitStatus.PENDING.name(), "isApprovalTarget", true),
+                visit.getVisitorName(),
+                dto.getStartDate(),
+                dto.getEndDate());
 
         return visitId;
     }
 
     @Transactional
     public Long registerOnSiteVisit(OnSiteVisitRequestDto dto) throws IOException {
-
-        User host =
-                userRepository
-                        .findById(dto.getHostId())
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
+        List<User> hosts = findUsersByIds(dto.getHostIds());
         String encodedPassword = passwordEncoder.encode(dto.getPassword());
         String signatureKey = s3Service.uploadFile(dto.getSignatureFile());
 
-        Visit visit = visitMapper.toOnSiteVisit(dto, host, encodedPassword);
+        Visit visit = visitMapper.toOnSiteVisit(dto, hosts.get(0).getWorkLocation(), encodedPassword);
         syncAndValidatePermissions(visit, dto);
-
-        Long hostDeptId = host.getDepartment() != null ? host.getDepartment().getId() : null;
+        addHostsToVisit(visit, hosts);
 
         VisitRecord record =
                 VisitRecord.builder()
                         .visit(visit)
                         .visitDate(LocalDate.now())
                         .entryTime(LocalDateTime.now())
-                        .exitTime(null) // 현장 방문 시점에는 퇴실 시간이 없음
+                        .exitTime(null)
                         .signatureKey(signatureKey)
                         .build();
 
@@ -163,22 +171,26 @@ public class VisitService {
 
         Long visitId = visitRepository.save(visit).getId();
 
-        // 담당 부서 소속 전원에게 입실 알림
-        if (hostDeptId != null) {
-            notificationService.sendVisitAlertToDepartment(
-                    NotificationMessage.VISIT_CHECK_IN,
-                    visitId,
-                    hostDeptId,
-                    Map.of("isApprovalTarget", false, "status", VisitStatus.IN_PROGRESS.name()),
-                    visit.getVisitorName(),
-                    formatNotificationTime(record.getEntryTime().toLocalTime()));
-        }
+        sendVisitAlertToHostDepartments(
+                NotificationMessage.VISIT_CHECK_IN,
+                visitId,
+                hosts,
+                Map.of("isApprovalTarget", false, "status", VisitStatus.IN_PROGRESS.name()),
+                visit.getVisitorName(),
+                formatNotificationTime(record.getEntryTime().toLocalTime()));
+
+        sendEnvironmentSafetyAlertIfRequired(
+                visit.getPurpose(),
+                NotificationMessage.VISIT_CHECK_IN,
+                visitId,
+                Map.of("isApprovalTarget", false, "status", VisitStatus.IN_PROGRESS.name()),
+                visit.getVisitorName(),
+                formatNotificationTime(record.getEntryTime().toLocalTime()));
 
         return visitId;
     }
 
     private void syncAndValidatePermissions(Visit visit, VisitRequest dto) {
-        // 1. 매퍼가 놓칠 수 있는 필드 바인딩 (수정 시 null 체크 포함)
         if (dto.getPurpose() != null) {
             visit.setPurpose(dto.getPurpose());
         }
@@ -186,15 +198,12 @@ public class VisitService {
             visit.setPermissionType(dto.getPermissionType());
         }
 
-        // 2. '기타 허가'가 아닐 경우 기존 상세내용 초기화 (데이터 정합성)
         if (visit.getPermissionType() != AdditionalPermissionType.OTHER_PERMISSION) {
             visit.setPermissionDetail(null);
         } else if (StringUtils.hasText(dto.getPermissionDetail())) {
             visit.setPermissionDetail(dto.getPermissionDetail());
         }
 
-        // 3. 비즈니스 규칙 통합 검증 (엔티티의 최종 상태 기준)
-        // 규칙 1: 시설공사는 보충적 허가 필수
         if (visit.getPurpose() == VisitPurpose.FACILITY_CONSTRUCTION) {
             if (visit.getPermissionType() == null
                     || visit.getPermissionType() == AdditionalPermissionType.NONE) {
@@ -202,7 +211,6 @@ public class VisitService {
             }
         }
 
-        // 규칙 2: '기타 허가' 선택 시 상세 내용 필수
         if (visit.getPermissionType() == AdditionalPermissionType.OTHER_PERMISSION) {
             if (!StringUtils.hasText(visit.getPermissionDetail())) {
                 throw new CustomException(ErrorCode.PERMISSION_DETAIL_REQUIRED);
@@ -214,7 +222,6 @@ public class VisitService {
         if (endDate.isBefore(startDate)) {
             throw new CustomException(ErrorCode.INVALID_VISIT_DATE_RANGE);
         }
-        // 시작일 기준 정확히 3개월 뒤 날짜 계산
         LocalDate maxEndDate = startDate.plusMonths(3);
         if (endDate.isAfter(maxEndDate)) {
             throw new CustomException(ErrorCode.LONG_TERM_PERIOD_EXCEEDED);
@@ -225,22 +232,17 @@ public class VisitService {
         return time.format(NOTIFICATION_TIME_FORMATTER);
     }
 
-    // 방문처리
     @Transactional
     public Long checkIn(CheckInRequestDto dto) throws IOException {
-        // 1. 방문 신청 건 조회
         Visit visit =
                 visitRepository
                         .findById(dto.getVisitId())
                         .orElseThrow(() -> new CustomException(ErrorCode.VISIT_NOT_FOUND));
 
-        // 2. 입실 가능 상태 검증
         visit.validateCheckInEligible();
 
-        // 5. 서명 이미지 S3 업로드
         String signatureKey = s3Service.uploadFile(dto.getSignatureFile());
 
-        // 6. 입실 기록(VisitRecord) 생성
         VisitRecord record =
                 VisitRecord.builder()
                         .visit(visit)
@@ -250,23 +252,25 @@ public class VisitService {
                         .build();
 
         visit.getRecords().add(record);
-
-        // 7. 방문 상태 업데이트
         visit.setStatus(VisitStatus.IN_PROGRESS);
         visit.setVisited(true);
 
-        // 8. 담당 부서 소속 전원에게 입실 알림
-        User host = visit.getUser();
-        if (host != null && host.getDepartment() != null) {
-            LocalDateTime entryTime = record.getEntryTime();
-            notificationService.sendVisitAlertToDepartment(
-                    NotificationMessage.VISIT_CHECK_IN,
-                    visit.getId(),
-                    host.getDepartment().getId(),
-                    Map.of("isApprovalTarget", false, "status", VisitStatus.IN_PROGRESS.name()),
-                    visit.getVisitorName(),
-                    formatNotificationTime(entryTime.toLocalTime()));
-        }
+        List<User> hosts = visit.getHosts().stream().map(VisitHost::getUser).toList();
+        sendVisitAlertToHostDepartments(
+                NotificationMessage.VISIT_CHECK_IN,
+                visit.getId(),
+                hosts,
+                Map.of("isApprovalTarget", false, "status", VisitStatus.IN_PROGRESS.name()),
+                visit.getVisitorName(),
+                formatNotificationTime(record.getEntryTime().toLocalTime()));
+
+        sendEnvironmentSafetyAlertIfRequired(
+                visit.getPurpose(),
+                NotificationMessage.VISIT_CHECK_IN,
+                visit.getId(),
+                Map.of("isApprovalTarget", false, "status", VisitStatus.IN_PROGRESS.name()),
+                visit.getVisitorName(),
+                formatNotificationTime(record.getEntryTime().toLocalTime()));
 
         return visit.getId();
     }
@@ -288,22 +292,19 @@ public class VisitService {
 
         boolean isInitialCheckOut = (record.getExitTime() == null);
 
-        // 상태 변경 로직
         if (isInitialCheckOut) {
-            // 최초 퇴실 처리 시에는 입실을 한 상태인지 확인
             if (visit.getStatus() != VisitStatus.IN_PROGRESS) {
                 throw new CustomException(ErrorCode.NOT_IN_PROGRESS);
             }
             if (visit.getVisitCategory() == VisitCategory.PRE_LONG_TERM) {
-                visit.setStatus(VisitStatus.APPROVED); // 다음 입실을 위해 다시 승인 상태로
+                visit.setStatus(VisitStatus.APPROVED);
             } else {
-                visit.setStatus(VisitStatus.COMPLETED); // 단기 방문은 최종 완료
+                visit.setStatus(VisitStatus.COMPLETED);
             }
         }
 
         if (dto.getCheckOutTime().isBefore(record.getEntryTime())) {
-            throw new CustomException(
-                    ErrorCode.INVALID_CHECKOUT_TIME); // "퇴실 시간은 입실 시간보다 빠를 수 없습니다."
+            throw new CustomException(ErrorCode.INVALID_CHECKOUT_TIME);
         }
 
         record.setExitTime(dto.getCheckOutTime());
@@ -311,7 +312,6 @@ public class VisitService {
         return visit.getId();
     }
 
-    // 내 방문 목록 조회
     @Transactional(readOnly = true)
     public List<MyVisitListResponseDto> getMyVisitList(VisitSearchRequestDto dto) {
         String inputPhoneHash = hashValue(dto.getPhoneNumber());
@@ -321,28 +321,21 @@ public class VisitService {
                         dto.getName(), inputPhoneHash);
 
         return visits.stream()
+                .filter(visit -> StringUtils.hasText(visit.getPassword()))
                 .filter(
                         visit ->
-                                StringUtils.hasText(
-                                        visit.getPassword())) // 비밀번호가 있는 건만 대상 (현장 내방 제외)
-                .filter(
-                        visit ->
-                                passwordEncoder.matches(
-                                        dto.getPassword(), visit.getPassword())) // 비번 일치 확인
+                                passwordEncoder.matches(dto.getPassword(), visit.getPassword()))
                 .map(visitMapper::toMyVisitListResponseDto)
                 .toList();
     }
 
-    // 내 방문 상세 조회
     @Transactional(readOnly = true)
     public MyVisitDetailResponseDto getMyVisitDetail(Long visitId) {
-        // 1. 존재 여부 확인
         Visit visit =
                 visitRepository
                         .findById(visitId)
                         .orElseThrow(() -> new CustomException(ErrorCode.VISIT_NOT_FOUND));
 
-        // 2. 엔티티 -> DTO 변환 (시간 계산은 매퍼의 default 메서드가 처리)
         MyVisitDetailResponseDto responseDto = visitMapper.toMyVisitDetailResponseDto(visit);
 
         if (responseDto.getRecords() != null) {
@@ -361,7 +354,6 @@ public class VisitService {
 
     @Transactional
     public void updateMyVisit(Long visitId, MyVisitUpdateRequestDto dto) {
-
         Visit visit =
                 visitRepository
                         .findById(visitId)
@@ -371,30 +363,26 @@ public class VisitService {
             throw new CustomException(ErrorCode.INVALID_PASSWORD);
         }
 
-        // 수정 가능 상태 검증 (하루: NOT_VISITED, 장기: PENDING)
         validateUpdateStatus(visit);
 
         if (visit.getVisitCategory() == VisitCategory.PRE_LONG_TERM) {
-
             LocalDate effectiveStart =
                     (dto.getStartDate() != null) ? dto.getStartDate() : visit.getStartDate();
             LocalDate effectiveEnd =
                     (dto.getEndDate() != null) ? dto.getEndDate() : visit.getEndDate();
 
             validateLongTermPeriod(effectiveStart, effectiveEnd);
-            // 장기 방문은 수정 후 다시 승인 대기 상태로 변경
             visit.setStatus(VisitStatus.PENDING);
         }
 
         visitMapper.updateVisitFromDto(dto, visit);
 
-        if (dto.getHostId() != null) {
-            User host =
-                    userRepository
-                            .findById(dto.getHostId())
-                            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-            visit.setUser(host);
+        if (dto.getHostIds() != null && !dto.getHostIds().isEmpty()) {
+            List<User> newHosts = findUsersByIds(dto.getHostIds());
+            visit.getHosts().clear();
+            addHostsToVisit(visit, newHosts);
         }
+
         if (dto.getVisitorPhoneNumber() != null) {
             visit.setVisitorPhoneNumber(dto.getVisitorPhoneNumber());
             visit.setPhoneNumberHash(hashValue(dto.getVisitorPhoneNumber()));
@@ -409,7 +397,7 @@ public class VisitService {
 
     private void validateUpdateStatus(Visit visit) {
         if (visit.getStatus() == VisitStatus.COMPLETED) {
-            throw new CustomException(ErrorCode.INVALID_VISIT_STATUS); // "완료된 방문은 수정할 수 없습니다."
+            throw new CustomException(ErrorCode.INVALID_VISIT_STATUS);
         }
 
         if (visit.isVisited()) {
@@ -422,14 +410,12 @@ public class VisitService {
                 throw new CustomException(ErrorCode.INVALID_VISIT_STATUS);
             }
         } else {
-            // 하루 방문은 입실 전(NOT_VISITED) 상태여야 함
             if (visit.getStatus() != VisitStatus.NOT_VISITED) {
-                throw new CustomException(ErrorCode.INVALID_VISIT_STATUS); // "방문 전 상태에서만 수정 가능합니다."
+                throw new CustomException(ErrorCode.INVALID_VISIT_STATUS);
             }
         }
     }
 
-    // 직용원 방문 목록 조회
     @Transactional(readOnly = true)
     public Page<VisitListResponseDto> getVisitsForAdmin(
             Long userId,
@@ -445,7 +431,6 @@ public class VisitService {
                 .map(visitMapper::toVisitListResponseDto);
     }
 
-    // 직원용 방문 상세 조회
     @Transactional(readOnly = true)
     public MyVisitDetailResponseDto getVisitDetailForAdmin(Long userId, Long visitId) {
         validateEmployeeAccess(userId);
@@ -493,22 +478,28 @@ public class VisitService {
     private void validateManagedDepartmentAccess(User manager, Visit visit) {
         Long managerDepartmentId =
                 manager.getDepartment() != null ? manager.getDepartment().getId() : null;
-        Long hostDepartmentId =
-                visit.getUser() != null && visit.getUser().getDepartment() != null
-                        ? visit.getUser().getDepartment().getId()
-                        : null;
 
-        if (managerDepartmentId == null
-                || hostDepartmentId == null
-                || !managerDepartmentId.equals(hostDepartmentId)) {
+        if (managerDepartmentId == null) {
+            throw new CustomException(ErrorCode.VISIT_ACCESS_DENIED);
+        }
+
+        boolean hasAccess =
+                visit.getHosts().stream()
+                        .filter(h -> h.getUser() != null && h.getUser().getDepartment() != null)
+                        .anyMatch(
+                                h ->
+                                        h.getUser()
+                                                .getDepartment()
+                                                .getId()
+                                                .equals(managerDepartmentId));
+
+        if (!hasAccess) {
             throw new CustomException(ErrorCode.VISIT_ACCESS_DENIED);
         }
     }
 
-    // 직원용 사전 장기방문 승인 및 반려
     @Transactional
     public void processVisit(Long userId, Long visitId, VisitProcessRequestDto dto) {
-        // 2. 방문 신청 건 조회
         Visit visit =
                 visitRepository
                         .findById(visitId)
@@ -516,27 +507,74 @@ public class VisitService {
         User manager = validateVisitorManageAuthority(userId);
         validateManagedDepartmentAccess(manager, visit);
 
-        // 3. 승인 가능한 상태인지 검증
-        // - 장기 방문이어야 함
-        // - 현재 상태가 PENDING(승인 대기)이어야 함
         if (visit.getVisitCategory() != VisitCategory.PRE_LONG_TERM) {
-            throw new CustomException(ErrorCode.NOT_LONG_TERM_VISIT); // "장기 방문 건이 아닙니다."
+            throw new CustomException(ErrorCode.NOT_LONG_TERM_VISIT);
         }
 
         if (visit.getStatus() != VisitStatus.PENDING) {
-            throw new CustomException(ErrorCode.INVALID_VISIT_STATUS); // "승인 가능한 상태가 아닙니다."
+            throw new CustomException(ErrorCode.INVALID_VISIT_STATUS);
         }
 
-        // 4. 반려 시 사유 필수 검증
         if (dto.getStatus() == VisitStatus.REJECTED
                 && !StringUtils.hasText(dto.getRejectionReason())) {
             throw new CustomException(ErrorCode.REJECTION_REASON_REQUIRED);
         }
 
-        // 5. 상태 변경 처리
         visit.process(dto.getStatus(), dto.getRejectionReason());
 
-        // 6. 승인 대기 알림 해제 (승인/반려 모두)
         notificationService.resolveRequiresApproval(NotificationDomainType.VISIT, visitId);
+    }
+
+    // --- Helper methods ---
+
+    private List<User> findUsersByIds(List<Long> hostIds) {
+        return hostIds.stream()
+                .map(
+                        id ->
+                                userRepository
+                                        .findById(id)
+                                        .orElseThrow(
+                                                () -> new CustomException(ErrorCode.USER_NOT_FOUND)))
+                .toList();
+    }
+
+    private void addHostsToVisit(Visit visit, List<User> hostUsers) {
+        hostUsers.forEach(
+                user ->
+                        visit.getHosts()
+                                .add(VisitHost.builder().visit(visit).user(user).build()));
+    }
+
+    private void sendVisitAlertToHostDepartments(
+            NotificationMessage template,
+            Long visitId,
+            List<User> hosts,
+            Map<String, Object> metadata,
+            Object... contentArgs) {
+        hosts.stream()
+                .filter(h -> h.getDepartment() != null)
+                .map(h -> h.getDepartment().getId())
+                .collect(Collectors.toSet())
+                .forEach(
+                        deptId ->
+                                notificationService.sendVisitAlertToDepartment(
+                                        template, visitId, deptId, metadata, contentArgs));
+    }
+
+    private void sendEnvironmentSafetyAlertIfRequired(
+            VisitPurpose purpose,
+            NotificationMessage template,
+            Long visitId,
+            Map<String, Object> metadata,
+            Object... contentArgs) {
+        if (!ENVIRONMENT_SAFETY_REQUIRED_PURPOSES.contains(purpose)) {
+            return;
+        }
+        departmentRepository
+                .findByName(DepartmentName.ENVIRONMENT_SAFETY)
+                .ifPresent(
+                        dept ->
+                                notificationService.sendVisitAlertToDepartment(
+                                        template, visitId, dept.getId(), metadata, contentArgs));
     }
 }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
@@ -2100,11 +2100,7 @@ public class EduReportServiceTest {
             // given
             User user = createNormalUser();
             EduReport report =
-                    EduReport.builder()
-                            .id(10L)
-                            .eduType(EduType.SAFETY)
-                            .title("안전 교육")
-                            .build();
+                    EduReport.builder().id(10L).eduType(EduType.SAFETY).title("안전 교육").build();
 
             when(userRepository.findById(1L)).thenReturn(Optional.of(user));
             when(eduReportRepository.findById(10L)).thenReturn(Optional.of(report));
@@ -2123,11 +2119,7 @@ public class EduReportServiceTest {
             User requestUser = createNormalUser(); // id = 1L
 
             EduReport report =
-                    EduReport.builder()
-                            .id(10L)
-                            .eduType(EduType.PSM)
-                            .title("PSM 교육")
-                            .build();
+                    EduReport.builder().id(10L).eduType(EduType.PSM).title("PSM 교육").build();
 
             when(userRepository.findById(1L)).thenReturn(Optional.of(requestUser));
             when(eduReportRepository.findById(10L)).thenReturn(Optional.of(report));

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
@@ -3,6 +3,7 @@ package kr.co.awesomelead.groupware_backend.domain.visit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
@@ -12,6 +13,7 @@ import static org.mockito.Mockito.verify;
 import kr.co.awesomelead.groupware_backend.domain.department.entity.Department;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
+import kr.co.awesomelead.groupware_backend.domain.department.repository.DepartmentRepository;
 import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Authority;
@@ -26,6 +28,7 @@ import kr.co.awesomelead.groupware_backend.domain.visit.dto.request.OneDayVisitR
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.request.VisitProcessRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.response.VisitListResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.entity.Visit;
+import kr.co.awesomelead.groupware_backend.domain.visit.entity.VisitHost;
 import kr.co.awesomelead.groupware_backend.domain.visit.entity.VisitRecord;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.AdditionalPermissionType;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitCategory;
@@ -76,6 +79,7 @@ public class VisitServiceTest {
     @Mock private VisitRepository visitRepository;
     @Mock private VisitQueryRepository visitQueryRepository;
     @Mock private UserRepository userRepository;
+    @Mock private DepartmentRepository departmentRepository;
     @Mock private S3Service s3Service;
     @Mock private PasswordEncoder passwordEncoder;
     @Mock private NotificationService notificationService;
@@ -103,14 +107,16 @@ public class VisitServiceTest {
     }
 
     private Visit createBaseVisit(VisitStatus status, VisitCategory visitCategory) {
-        return Visit.builder()
-                .id(VISIT_ID)
-                .password(ENCODED_PASSWORD)
-                .status(status)
-                .visitCategory(visitCategory)
-                .user(createHost())
-                .records(new ArrayList<>())
-                .build();
+        Visit visit =
+                Visit.builder()
+                        .id(VISIT_ID)
+                        .password(ENCODED_PASSWORD)
+                        .status(status)
+                        .visitCategory(visitCategory)
+                        .records(new ArrayList<>())
+                        .build();
+        visit.getHosts().add(VisitHost.builder().user(createHost()).build());
+        return visit;
     }
 
     @Nested
@@ -169,14 +175,12 @@ public class VisitServiceTest {
                 OneDayVisitRequestDto dto =
                         createOneDayDto(VisitPurpose.MEETING, AdditionalPermissionType.NONE, null);
 
-                User mockHost = User.builder().id(dto.getHostId()).build();
                 String encodedPassword = "encoded_password_1234";
 
                 Visit mockVisit =
                         createBaseVisit(VisitStatus.NOT_VISITED, VisitCategory.PRE_ONE_DAY);
                 mockVisit.setPurpose(dto.getPurpose());
 
-                given(userRepository.findById(dto.getHostId())).willReturn(Optional.of(mockHost));
                 given(passwordEncoder.encode(dto.getPassword())).willReturn(encodedPassword);
                 given(visitMapper.toOneDayVisit(any(), any(), any())).willReturn(mockVisit);
                 given(visitRepository.save(any(Visit.class))).willReturn(mockVisit);
@@ -186,7 +190,7 @@ public class VisitServiceTest {
 
                 // then
                 assertThat(resultId).isEqualTo(VISIT_ID);
-                verify(userRepository, times(1)).findById(dto.getHostId());
+                verify(userRepository, times(1)).findById(1L);
                 verify(passwordEncoder, times(1)).encode(dto.getPassword());
                 verify(visitRepository, times(1)).save(any(Visit.class));
             }
@@ -204,7 +208,7 @@ public class VisitServiceTest {
                     .visitDate(LocalDate.now().plusDays(1))
                     .plannedEntryTime(LocalTime.of(10, 0))
                     .plannedExitTime(LocalTime.of(18, 0))
-                    .hostId(1L)
+                    .hostIds(List.of(1L))
                     .password("1234")
                     .build();
         }
@@ -263,7 +267,7 @@ public class VisitServiceTest {
                 LocalDate startDate = LocalDate.of(2026, 1, 22);
                 LongTermVisitRequestDto dto =
                         LongTermVisitRequestDto.builder()
-                                .hostId(1L)
+                                .hostIds(List.of(1L))
                                 .password("1234")
                                 .startDate(startDate)
                                 .endDate(startDate.plusMonths(3))
@@ -295,7 +299,7 @@ public class VisitServiceTest {
             OnSiteVisitRequestDto dto =
                     OnSiteVisitRequestDto.builder()
                             .visitorName("현장방문객")
-                            .hostId(1L)
+                            .hostIds(List.of(1L))
                             .password("1234")
                             .signatureFile(
                                     new MockMultipartFile(
@@ -491,7 +495,7 @@ public class VisitServiceTest {
                 MyVisitUpdateRequestDto dto =
                         MyVisitUpdateRequestDto.builder()
                                 .password(PLAIN_PASSWORD)
-                                .hostId(newHostId)
+                                .hostIds(List.of(newHostId))
                                 .build();
 
                 Visit visit = createBaseVisit(VisitStatus.NOT_VISITED, VisitCategory.PRE_ONE_DAY);
@@ -505,8 +509,8 @@ public class VisitServiceTest {
                 visitService.updateMyVisit(VISIT_ID, dto);
 
                 // then
-                assertThat(visit.getUser()).isNotNull();
-                assertThat(visit.getUser().getId()).isEqualTo(newHostId);
+                assertThat(visit.getHosts()).hasSize(1);
+                assertThat(visit.getHosts().get(0).getUser().getId()).isEqualTo(newHostId);
             }
         }
 
@@ -644,10 +648,10 @@ public class VisitServiceTest {
                                 .visitCategory(VisitCategory.PRE_LONG_TERM)
                                 .startDate(LocalDate.now().minusDays(5))
                                 .endDate(LocalDate.now().plusDays(5))
-                                .user(createHost())
                                 .records(new ArrayList<>())
                                 .visited(false)
                                 .build();
+                visit.getHosts().add(VisitHost.builder().user(createHost()).build());
 
                 User admin =
                         User.builder()
@@ -1056,6 +1060,134 @@ public class VisitServiceTest {
     }
 
     @Nested
+    @DisplayName("VisitHost 엔티티는")
+    class Describe_VisitHost {
+
+        @Nested
+        @DisplayName("visit과 user를 인자로 생성하면")
+        class Context_with_visit_and_user {
+
+            @Test
+            @DisplayName("visit 필드와 user 필드가 올바르게 초기화된다.")
+            void visitHost_create_success() {
+                // given
+                // TODO: 구현 필요 — VisitHost 클래스가 아직 없으므로 컴파일 에러 발생
+                Visit visit = createBaseVisit(VisitStatus.PENDING, VisitCategory.PRE_LONG_TERM);
+                User user = createHost();
+
+                // when
+                VisitHost visitHost = VisitHost.builder()
+                        .visit(visit)
+                        .user(user)
+                        .build();
+
+                // then
+                assertThat(visitHost.getVisit()).isEqualTo(visit);
+                assertThat(visitHost.getUser()).isEqualTo(user);
+            }
+        }
+
+        @Nested
+        @DisplayName("visit 없이 생성하면")
+        class Context_without_visit {
+
+            @Test
+            @DisplayName("visit 필드가 null이다.")
+            void visitHost_visit_is_null_when_not_set() {
+                // given
+                // TODO: 구현 필요 — VisitHost 클래스가 아직 없으므로 컴파일 에러 발생
+                User user = createHost();
+
+                // when
+                VisitHost visitHost = VisitHost.builder()
+                        .user(user)
+                        .build();
+
+                // then
+                assertThat(visitHost.getVisit()).isNull();
+            }
+        }
+
+        @Nested
+        @DisplayName("user 없이 생성하면")
+        class Context_without_user {
+
+            @Test
+            @DisplayName("user 필드가 null이다.")
+            void visitHost_user_is_null_when_not_set() {
+                // given
+                // TODO: 구현 필요 — VisitHost 클래스가 아직 없으므로 컴파일 에러 발생
+                Visit visit = createBaseVisit(VisitStatus.PENDING, VisitCategory.PRE_LONG_TERM);
+
+                // when
+                VisitHost visitHost = VisitHost.builder()
+                        .visit(visit)
+                        .build();
+
+                // then
+                assertThat(visitHost.getUser()).isNull();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Visit 엔티티의 hosts 필드는")
+    class Describe_VisitHosts_Field {
+
+        @Nested
+        @DisplayName("빌더로 hosts 리스트를 포함하여 생성하면")
+        class Context_with_hosts {
+
+            @Test
+            @DisplayName("getHosts()가 해당 VisitHost 목록을 반환한다.")
+            void getHosts_returnsProvidedHosts() {
+                // given
+                Visit visit = createBaseVisit(VisitStatus.PENDING, VisitCategory.PRE_LONG_TERM);
+                User user = createHost();
+                VisitHost visitHost = VisitHost.builder().visit(visit).user(user).build();
+                List<VisitHost> hosts = List.of(visitHost);
+
+                // when
+                // TODO: 구현 필요 — Visit.hosts 필드가 없으므로 컴파일 에러 발생
+                Visit visitWithHosts =
+                        Visit.builder()
+                                .id(VISIT_ID)
+                                .password(ENCODED_PASSWORD)
+                                .status(VisitStatus.PENDING)
+                                .visitCategory(VisitCategory.PRE_LONG_TERM)
+                                .hosts(hosts)
+                                .build();
+
+                // then
+                assertThat(visitWithHosts.getHosts()).containsExactlyElementsOf(hosts);
+            }
+        }
+
+        @Nested
+        @DisplayName("기본 빌더로 생성하면")
+        class Context_with_default_builder {
+
+            @Test
+            @DisplayName("getHosts()가 빈 리스트를 반환한다.")
+            void getHosts_returnsEmptyListByDefault() {
+                // given & when
+                // TODO: 구현 필요 — Visit.hosts 필드가 없으므로 컴파일 에러 발생
+                Visit visit =
+                        Visit.builder()
+                                .id(VISIT_ID)
+                                .password(ENCODED_PASSWORD)
+                                .status(VisitStatus.PENDING)
+                                .visitCategory(VisitCategory.PRE_LONG_TERM)
+                                .build();
+
+                // then
+                assertThat(visit.getHosts()).isNotNull();
+                assertThat(visit.getHosts()).isEmpty();
+            }
+        }
+    }
+
+    @Nested
     @DisplayName("getVisitDetailForAdmin 메서드는")
     class Describe_getVisitDetailForAdmin {
 
@@ -1079,7 +1211,6 @@ public class VisitServiceTest {
                             .password(ENCODED_PASSWORD)
                             .status(VisitStatus.IN_PROGRESS)
                             .visitCategory(VisitCategory.PRE_ONE_DAY)
-                            .user(host)
                             .records(new ArrayList<>())
                             .build();
             given(visitRepository.findById(VISIT_ID)).willReturn(Optional.of(visit));
@@ -1092,6 +1223,377 @@ public class VisitServiceTest {
                     .isInstanceOf(
                             kr.co.awesomelead.groupware_backend.domain.visit.dto.response
                                     .MyVisitDetailResponseDto.class);
+        }
+    }
+
+    // =========================================================
+    // A. 다중 VisitHost 생성 테스트
+    // =========================================================
+
+    @Nested
+    @DisplayName("registerOneDayPreVisit - 다중 VisitHost 생성")
+    class Describe_registerOneDayPreVisit_multipleHosts {
+
+        @Nested
+        @DisplayName("hostIds에 2개의 ID를 전달하면")
+        class Context_with_two_host_ids {
+
+            @Test
+            @DisplayName("Visit에 VisitHost가 2개 생성되어 저장된다.")
+            void registerOneDayPreVisit_twoHostIdsCreatingTwoVisitHosts() {
+                // given
+                Long hostId1 = 1L;
+                Long hostId2 = 2L;
+
+                Department dept = createDepartment(10L);
+
+                User host1 =
+                        User.builder()
+                                .id(hostId1)
+                                .nameKor("담당자1")
+                                .workLocation(Company.AWESOME)
+                                .jobType(JobType.MANAGEMENT)
+                                .department(dept)
+                                .build();
+                host1.addAuthority(Authority.MANAGE_VISITOR);
+
+                User host2 =
+                        User.builder()
+                                .id(hostId2)
+                                .nameKor("담당자2")
+                                .workLocation(Company.AWESOME)
+                                .jobType(JobType.MANAGEMENT)
+                                .department(dept)
+                                .build();
+                host2.addAuthority(Authority.MANAGE_VISITOR);
+
+                OneDayVisitRequestDto dto =
+                        OneDayVisitRequestDto.builder()
+                                .visitorName("홍길동")
+                                .visitorPhoneNumber("01012345678")
+                                .visitorCompany("테스트컴퍼니")
+                                .purpose(VisitPurpose.MEETING)
+                                .permissionType(AdditionalPermissionType.NONE)
+                                .visitDate(LocalDate.now().plusDays(1))
+                                .plannedEntryTime(LocalTime.of(10, 0))
+                                .plannedExitTime(LocalTime.of(18, 0))
+                                .hostIds(List.of(hostId1, hostId2))
+                                .password("1234")
+                                .build();
+
+                given(userRepository.findById(hostId1)).willReturn(Optional.of(host1));
+                given(userRepository.findById(hostId2)).willReturn(Optional.of(host2));
+                given(passwordEncoder.encode(dto.getPassword())).willReturn(ENCODED_PASSWORD);
+
+                Visit savedVisit =
+                        Visit.builder()
+                                .id(VISIT_ID)
+                                .password(ENCODED_PASSWORD)
+                                .status(VisitStatus.NOT_VISITED)
+                                .visitCategory(VisitCategory.PRE_ONE_DAY)
+                                .records(new ArrayList<>())
+                                .build();
+                given(visitMapper.toOneDayVisit(any(), any(), any())).willReturn(savedVisit);
+                given(visitRepository.save(any(Visit.class))).willReturn(savedVisit);
+
+                // when
+                visitService.registerOneDayPreVisit(dto);
+
+                // then
+                verify(visitRepository).save(
+                        argThat(visit -> visit.getHosts().size() == 2));
+            }
+        }
+    }
+
+    // =========================================================
+    // B. 복수 담당자 부서에 알림 발송 테스트
+    // =========================================================
+
+    @Nested
+    @DisplayName("registerOneDayPreVisit - 복수 담당자 부서 알림 발송")
+    class Describe_registerOneDayPreVisit_departmentNotification {
+
+        @Nested
+        @DisplayName("두 담당자가 서로 다른 부서에 속할 때")
+        class Context_with_two_hosts_in_different_departments {
+
+            @Test
+            @DisplayName("sendVisitAlertToDepartment가 2번 호출된다.")
+            void registerOneDayPreVisit_differentDepartments_sendAlertTwice() {
+                // given
+                Long hostId1 = 1L;
+                Long hostId2 = 2L;
+
+                Department dept1 = createDepartment(10L);
+                Department dept2 = Department.builder().id(20L).name(DepartmentName.SALES_DEPT).build();
+
+                User host1 =
+                        User.builder()
+                                .id(hostId1)
+                                .nameKor("담당자1")
+                                .workLocation(Company.AWESOME)
+                                .jobType(JobType.MANAGEMENT)
+                                .department(dept1)
+                                .build();
+                host1.addAuthority(Authority.MANAGE_VISITOR);
+
+                User host2 =
+                        User.builder()
+                                .id(hostId2)
+                                .nameKor("담당자2")
+                                .workLocation(Company.AWESOME)
+                                .jobType(JobType.MANAGEMENT)
+                                .department(dept2)
+                                .build();
+                host2.addAuthority(Authority.MANAGE_VISITOR);
+
+                OneDayVisitRequestDto dto =
+                        OneDayVisitRequestDto.builder()
+                                .visitorName("홍길동")
+                                .visitorPhoneNumber("01012345678")
+                                .visitorCompany("테스트컴퍼니")
+                                .purpose(VisitPurpose.MEETING)
+                                .permissionType(AdditionalPermissionType.NONE)
+                                .visitDate(LocalDate.now().plusDays(1))
+                                .plannedEntryTime(LocalTime.of(10, 0))
+                                .plannedExitTime(LocalTime.of(18, 0))
+                                .hostIds(List.of(hostId1, hostId2))
+                                .password("1234")
+                                .build();
+
+                given(userRepository.findById(hostId1)).willReturn(Optional.of(host1));
+                given(userRepository.findById(hostId2)).willReturn(Optional.of(host2));
+                given(passwordEncoder.encode(any())).willReturn(ENCODED_PASSWORD);
+
+                Visit savedVisit =
+                        Visit.builder()
+                                .id(VISIT_ID)
+                                .password(ENCODED_PASSWORD)
+                                .status(VisitStatus.NOT_VISITED)
+                                .visitCategory(VisitCategory.PRE_ONE_DAY)
+                                .records(new ArrayList<>())
+                                .build();
+                given(visitMapper.toOneDayVisit(any(), any(), any())).willReturn(savedVisit);
+                given(visitRepository.save(any(Visit.class))).willReturn(savedVisit);
+
+                // when
+                visitService.registerOneDayPreVisit(dto);
+
+                // then: 서로 다른 부서 ID(10L, 20L)로 각각 1회씩 총 2회 호출
+                verify(notificationService, times(2))
+                        .sendVisitAlertToDepartment(
+                                any(), any(), any(), any(), any(), any(), any(), any());
+            }
+        }
+
+        @Nested
+        @DisplayName("두 담당자가 같은 부서에 속할 때")
+        class Context_with_two_hosts_in_same_department {
+
+            @Test
+            @DisplayName("sendVisitAlertToDepartment가 1번만 호출된다 (중복 제거).")
+            void registerOneDayPreVisit_sameDepartment_sendAlertOnce() {
+                // given
+                Long hostId1 = 1L;
+                Long hostId2 = 2L;
+
+                Department sharedDept = createDepartment(10L);
+
+                User host1 =
+                        User.builder()
+                                .id(hostId1)
+                                .nameKor("담당자1")
+                                .workLocation(Company.AWESOME)
+                                .jobType(JobType.MANAGEMENT)
+                                .department(sharedDept)
+                                .build();
+                host1.addAuthority(Authority.MANAGE_VISITOR);
+
+                User host2 =
+                        User.builder()
+                                .id(hostId2)
+                                .nameKor("담당자2")
+                                .workLocation(Company.AWESOME)
+                                .jobType(JobType.MANAGEMENT)
+                                .department(sharedDept)
+                                .build();
+                host2.addAuthority(Authority.MANAGE_VISITOR);
+
+                OneDayVisitRequestDto dto =
+                        OneDayVisitRequestDto.builder()
+                                .visitorName("홍길동")
+                                .visitorPhoneNumber("01012345678")
+                                .visitorCompany("테스트컴퍼니")
+                                .purpose(VisitPurpose.MEETING)
+                                .permissionType(AdditionalPermissionType.NONE)
+                                .visitDate(LocalDate.now().plusDays(1))
+                                .plannedEntryTime(LocalTime.of(10, 0))
+                                .plannedExitTime(LocalTime.of(18, 0))
+                                .hostIds(List.of(hostId1, hostId2))
+                                .password("1234")
+                                .build();
+
+                given(userRepository.findById(hostId1)).willReturn(Optional.of(host1));
+                given(userRepository.findById(hostId2)).willReturn(Optional.of(host2));
+                given(passwordEncoder.encode(any())).willReturn(ENCODED_PASSWORD);
+
+                Visit savedVisit =
+                        Visit.builder()
+                                .id(VISIT_ID)
+                                .password(ENCODED_PASSWORD)
+                                .status(VisitStatus.NOT_VISITED)
+                                .visitCategory(VisitCategory.PRE_ONE_DAY)
+                                .records(new ArrayList<>())
+                                .build();
+                given(visitMapper.toOneDayVisit(any(), any(), any())).willReturn(savedVisit);
+                given(visitRepository.save(any(Visit.class))).willReturn(savedVisit);
+
+                // when
+                visitService.registerOneDayPreVisit(dto);
+
+                // then: 같은 부서이므로 중복 제거 후 1회만 호출
+                verify(notificationService, times(1))
+                        .sendVisitAlertToDepartment(
+                                any(), any(), any(), any(), any(), any(), any(), any());
+            }
+        }
+    }
+
+    // =========================================================
+    // C. 환경안전부 조건부 알림 테스트
+    // =========================================================
+
+    @Nested
+    @DisplayName("registerOneDayPreVisit - 환경안전부 조건부 알림")
+    class Describe_registerOneDayPreVisit_environmentSafetyAlert {
+
+        @Nested
+        @DisplayName("방문 목적이 CUSTOMER_INSPECTION일 때")
+        class Context_with_customer_inspection_purpose {
+
+            @Test
+            @DisplayName("환경안전부가 존재하면 해당 부서 ID로 sendVisitAlertToDepartment가 추가 호출된다.")
+            void registerOneDayPreVisit_customerInspection_sendsEnvironmentSafetyAlert() {
+                // given
+                Long hostId = 1L;
+                Long envSafetyDeptId = 99L;
+
+                Department hostDept = createDepartment(10L);
+                Department envSafetyDept =
+                        Department.builder()
+                                .id(envSafetyDeptId)
+                                .name(DepartmentName.ENVIRONMENT_SAFETY)
+                                .build();
+
+                User host =
+                        User.builder()
+                                .id(hostId)
+                                .nameKor("담당자")
+                                .workLocation(Company.AWESOME)
+                                .jobType(JobType.MANAGEMENT)
+                                .department(hostDept)
+                                .build();
+                host.addAuthority(Authority.MANAGE_VISITOR);
+
+                OneDayVisitRequestDto dto =
+                        OneDayVisitRequestDto.builder()
+                                .visitorName("홍길동")
+                                .visitorPhoneNumber("01012345678")
+                                .visitorCompany("테스트컴퍼니")
+                                .purpose(VisitPurpose.CUSTOMER_INSPECTION)
+                                .permissionType(AdditionalPermissionType.NONE)
+                                .visitDate(LocalDate.now().plusDays(1))
+                                .plannedEntryTime(LocalTime.of(10, 0))
+                                .plannedExitTime(LocalTime.of(18, 0))
+                                .hostIds(List.of(hostId))
+                                .password("1234")
+                                .build();
+
+                given(userRepository.findById(hostId)).willReturn(Optional.of(host));
+                given(passwordEncoder.encode(any())).willReturn(ENCODED_PASSWORD);
+                given(departmentRepository.findByName(DepartmentName.ENVIRONMENT_SAFETY))
+                        .willReturn(Optional.of(envSafetyDept));
+
+                Visit savedVisit =
+                        Visit.builder()
+                                .id(VISIT_ID)
+                                .password(ENCODED_PASSWORD)
+                                .status(VisitStatus.NOT_VISITED)
+                                .visitCategory(VisitCategory.PRE_ONE_DAY)
+                                .records(new ArrayList<>())
+                                .build();
+                given(visitMapper.toOneDayVisit(any(), any(), any())).willReturn(savedVisit);
+                given(visitRepository.save(any(Visit.class))).willReturn(savedVisit);
+
+                // when
+                visitService.registerOneDayPreVisit(dto);
+
+                // then
+                // 담당부서(10L) 1회 + 환경안전부(99L) 1회 = 총 2회
+                verify(departmentRepository).findByName(DepartmentName.ENVIRONMENT_SAFETY);
+                verify(notificationService, times(2))
+                        .sendVisitAlertToDepartment(
+                                any(), any(), any(), any(), any(), any(), any(), any());
+            }
+        }
+
+        @Nested
+        @DisplayName("방문 목적이 MEETING(환경안전 미해당)일 때")
+        class Context_with_meeting_purpose {
+
+            @Test
+            @DisplayName("departmentRepository.findByName이 호출되지 않는다.")
+            void registerOneDayPreVisit_meeting_doesNotQueryEnvironmentSafetyDept() {
+                // given
+                Long hostId = 1L;
+                Department hostDept = createDepartment(10L);
+
+                User host =
+                        User.builder()
+                                .id(hostId)
+                                .nameKor("담당자")
+                                .workLocation(Company.AWESOME)
+                                .jobType(JobType.MANAGEMENT)
+                                .department(hostDept)
+                                .build();
+                host.addAuthority(Authority.MANAGE_VISITOR);
+
+                OneDayVisitRequestDto dto =
+                        OneDayVisitRequestDto.builder()
+                                .visitorName("홍길동")
+                                .visitorPhoneNumber("01012345678")
+                                .visitorCompany("테스트컴퍼니")
+                                .purpose(VisitPurpose.MEETING)
+                                .permissionType(AdditionalPermissionType.NONE)
+                                .visitDate(LocalDate.now().plusDays(1))
+                                .plannedEntryTime(LocalTime.of(10, 0))
+                                .plannedExitTime(LocalTime.of(18, 0))
+                                .hostIds(List.of(hostId))
+                                .password("1234")
+                                .build();
+
+                given(userRepository.findById(hostId)).willReturn(Optional.of(host));
+                given(passwordEncoder.encode(any())).willReturn(ENCODED_PASSWORD);
+
+                Visit savedVisit =
+                        Visit.builder()
+                                .id(VISIT_ID)
+                                .password(ENCODED_PASSWORD)
+                                .status(VisitStatus.NOT_VISITED)
+                                .visitCategory(VisitCategory.PRE_ONE_DAY)
+                                .records(new ArrayList<>())
+                                .build();
+                given(visitMapper.toOneDayVisit(any(), any(), any())).willReturn(savedVisit);
+                given(visitRepository.save(any(Visit.class))).willReturn(savedVisit);
+
+                // when
+                visitService.registerOneDayPreVisit(dto);
+
+                // then
+                verify(departmentRepository, times(0))
+                        .findByName(DepartmentName.ENVIRONMENT_SAFETY);
+            }
         }
     }
 }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
@@ -3,7 +3,6 @@ package kr.co.awesomelead.groupware_backend.domain.visit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
@@ -1076,10 +1075,7 @@ public class VisitServiceTest {
                 User user = createHost();
 
                 // when
-                VisitHost visitHost = VisitHost.builder()
-                        .visit(visit)
-                        .user(user)
-                        .build();
+                VisitHost visitHost = VisitHost.builder().visit(visit).user(user).build();
 
                 // then
                 assertThat(visitHost.getVisit()).isEqualTo(visit);
@@ -1099,9 +1095,7 @@ public class VisitServiceTest {
                 User user = createHost();
 
                 // when
-                VisitHost visitHost = VisitHost.builder()
-                        .user(user)
-                        .build();
+                VisitHost visitHost = VisitHost.builder().user(user).build();
 
                 // then
                 assertThat(visitHost.getVisit()).isNull();
@@ -1120,9 +1114,7 @@ public class VisitServiceTest {
                 Visit visit = createBaseVisit(VisitStatus.PENDING, VisitCategory.PRE_LONG_TERM);
 
                 // when
-                VisitHost visitHost = VisitHost.builder()
-                        .visit(visit)
-                        .build();
+                VisitHost visitHost = VisitHost.builder().visit(visit).build();
 
                 // then
                 assertThat(visitHost.getUser()).isNull();
@@ -1300,8 +1292,7 @@ public class VisitServiceTest {
                 visitService.registerOneDayPreVisit(dto);
 
                 // then
-                verify(visitRepository).save(
-                        argThat(visit -> visit.getHosts().size() == 2));
+                verify(visitRepository).save(argThat(visit -> visit.getHosts().size() == 2));
             }
         }
     }
@@ -1326,7 +1317,8 @@ public class VisitServiceTest {
                 Long hostId2 = 2L;
 
                 Department dept1 = createDepartment(10L);
-                Department dept2 = Department.builder().id(20L).name(DepartmentName.SALES_DEPT).build();
+                Department dept2 =
+                        Department.builder().id(20L).name(DepartmentName.SALES_DEPT).build();
 
                 User host1 =
                         User.builder()


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #379

## 📝작업 내용

- `VisitHost` 중간 엔티티 추가 — Visit과 User를 연결하는 M:N 중간 테이블 구조로 설계
- `Visit.user` (단일 담당자) → `List<VisitHost> hosts` (복수 담당자) 전환
  - cascade ALL, orphanRemoval 적용
  - `User.visits` (mappedBy="user") 잔존 필드 제거
- Request DTO 4종 (`OneDayVisit`, `LongTermVisit`, `OnSiteVisit`, `MyVisitUpdate`): `hostId` → `List<Long> hostIds` (@NotEmpty)
- Response DTO 4종 + `VisitHostResponseDto` 신규: 단일 host 필드 → `List<VisitHostResponseDto> hosts` (userId, name, position, departmentName)
- 방문 신청/수정 시 복수 담당자 VisitHost 생성 및 교체 로직 구현 (`hosts.clear()` + 재추가)
- 방문 알림 발송: 복수 호스트의 유니크 부서별로 각 1회 발송 (중복 부서 제거)
- 환경안전부 조건부 FCM 알림 추가: `CUSTOMER_INSPECTION`, `HAZARDOUS_SUBSTANCE`, `FACILITY_CONSTRUCTION` 목적 시 환경안전부 사용자에게 추가 발송
- 직원용 방문 목록 조회 QueryRepository: OneToMany fetchJoin + LIMIT에 의한 in-memory pagination 방지를 위한 two-pass 쿼리 적용
- 내방객용 방문 목록 조회 N+1 해결: `@EntityGraph(attributePaths = {"hosts", "hosts.user", "hosts.user.department"})` 적용

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)

- X