### PR TITLE
fix(382): Visit 알림 발송 대상 부서 중복 제거

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
@@ -91,20 +91,11 @@ public class VisitService {
 
         Long visitId = visitRepository.save(visit).getId();
 
-        sendVisitAlertToHostDepartments(
-                NotificationMessage.VISIT_ONE_DAY_PRE,
-                visitId,
-                hosts,
-                Map.of("isApprovalTarget", false, "status", VisitStatus.PENDING.name()),
-                visit.getVisitorName(),
-                visit.getStartDate(),
-                dto.getPlannedEntryTime(),
-                hosts.get(0).getDisplayName());
-
-        sendEnvironmentSafetyAlertIfRequired(
+        sendVisitAlerts(
                 visit.getPurpose(),
                 NotificationMessage.VISIT_ONE_DAY_PRE,
                 visitId,
+                hosts,
                 Map.of("isApprovalTarget", false, "status", VisitStatus.PENDING.name()),
                 visit.getVisitorName(),
                 visit.getStartDate(),
@@ -128,19 +119,11 @@ public class VisitService {
 
         Long visitId = visitRepository.save(visit).getId();
 
-        sendVisitAlertToHostDepartments(
-                NotificationMessage.VISIT_LONG_TERM_PRE,
-                visitId,
-                hosts,
-                Map.of("status", VisitStatus.PENDING.name(), "isApprovalTarget", true),
-                visit.getVisitorName(),
-                dto.getStartDate(),
-                dto.getEndDate());
-
-        sendEnvironmentSafetyAlertIfRequired(
+        sendVisitAlerts(
                 visit.getPurpose(),
                 NotificationMessage.VISIT_LONG_TERM_PRE,
                 visitId,
+                hosts,
                 Map.of("status", VisitStatus.PENDING.name(), "isApprovalTarget", true),
                 visit.getVisitorName(),
                 dto.getStartDate(),
@@ -173,18 +156,11 @@ public class VisitService {
 
         Long visitId = visitRepository.save(visit).getId();
 
-        sendVisitAlertToHostDepartments(
-                NotificationMessage.VISIT_CHECK_IN,
-                visitId,
-                hosts,
-                Map.of("isApprovalTarget", false, "status", VisitStatus.IN_PROGRESS.name()),
-                visit.getVisitorName(),
-                formatNotificationTime(record.getEntryTime().toLocalTime()));
-
-        sendEnvironmentSafetyAlertIfRequired(
+        sendVisitAlerts(
                 visit.getPurpose(),
                 NotificationMessage.VISIT_CHECK_IN,
                 visitId,
+                hosts,
                 Map.of("isApprovalTarget", false, "status", VisitStatus.IN_PROGRESS.name()),
                 visit.getVisitorName(),
                 formatNotificationTime(record.getEntryTime().toLocalTime()));
@@ -258,18 +234,11 @@ public class VisitService {
         visit.setVisited(true);
 
         List<User> hosts = visit.getHosts().stream().map(VisitHost::getUser).toList();
-        sendVisitAlertToHostDepartments(
-                NotificationMessage.VISIT_CHECK_IN,
-                visit.getId(),
-                hosts,
-                Map.of("isApprovalTarget", false, "status", VisitStatus.IN_PROGRESS.name()),
-                visit.getVisitorName(),
-                formatNotificationTime(record.getEntryTime().toLocalTime()));
-
-        sendEnvironmentSafetyAlertIfRequired(
+        sendVisitAlerts(
                 visit.getPurpose(),
                 NotificationMessage.VISIT_CHECK_IN,
                 visit.getId(),
+                hosts,
                 Map.of("isApprovalTarget", false, "status", VisitStatus.IN_PROGRESS.name()),
                 visit.getVisitorName(),
                 formatNotificationTime(record.getEntryTime().toLocalTime()));
@@ -545,36 +514,28 @@ public class VisitService {
                 user -> visit.getHosts().add(VisitHost.builder().visit(visit).user(user).build()));
     }
 
-    private void sendVisitAlertToHostDepartments(
+    private void sendVisitAlerts(
+            VisitPurpose purpose,
             NotificationMessage template,
             Long visitId,
             List<User> hosts,
             Map<String, Object> metadata,
             Object... contentArgs) {
-        hosts.stream()
-                .filter(h -> h.getDepartment() != null)
-                .map(h -> h.getDepartment().getId())
-                .collect(Collectors.toSet())
-                .forEach(
-                        deptId ->
-                                notificationService.sendVisitAlertToDepartment(
-                                        template, visitId, deptId, metadata, contentArgs));
-    }
+        Set<Long> targetDeptIds =
+                hosts.stream()
+                        .filter(h -> h.getDepartment() != null)
+                        .map(h -> h.getDepartment().getId())
+                        .collect(Collectors.toCollection(java.util.HashSet::new));
 
-    private void sendEnvironmentSafetyAlertIfRequired(
-            VisitPurpose purpose,
-            NotificationMessage template,
-            Long visitId,
-            Map<String, Object> metadata,
-            Object... contentArgs) {
-        if (!ENVIRONMENT_SAFETY_REQUIRED_PURPOSES.contains(purpose)) {
-            return;
+        if (ENVIRONMENT_SAFETY_REQUIRED_PURPOSES.contains(purpose)) {
+            departmentRepository
+                    .findByName(DepartmentName.ENVIRONMENT_SAFETY)
+                    .ifPresent(dept -> targetDeptIds.add(dept.getId()));
         }
-        departmentRepository
-                .findByName(DepartmentName.ENVIRONMENT_SAFETY)
-                .ifPresent(
-                        dept ->
-                                notificationService.sendVisitAlertToDepartment(
-                                        template, visitId, dept.getId(), metadata, contentArgs));
+
+        targetDeptIds.forEach(
+                deptId ->
+                        notificationService.sendVisitAlertToDepartment(
+                                template, visitId, deptId, metadata, contentArgs));
     }
 }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
@@ -1597,7 +1597,14 @@ public class VisitServiceTest {
                 //       중복 제거 후 99L로 정확히 1회만 호출되어야 한다.
                 verify(notificationService, times(1))
                         .sendVisitAlertToDepartment(
-                                any(), any(), eq(envSafetyDeptId), any(), any(), any(), any(), any());
+                                any(),
+                                any(),
+                                eq(envSafetyDeptId),
+                                any(),
+                                any(),
+                                any(),
+                                any(),
+                                any());
             }
         }
     }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -1455,6 +1456,151 @@ public class VisitServiceTest {
     // =========================================================
     // C. 환경안전부 조건부 알림 테스트
     // =========================================================
+
+    // =========================================================
+    // D. 알림 발송 중복 제거 테스트
+    // =========================================================
+
+    @Nested
+    @DisplayName("registerOneDayPreVisit - 알림 발송 중복 제거")
+    class Describe_registerOneDayPreVisit_deduplicateAlerts {
+
+        @Nested
+        @DisplayName("같은 부서(dept ID=1L) 소속 담당자가 2명일 때")
+        class Context_with_two_hosts_in_same_dept {
+
+            @Test
+            @DisplayName("sendVisitAlertToDepartment가 해당 부서로 정확히 1회만 호출된다.")
+            void registerOneDayPreVisit_sameDept_sendAlertOnce() {
+                // given
+                Long deptId = 1L;
+                Department sharedDept = createDepartment(deptId);
+
+                User host1 =
+                        User.builder()
+                                .id(10L)
+                                .nameKor("담당자1")
+                                .workLocation(Company.AWESOME)
+                                .jobType(JobType.MANAGEMENT)
+                                .department(sharedDept)
+                                .build();
+                host1.addAuthority(Authority.MANAGE_VISITOR);
+
+                User host2 =
+                        User.builder()
+                                .id(11L)
+                                .nameKor("담당자2")
+                                .workLocation(Company.AWESOME)
+                                .jobType(JobType.MANAGEMENT)
+                                .department(sharedDept)
+                                .build();
+                host2.addAuthority(Authority.MANAGE_VISITOR);
+
+                OneDayVisitRequestDto dto =
+                        OneDayVisitRequestDto.builder()
+                                .visitorName("홍길동")
+                                .visitorPhoneNumber("01012345678")
+                                .visitorCompany("테스트컴퍼니")
+                                .purpose(VisitPurpose.MEETING)
+                                .permissionType(AdditionalPermissionType.NONE)
+                                .visitDate(LocalDate.now().plusDays(1))
+                                .plannedEntryTime(LocalTime.of(10, 0))
+                                .plannedExitTime(LocalTime.of(18, 0))
+                                .hostIds(List.of(10L, 11L))
+                                .password("1234")
+                                .build();
+
+                given(userRepository.findById(10L)).willReturn(Optional.of(host1));
+                given(userRepository.findById(11L)).willReturn(Optional.of(host2));
+                given(passwordEncoder.encode(any())).willReturn(ENCODED_PASSWORD);
+
+                Visit savedVisit =
+                        Visit.builder()
+                                .id(VISIT_ID)
+                                .password(ENCODED_PASSWORD)
+                                .status(VisitStatus.NOT_VISITED)
+                                .visitCategory(VisitCategory.PRE_ONE_DAY)
+                                .records(new ArrayList<>())
+                                .build();
+                given(visitMapper.toOneDayVisit(any(), any(), any())).willReturn(savedVisit);
+                given(visitRepository.save(any(Visit.class))).willReturn(savedVisit);
+
+                // when
+                visitService.registerOneDayPreVisit(dto);
+
+                // then: 같은 부서이므로 중복 제거 후 deptId=1L로 정확히 1회만 호출
+                verify(notificationService, times(1))
+                        .sendVisitAlertToDepartment(
+                                any(), any(), eq(deptId), any(), any(), any(), any(), any());
+            }
+        }
+
+        @Nested
+        @DisplayName("담당자가 환경안전부(dept ID=99L) 소속이고 방문 목적이 FACILITY_CONSTRUCTION일 때")
+        class Context_with_env_safety_host_and_facility_construction_purpose {
+
+            @Test
+            @DisplayName("sendVisitAlertToDepartment가 환경안전부(99L)로 정확히 1회만 호출된다.")
+            void registerOneDayPreVisit_envSafetyHostWithFacilityConstruction_sendAlertOnce() {
+                // given
+                Long envSafetyDeptId = 99L;
+                Department envSafetyDept =
+                        Department.builder()
+                                .id(envSafetyDeptId)
+                                .name(DepartmentName.ENVIRONMENT_SAFETY)
+                                .build();
+
+                User host =
+                        User.builder()
+                                .id(20L)
+                                .nameKor("환경안전담당자")
+                                .workLocation(Company.AWESOME)
+                                .jobType(JobType.MANAGEMENT)
+                                .department(envSafetyDept)
+                                .build();
+                host.addAuthority(Authority.MANAGE_VISITOR);
+
+                OneDayVisitRequestDto dto =
+                        OneDayVisitRequestDto.builder()
+                                .visitorName("홍길동")
+                                .visitorPhoneNumber("01012345678")
+                                .visitorCompany("테스트컴퍼니")
+                                .purpose(VisitPurpose.FACILITY_CONSTRUCTION)
+                                .permissionType(AdditionalPermissionType.CONFINED_SPACE_ENTRY)
+                                .visitDate(LocalDate.now().plusDays(1))
+                                .plannedEntryTime(LocalTime.of(10, 0))
+                                .plannedExitTime(LocalTime.of(18, 0))
+                                .hostIds(List.of(20L))
+                                .password("1234")
+                                .build();
+
+                given(userRepository.findById(20L)).willReturn(Optional.of(host));
+                given(passwordEncoder.encode(any())).willReturn(ENCODED_PASSWORD);
+                given(departmentRepository.findByName(DepartmentName.ENVIRONMENT_SAFETY))
+                        .willReturn(Optional.of(envSafetyDept));
+
+                Visit savedVisit =
+                        Visit.builder()
+                                .id(VISIT_ID)
+                                .password(ENCODED_PASSWORD)
+                                .status(VisitStatus.NOT_VISITED)
+                                .visitCategory(VisitCategory.PRE_ONE_DAY)
+                                .records(new ArrayList<>())
+                                .build();
+                given(visitMapper.toOneDayVisit(any(), any(), any())).willReturn(savedVisit);
+                given(visitRepository.save(any(Visit.class))).willReturn(savedVisit);
+
+                // when
+                visitService.registerOneDayPreVisit(dto);
+
+                // then: 호스트 부서=환경안전부(99L), 조건부 환경안전부(99L) 모두 동일 부서이므로
+                //       중복 제거 후 99L로 정확히 1회만 호출되어야 한다.
+                verify(notificationService, times(1))
+                        .sendVisitAlertToDepartment(
+                                any(), any(), eq(envSafetyDeptId), any(), any(), any(), any(), any());
+            }
+        }
+    }
 
     @Nested
     @DisplayName("registerOneDayPreVisit - 환경안전부 조건부 알림")


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #382

## 📝작업 내용

- 환경안전부 소속 담당자가 CUSTOMER_INSPECTION / HAZARDOUS_SUBSTANCE / FACILITY_CONSTRUCTION
  목적으로 방문 등록 시 해당 부서에 알림이 2회 발송되던 버그 수정
    - 기존: sendVisitAlertToHostDepartments(hosts 부서 대상) +
            sendEnvironmentSafetyAlertIfRequired(환경안전부 대상) 독립 호출로 인해 중복 발생
    - 변경: 두 메서드를 sendVisitAlerts로 통합하여 hosts 부서 Set에 환경안전부 ID를 병합 후
            부서당 1회만 발송

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)

- hosts 간 동일 부서 중복은 기존부터 Set으로 처리되고 있었으며,
  이번 수정은 환경안전부 조건부 알림과의 중복 케이스만 해당