### PR TITLE
feat(385): 관리자 직원 목록 퇴사자 필터 및 상세 조회 퇴사일 반환 추가

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
@@ -133,6 +133,9 @@ public class AdminController {
             @Parameter(description = "역할 필터", required = false, example = "일반 사용자")
                     @RequestParam(required = false)
                     Role role,
+            @Parameter(description = "퇴사자(SUSPENDED) 제외 여부", required = false, example = "false")
+                    @RequestParam(required = false, defaultValue = "false")
+                    Boolean excludeSuspended,
             @ParameterObject @PageableDefault(page = 0, size = 20) Pageable pageable) {
 
         Page<AdminUserSummaryResponseDto> result =
@@ -143,6 +146,7 @@ public class AdminController {
                         departmentId,
                         jobType,
                         role,
+                        excludeSuspended,
                         pageable);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(result));

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
@@ -181,6 +181,7 @@ public class AdminService {
             Long departmentId,
             JobType jobType,
             Role role,
+            Boolean excludeSuspended,
             Pageable pageable) {
         User admin =
                 userRepository
@@ -195,10 +196,17 @@ public class AdminService {
                         .collect(Collectors.toSet());
 
         String normalizedKeyword = hasText(keyword) ? keyword.trim() : null;
+        boolean effectiveExcludeSuspended = excludeSuspended != null && excludeSuspended;
 
         return userRepository
                 .findAllWithDepartmentAndKeyword(
-                        normalizedKeyword, position, departmentId, jobType, role, pageable)
+                        normalizedKeyword,
+                        position,
+                        departmentId,
+                        jobType,
+                        role,
+                        effectiveExcludeSuspended,
+                        pageable)
                 .map(
                         u ->
                                 AdminUserSummaryResponseDto.from(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/dto/response/UserDetailResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/dto/response/UserDetailResponseDto.java
@@ -35,6 +35,9 @@ public class UserDetailResponseDto {
     @Schema(description = "입사일", example = "2024-03-01")
     private LocalDate hireDate;
 
+    @Schema(description = "퇴사일", example = "2026-03-31")
+    private LocalDate resignationDate;
+
     public static UserDetailResponseDto from(User user) {
         return UserDetailResponseDto.builder()
                 .name(user.getDisplayName())
@@ -44,6 +47,7 @@ public class UserDetailResponseDto {
                 .jobType(user.getJobType())
                 .position(user.getPosition())
                 .hireDate(user.getHireDate())
+                .resignationDate(user.getResignationDate())
                 .build();
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/UserRepository.java
@@ -100,6 +100,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
                             + "AND (:departmentId IS NULL OR u.department.id = :departmentId) "
                             + "AND (:jobType IS NULL OR u.jobType = :jobType) "
                             + "AND (:role IS NULL OR u.role = :role) "
+                            + "AND (:excludeSuspended = false OR u.status <> 'SUSPENDED') "
                             + "ORDER BY u.id DESC",
             countQuery =
                     "SELECT count(u) FROM User u "
@@ -110,12 +111,14 @@ public interface UserRepository extends JpaRepository<User, Long> {
                             + "AND (:position IS NULL OR u.position = :position) "
                             + "AND (:departmentId IS NULL OR u.department.id = :departmentId) "
                             + "AND (:jobType IS NULL OR u.jobType = :jobType) "
-                            + "AND (:role IS NULL OR u.role = :role)")
+                            + "AND (:role IS NULL OR u.role = :role) "
+                            + "AND (:excludeSuspended = false OR u.status <> 'SUSPENDED')")
     Page<User> findAllWithDepartmentAndKeyword(
             @Param("keyword") String keyword,
             @Param("position") Position position,
             @Param("departmentId") Long departmentId,
             @Param("jobType") JobType jobType,
             @Param("role") Role role,
+            @Param("excludeSuspended") Boolean excludeSuspended,
             Pageable pageable);
 }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
@@ -282,7 +282,13 @@ class AdminServiceTest {
             Pageable pageable = PageRequest.of(0, 20);
             Page<User> userPage = new PageImpl<>(List.of(user), pageable, 1);
             when(userRepository.findAllWithDepartmentAndKeyword(
-                            "홍길동", Position.STAFF, 11L, JobType.MANAGEMENT, Role.USER, pageable))
+                            "홍길동",
+                            Position.STAFF,
+                            11L,
+                            JobType.MANAGEMENT,
+                            Role.USER,
+                            false,
+                            pageable))
                     .thenReturn(userPage);
             when(myInfoUpdateRequestRepository.findDistinctUserIdsByStatus(
                             MyInfoUpdateRequestStatus.PENDING))
@@ -297,6 +303,7 @@ class AdminServiceTest {
                             11L,
                             JobType.MANAGEMENT,
                             Role.USER,
+                            false,
                             pageable);
 
             // then
@@ -328,10 +335,49 @@ class AdminServiceTest {
                                             null,
                                             null,
                                             null,
+                                            false,
                                             PageRequest.of(0, 20)))
                     .isInstanceOf(CustomException.class)
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.NO_AUTHORITY_FOR_REGISTRATION);
+        }
+
+        @Test
+        @DisplayName("excludeSuspended가 false이면 false로 repository를 호출한다")
+        void getUsers_excludeSuspended가_false이면_excludeSuspended_false로_repository_호출() {
+            // given
+            Pageable pageable = PageRequest.of(0, 20);
+            when(myInfoUpdateRequestRepository.findDistinctUserIdsByStatus(any()))
+                    .thenReturn(List.of());
+            when(userRepository.findAllWithDepartmentAndKeyword(
+                            null, null, null, null, null, false, pageable))
+                    .thenReturn(Page.empty());
+
+            // when
+            adminService.getUsers(adminId, null, null, null, null, null, false, pageable);
+
+            // then
+            verify(userRepository)
+                    .findAllWithDepartmentAndKeyword(null, null, null, null, null, false, pageable);
+        }
+
+        @Test
+        @DisplayName("excludeSuspended가 true이면 true로 repository를 호출한다")
+        void getUsers_excludeSuspended가_true이면_excludeSuspended_true로_repository_호출() {
+            // given
+            Pageable pageable = PageRequest.of(0, 20);
+            when(myInfoUpdateRequestRepository.findDistinctUserIdsByStatus(any()))
+                    .thenReturn(List.of());
+            when(userRepository.findAllWithDepartmentAndKeyword(
+                            null, null, null, null, null, true, pageable))
+                    .thenReturn(Page.empty());
+
+            // when
+            adminService.getUsers(adminId, null, null, null, null, null, true, pageable);
+
+            // then
+            verify(userRepository)
+                    .findAllWithDepartmentAndKeyword(null, null, null, null, null, true, pageable);
         }
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #385

## 📝작업 내용

- `GET /api/admin/users` — `excludeSuspended` 쿼리 파라미터 추가 (기본값 `false`)
    - `UserRepository.findAllWithDepartmentAndKeyword` value/countQuery 양쪽에 `AND (:excludeSuspended = false OR u.status <> 'SUSPENDED')` 조건 추가
    - `AdminService.getUsers`, `AdminController.getUsers` 파라미터 전달 체인 추가
    - Swagger `@Parameter(description = "퇴사자(SUSPENDED) 제외 여부")` 명시
- `GET /api/users/{userId}` — 응답 DTO에 `resignationDate` 필드 추가
    - `UserDetailResponseDto`에 `LocalDate resignationDate` 필드 추가 및 `from()` 매핑

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함