### PR TITLE
refactor(388): 관리자 직원 목록 조회 QueryDSL 전환

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
@@ -25,6 +25,7 @@ import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.MyInfoUpdateRequestRepository;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
+import kr.co.awesomelead.groupware_backend.domain.user.repository.querydsl.UserQueryRepository;
 import kr.co.awesomelead.groupware_backend.global.error.CustomException;
 import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
 
@@ -45,6 +46,7 @@ import java.util.stream.Collectors;
 public class AdminService {
 
     private final UserRepository userRepository;
+    private final UserQueryRepository userQueryRepository;
     private final DepartmentRepository departmentRepository;
     private final MyInfoUpdateRequestRepository myInfoUpdateRequestRepository;
     private final PhoneAuthService phoneAuthService;
@@ -196,16 +198,15 @@ public class AdminService {
                         .collect(Collectors.toSet());
 
         String normalizedKeyword = hasText(keyword) ? keyword.trim() : null;
-        boolean effectiveExcludeSuspended = excludeSuspended != null && excludeSuspended;
 
-        return userRepository
-                .findAllWithDepartmentAndKeyword(
+        return userQueryRepository
+                .findAllForAdminWithFilters(
                         normalizedKeyword,
                         position,
                         departmentId,
                         jobType,
                         role,
-                        effectiveExcludeSuspended,
+                        excludeSuspended,
                         pageable)
                 .map(
                         u ->

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/UserRepository.java
@@ -87,5 +87,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
                             + "AND MATCH(u.name_kor) AGAINST(:keyword IN BOOLEAN MODE)",
             nativeQuery = true)
     Page<User> searchByNameKorFullText(@Param("keyword") String keyword, Pageable pageable);
-
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/UserRepository.java
@@ -3,7 +3,6 @@ package kr.co.awesomelead.groupware_backend.domain.user.repository;
 import kr.co.awesomelead.groupware_backend.domain.department.entity.Department;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
-import kr.co.awesomelead.groupware_backend.domain.user.enums.JobType;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
@@ -89,36 +88,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
             nativeQuery = true)
     Page<User> searchByNameKorFullText(@Param("keyword") String keyword, Pageable pageable);
 
-    @Query(
-            value =
-                    "SELECT u FROM User u LEFT JOIN FETCH u.department d "
-                            + "WHERE (:keyword IS NULL OR :keyword = '' "
-                            + "OR lower(u.nameKor) LIKE lower(concat('%', :keyword, '%')) "
-                            + "OR lower(u.nameEng) LIKE lower(concat('%', :keyword, '%')) "
-                            + "OR lower(u.email) LIKE lower(concat('%', :keyword, '%'))) "
-                            + "AND (:position IS NULL OR u.position = :position) "
-                            + "AND (:departmentId IS NULL OR u.department.id = :departmentId) "
-                            + "AND (:jobType IS NULL OR u.jobType = :jobType) "
-                            + "AND (:role IS NULL OR u.role = :role) "
-                            + "AND (:excludeSuspended = false OR u.status <> 'SUSPENDED') "
-                            + "ORDER BY u.id DESC",
-            countQuery =
-                    "SELECT count(u) FROM User u "
-                            + "WHERE (:keyword IS NULL OR :keyword = '' "
-                            + "OR lower(u.nameKor) LIKE lower(concat('%', :keyword, '%')) "
-                            + "OR lower(u.nameEng) LIKE lower(concat('%', :keyword, '%')) "
-                            + "OR lower(u.email) LIKE lower(concat('%', :keyword, '%'))) "
-                            + "AND (:position IS NULL OR u.position = :position) "
-                            + "AND (:departmentId IS NULL OR u.department.id = :departmentId) "
-                            + "AND (:jobType IS NULL OR u.jobType = :jobType) "
-                            + "AND (:role IS NULL OR u.role = :role) "
-                            + "AND (:excludeSuspended = false OR u.status <> 'SUSPENDED')")
-    Page<User> findAllWithDepartmentAndKeyword(
-            @Param("keyword") String keyword,
-            @Param("position") Position position,
-            @Param("departmentId") Long departmentId,
-            @Param("jobType") JobType jobType,
-            @Param("role") Role role,
-            @Param("excludeSuspended") Boolean excludeSuspended,
-            Pageable pageable);
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/querydsl/UserQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/querydsl/UserQueryRepository.java
@@ -70,6 +70,52 @@ public class UserQueryRepository {
                                 .fetchOne());
     }
 
+    public Page<User> findAllForAdminWithFilters(
+            String keyword,
+            Position position,
+            Long departmentId,
+            JobType jobType,
+            Role role,
+            Boolean excludeSuspended,
+            Pageable pageable) {
+        List<User> content =
+                queryFactory
+                        .selectFrom(user)
+                        .leftJoin(user.department, QDepartment.department)
+                        .fetchJoin()
+                        .where(
+                                keywordFilter(keyword),
+                                positionFilter(position),
+                                departmentFilter(departmentId),
+                                jobTypeFilter(jobType),
+                                roleFilter(role),
+                                excludeSuspendedFilter(excludeSuspended))
+                        .orderBy(user.id.desc())
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize())
+                        .fetch();
+
+        return PageableExecutionUtils.getPage(
+                content,
+                pageable,
+                () ->
+                        queryFactory
+                                .select(user.count())
+                                .from(user)
+                                .where(
+                                        keywordFilter(keyword),
+                                        positionFilter(position),
+                                        departmentFilter(departmentId),
+                                        jobTypeFilter(jobType),
+                                        roleFilter(role),
+                                        excludeSuspendedFilter(excludeSuspended))
+                                .fetchOne());
+    }
+
+    private BooleanExpression excludeSuspendedFilter(Boolean excludeSuspended) {
+        return Boolean.TRUE.equals(excludeSuspended) ? user.status.ne(Status.SUSPENDED) : null;
+    }
+
     private BooleanExpression keywordFilter(String keyword) {
         if (!StringUtils.hasText(keyword)) {
             return null;

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
@@ -32,6 +32,7 @@ import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.MyInfoUpdateRequestRepository;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
+import kr.co.awesomelead.groupware_backend.domain.user.repository.querydsl.UserQueryRepository;
 import kr.co.awesomelead.groupware_backend.global.error.CustomException;
 import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
 
@@ -59,6 +60,7 @@ import java.util.Optional;
 class AdminServiceTest {
 
     @Mock private UserRepository userRepository;
+    @Mock private UserQueryRepository userQueryRepository;
     @Mock private DepartmentRepository departmentRepository;
     @Mock private MyInfoUpdateRequestRepository myInfoUpdateRequestRepository;
     @Mock private PhoneAuthService phoneAuthService;
@@ -281,7 +283,7 @@ class AdminServiceTest {
 
             Pageable pageable = PageRequest.of(0, 20);
             Page<User> userPage = new PageImpl<>(List.of(user), pageable, 1);
-            when(userRepository.findAllWithDepartmentAndKeyword(
+            when(userQueryRepository.findAllForAdminWithFilters(
                             "홍길동",
                             Position.STAFF,
                             11L,
@@ -349,7 +351,7 @@ class AdminServiceTest {
             Pageable pageable = PageRequest.of(0, 20);
             when(myInfoUpdateRequestRepository.findDistinctUserIdsByStatus(any()))
                     .thenReturn(List.of());
-            when(userRepository.findAllWithDepartmentAndKeyword(
+            when(userQueryRepository.findAllForAdminWithFilters(
                             null, null, null, null, null, false, pageable))
                     .thenReturn(Page.empty());
 
@@ -357,8 +359,8 @@ class AdminServiceTest {
             adminService.getUsers(adminId, null, null, null, null, null, false, pageable);
 
             // then
-            verify(userRepository)
-                    .findAllWithDepartmentAndKeyword(null, null, null, null, null, false, pageable);
+            verify(userQueryRepository)
+                    .findAllForAdminWithFilters(null, null, null, null, null, false, pageable);
         }
 
         @Test
@@ -368,7 +370,7 @@ class AdminServiceTest {
             Pageable pageable = PageRequest.of(0, 20);
             when(myInfoUpdateRequestRepository.findDistinctUserIdsByStatus(any()))
                     .thenReturn(List.of());
-            when(userRepository.findAllWithDepartmentAndKeyword(
+            when(userQueryRepository.findAllForAdminWithFilters(
                             null, null, null, null, null, true, pageable))
                     .thenReturn(Page.empty());
 
@@ -376,8 +378,8 @@ class AdminServiceTest {
             adminService.getUsers(adminId, null, null, null, null, null, true, pageable);
 
             // then
-            verify(userRepository)
-                    .findAllWithDepartmentAndKeyword(null, null, null, null, null, true, pageable);
+            verify(userQueryRepository)
+                    .findAllForAdminWithFilters(null, null, null, null, null, true, pageable);
         }
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #388

## 📝작업 내용

- `UserQueryRepository`: `findAllForAdminWithFilters` 메서드 추가 (fetchJoin + PageableExecutionUtils 페이징 최적화)
- `UserQueryRepository`: `excludeSuspendedFilter` 헬퍼 추가 (`Boolean.TRUE.equals` null-safe 처리)
- `AdminService`: `userQueryRepository.findAllForAdminWithFilters` 호출로 전환, `effectiveExcludeSuspended` boolean 변환 로직 제거
- `UserRepository`: 사용하지 않게 된 `findAllWithDepartmentAndKeyword` @Query JPQL 메서드 삭제

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)

- `excludeSuspended=null` 처리 방식 변경: 기존 서비스 레이어에서 `boolean effectiveExcludeSuspended = excludeSuspended != null && excludeSuspended`로 primitive 변환하던 로직 제거. QueryDSL 필터에서 `Boolean.TRUE.equals(null) == false`로 null-safe 처리하여 동작은 동일