### PR TITLE
feat(391): 퇴사일 입력 시 유저 상태(SUSPENDED) 자동 연동

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
@@ -322,9 +322,7 @@ public class AdminService {
         if (requestDto.getHireDate() != null) {
             user.setHireDate(requestDto.getHireDate());
         }
-        if (requestDto.getResignationDate() != null) {
-            user.setResignationDate(requestDto.getResignationDate());
-        }
+        user.updateResignationInfo(requestDto.getResignationDate());
 
         userRepository.save(user);
     }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/entity/User.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/entity/User.java
@@ -216,6 +216,18 @@ public class User {
         }
     }
 
+    public void updateResignationInfo(LocalDate resignationDate) {
+        if (resignationDate != null) {
+            this.resignationDate = resignationDate;
+            this.status = Status.SUSPENDED;
+        } else {
+            this.resignationDate = null;
+            if (this.status != Status.PENDING) {
+                this.status = Status.AVAILABLE;
+            }
+        }
+    }
+
     // 관리자가 전화번호 수정 시 호출
     public void updatePhoneNumber(String newPhoneNumber) {
         if (newPhoneNumber != null && !newPhoneNumber.equals(this.phoneNumber)) {

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
@@ -506,6 +506,71 @@ class AdminServiceTest {
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.PHONE_NOT_VERIFIED);
         }
+
+        @Nested
+        @DisplayName("퇴사일 설정 및 상태 연동 시나리오")
+        class Context_resignation_update {
+
+            @Test
+            @DisplayName("AVAILABLE 유저의 resignationDate를 입력하면 상태가 SUSPENDED로 변경된다")
+            void updateUserInfo_resignationDateSet_statusChangesToSuspended() {
+                // given
+                User targetUser = User.builder().id(17L).phoneNumber("01011112222").build();
+                targetUser.setPhoneNumberHash(User.hashValue("01011112222"));
+                targetUser.setStatus(Status.AVAILABLE);
+                when(userRepository.findById(17L)).thenReturn(Optional.of(targetUser));
+
+                AdminUserUpdateRequestDto dto = new AdminUserUpdateRequestDto();
+                dto.setResignationDate(LocalDate.of(2026, 6, 30));
+
+                // when
+                adminService.updateUserInfo(17L, dto, adminId);
+
+                // then
+                assertThat(targetUser.getStatus()).isEqualTo(Status.SUSPENDED);
+                assertThat(targetUser.getResignationDate()).isEqualTo(LocalDate.of(2026, 6, 30));
+            }
+
+            @Test
+            @DisplayName("SUSPENDED 유저의 resignationDate를 null로 입력하면 상태가 AVAILABLE로 복구된다")
+            void updateUserInfo_resignationDateCleared_statusChangesToAvailable() {
+                // given
+                User targetUser = User.builder().id(17L).phoneNumber("01011112222").build();
+                targetUser.setPhoneNumberHash(User.hashValue("01011112222"));
+                targetUser.setStatus(Status.SUSPENDED);
+                targetUser.setResignationDate(LocalDate.of(2026, 3, 31));
+                when(userRepository.findById(17L)).thenReturn(Optional.of(targetUser));
+
+                AdminUserUpdateRequestDto dto = new AdminUserUpdateRequestDto();
+                dto.setResignationDate(null);
+
+                // when
+                adminService.updateUserInfo(17L, dto, adminId);
+
+                // then
+                assertThat(targetUser.getStatus()).isEqualTo(Status.AVAILABLE);
+                assertThat(targetUser.getResignationDate()).isNull();
+            }
+
+            @Test
+            @DisplayName("PENDING 유저의 resignationDate를 null로 입력해도 상태가 PENDING으로 유지된다")
+            void updateUserInfo_resignationDateNull_pendingStatusUnchanged() {
+                // given
+                User targetUser = User.builder().id(17L).phoneNumber("01011112222").build();
+                targetUser.setPhoneNumberHash(User.hashValue("01011112222"));
+                targetUser.setStatus(Status.PENDING);
+                when(userRepository.findById(17L)).thenReturn(Optional.of(targetUser));
+
+                AdminUserUpdateRequestDto dto = new AdminUserUpdateRequestDto();
+                dto.setResignationDate(null);
+
+                // when
+                adminService.updateUserInfo(17L, dto, adminId);
+
+                // then
+                assertThat(targetUser.getStatus()).isEqualTo(Status.PENDING);
+            }
+        }
     }
 
     private UserApprovalRequestDto createRequestDto() {


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #391

## 📝작업 내용

- `AdminService.updateUserInfo`: 퇴사일(`resignationDate`) 입력/삭제에 따라 유저 상태 자동 연동
    - `resignationDate` 설정 시 → status `SUSPENDED`로 즉시 전환
    - `resignationDate` 삭제(null) 시 → status `AVAILABLE`로 복원
    - `PENDING` 유저는 정보 수정만으로 강제 `AVAILABLE` 전환되지 않도록 방어 처리
- `User.updateResignationInfo(LocalDate)` 도메인 메서드 추가로 퇴사일/상태 연동 로직 캡슐화
- `AdminService`에서 setter 직접 호출 4줄 → 도메인 메서드 호출 1줄로 간소화

## 📸 스크린샷 (선택)

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)

- X