### PR TITLE
feat(394): GET /api/users/list에 excludeSuspended 필터 추가

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/controller/UserController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/controller/UserController.java
@@ -146,7 +146,13 @@ public class UserController {
         return ResponseEntity.ok(
                 ApiResponse.onSuccess(
                         userService.getEmployeeList(
-                                keyword, position, departmentId, jobType, role, excludeSuspended, pageable)));
+                                keyword,
+                                position,
+                                departmentId,
+                                jobType,
+                                role,
+                                excludeSuspended,
+                                pageable)));
     }
 
     @Operation(summary = "직원 상세 조회", description = "특정 직원의 상세 정보를 조회합니다. 인증 토큰이 필요합니다.")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/controller/UserController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/controller/UserController.java
@@ -100,8 +100,10 @@ public class UserController {
     @Operation(
             summary = "전 직원 목록 조회",
             description =
-                    "AVAILABLE 상태인 전 직원 목록을 페이징으로 조회합니다. "
-                            + "keyword 파라미터를 전달하면 N-gram Full-Text Search로 한글 이름을 검색합니다.")
+                    "전 직원 목록을 페이징으로 조회합니다. "
+                            + "기본값(excludeSuspended=false)은 AVAILABLE·SUSPENDED 상태 직원을 모두 반환하며, "
+                            + "excludeSuspended=true이면 SUSPENDED 상태 직원을 제외하고 AVAILABLE 상태만 반환합니다. "
+                            + "keyword 파라미터를 전달하면 이름·영문이름·이메일 부분 일치로 검색합니다.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -134,11 +136,17 @@ public class UserController {
             @RequestParam(required = false)
                     @io.swagger.v3.oas.annotations.Parameter(description = "역할 필터")
                     Role role,
+            @RequestParam(required = false, defaultValue = "false")
+                    @io.swagger.v3.oas.annotations.Parameter(
+                            description = "퇴사자(SUSPENDED) 제외 여부",
+                            required = false,
+                            example = "false")
+                    Boolean excludeSuspended,
             @PageableDefault(size = 20) Pageable pageable) {
         return ResponseEntity.ok(
                 ApiResponse.onSuccess(
                         userService.getEmployeeList(
-                                keyword, position, departmentId, jobType, role, pageable)));
+                                keyword, position, departmentId, jobType, role, excludeSuspended, pageable)));
     }
 
     @Operation(summary = "직원 상세 조회", description = "특정 직원의 상세 정보를 조회합니다. 인증 토큰이 필요합니다.")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/querydsl/UserQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/querydsl/UserQueryRepository.java
@@ -34,6 +34,7 @@ public class UserQueryRepository {
             Long departmentId,
             JobType jobType,
             Role role,
+            Boolean excludeSuspended,
             Pageable pageable) {
 
         List<User> content =
@@ -42,7 +43,7 @@ public class UserQueryRepository {
                         .leftJoin(user.department, QDepartment.department)
                         .fetchJoin()
                         .where(
-                                user.status.eq(Status.AVAILABLE),
+                                statusFilter(excludeSuspended),
                                 keywordFilter(keyword),
                                 positionFilter(position),
                                 departmentFilter(departmentId),
@@ -61,13 +62,20 @@ public class UserQueryRepository {
                                 .select(user.count())
                                 .from(user)
                                 .where(
-                                        user.status.eq(Status.AVAILABLE),
+                                        statusFilter(excludeSuspended),
                                         keywordFilter(keyword),
                                         positionFilter(position),
                                         departmentFilter(departmentId),
                                         jobTypeFilter(jobType),
                                         roleFilter(role))
                                 .fetchOne());
+    }
+
+    private BooleanExpression statusFilter(Boolean excludeSuspended) {
+        if (Boolean.TRUE.equals(excludeSuspended)) {
+            return user.status.eq(Status.AVAILABLE);
+        }
+        return user.status.in(Status.AVAILABLE, Status.SUSPENDED);
     }
 
     public Page<User> findAllForAdminWithFilters(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserService.java
@@ -190,11 +190,12 @@ public class UserService {
             Long departmentId,
             JobType jobType,
             Role role,
+            Boolean excludeSuspended,
             Pageable pageable) {
         Pageable unsorted = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
         return userQueryRepository
                 .findAllAvailableWithFilters(
-                        keyword, position, departmentId, jobType, role, unsorted)
+                        keyword, position, departmentId, jobType, role, excludeSuspended, unsorted)
                 .map(UserSummaryResponseDto::from);
     }
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserServiceTest.java
@@ -440,12 +440,12 @@ class UserServiceTest {
 
             given(
                             userQueryRepository.findAllAvailableWithFilters(
-                                    null, null, null, null, null, unsorted))
+                                    null, null, null, null, null, false, unsorted))
                     .willReturn(userPage);
 
             // when
             Page<UserSummaryResponseDto> result =
-                    userService.getEmployeeList(null, null, null, null, null, pageable);
+                    userService.getEmployeeList(null, null, null, null, null, false, pageable);
 
             // then
             assertThat(result.getTotalElements()).isEqualTo(2);
@@ -459,7 +459,7 @@ class UserServiceTest {
             assertThat(result.getContent().get(1).getName()).isEqualTo("이영희");
 
             verify(userQueryRepository)
-                    .findAllAvailableWithFilters(null, null, null, null, null, unsorted);
+                    .findAllAvailableWithFilters(null, null, null, null, null, false, unsorted);
         }
 
         @Test
@@ -472,12 +472,12 @@ class UserServiceTest {
 
             given(
                             userQueryRepository.findAllAvailableWithFilters(
-                                    null, null, null, null, null, unsorted))
+                                    null, null, null, null, null, false, unsorted))
                     .willReturn(emptyPage);
 
             // when
             Page<UserSummaryResponseDto> result =
-                    userService.getEmployeeList(null, null, null, null, null, pageable);
+                    userService.getEmployeeList(null, null, null, null, null, false, pageable);
 
             // then
             assertThat(result.getTotalElements()).isEqualTo(0);
@@ -495,12 +495,12 @@ class UserServiceTest {
 
             given(
                             userQueryRepository.findAllAvailableWithFilters(
-                                    null, null, null, null, null, unsorted))
+                                    null, null, null, null, null, false, unsorted))
                     .willReturn(userPage);
 
             // when
             Page<UserSummaryResponseDto> result =
-                    userService.getEmployeeList(null, null, null, null, null, pageable);
+                    userService.getEmployeeList(null, null, null, null, null, false, pageable);
 
             // then
             assertThat(result.getTotalElements()).isEqualTo(3);
@@ -520,19 +520,19 @@ class UserServiceTest {
 
             given(
                             userQueryRepository.findAllAvailableWithFilters(
-                                    "김철", null, null, null, null, unsorted))
+                                    "김철", null, null, null, null, false, unsorted))
                     .willReturn(userPage);
 
             // when
             Page<UserSummaryResponseDto> result =
-                    userService.getEmployeeList("김철", null, null, null, null, pageable);
+                    userService.getEmployeeList("김철", null, null, null, null, false, pageable);
 
             // then
             assertThat(result.getTotalElements()).isEqualTo(1);
             assertThat(result.getContent().get(0).getName()).isEqualTo(TEST_NAME_KOR);
 
             verify(userQueryRepository)
-                    .findAllAvailableWithFilters("김철", null, null, null, null, unsorted);
+                    .findAllAvailableWithFilters("김철", null, null, null, null, false, unsorted);
         }
 
         @Test
@@ -546,13 +546,13 @@ class UserServiceTest {
 
             given(
                             userQueryRepository.findAllAvailableWithFilters(
-                                    null, null, null, JobType.MANAGEMENT, null, unsorted))
+                                    null, null, null, JobType.MANAGEMENT, null, false, unsorted))
                     .willReturn(userPage);
 
             // when
             Page<UserSummaryResponseDto> result =
                     userService.getEmployeeList(
-                            null, null, null, JobType.MANAGEMENT, null, pageable);
+                            null, null, null, JobType.MANAGEMENT, null, false, pageable);
 
             // then
             assertThat(result.getTotalElements()).isEqualTo(1);
@@ -560,7 +560,82 @@ class UserServiceTest {
 
             verify(userQueryRepository)
                     .findAllAvailableWithFilters(
-                            null, null, null, JobType.MANAGEMENT, null, unsorted);
+                            null, null, null, JobType.MANAGEMENT, null, false, unsorted);
+        }
+
+        @Test
+        @DisplayName("성공: excludeSuspended=true이면 Repository에 true를 전달한다")
+        void getEmployeeList_excludeSuspendedTrue() {
+            // given
+            Pageable pageable = PageRequest.of(0, 20);
+            Pageable unsorted = PageRequest.of(0, 20);
+            User user = createTestUser();
+            Page<User> userPage = new PageImpl<>(List.of(user), pageable, 1);
+
+            given(
+                            userQueryRepository.findAllAvailableWithFilters(
+                                    null, null, null, null, null, true, unsorted))
+                    .willReturn(userPage);
+
+            // when
+            Page<UserSummaryResponseDto> result =
+                    userService.getEmployeeList(null, null, null, null, null, true, pageable);
+
+            // then
+            assertThat(result.getTotalElements()).isEqualTo(1);
+
+            verify(userQueryRepository)
+                    .findAllAvailableWithFilters(null, null, null, null, null, true, unsorted);
+        }
+
+        @Test
+        @DisplayName("성공: excludeSuspended=false이면 Repository에 false를 전달한다")
+        void getEmployeeList_excludeSuspendedFalse() {
+            // given
+            Pageable pageable = PageRequest.of(0, 20);
+            Pageable unsorted = PageRequest.of(0, 20);
+            User user = createTestUser();
+            Page<User> userPage = new PageImpl<>(List.of(user), pageable, 1);
+
+            given(
+                            userQueryRepository.findAllAvailableWithFilters(
+                                    null, null, null, null, null, false, unsorted))
+                    .willReturn(userPage);
+
+            // when
+            Page<UserSummaryResponseDto> result =
+                    userService.getEmployeeList(null, null, null, null, null, false, pageable);
+
+            // then
+            assertThat(result.getTotalElements()).isEqualTo(1);
+
+            verify(userQueryRepository)
+                    .findAllAvailableWithFilters(null, null, null, null, null, false, unsorted);
+        }
+
+        @Test
+        @DisplayName("성공: excludeSuspended=null이면 Repository에 null을 전달한다")
+        void getEmployeeList_excludeSuspendedNull() {
+            // given
+            Pageable pageable = PageRequest.of(0, 20);
+            Pageable unsorted = PageRequest.of(0, 20);
+            User user = createTestUser();
+            Page<User> userPage = new PageImpl<>(List.of(user), pageable, 1);
+
+            given(
+                            userQueryRepository.findAllAvailableWithFilters(
+                                    null, null, null, null, null, null, unsorted))
+                    .willReturn(userPage);
+
+            // when
+            Page<UserSummaryResponseDto> result =
+                    userService.getEmployeeList(null, null, null, null, null, null, pageable);
+
+            // then
+            assertThat(result.getTotalElements()).isEqualTo(1);
+
+            verify(userQueryRepository)
+                    .findAllAvailableWithFilters(null, null, null, null, null, null, unsorted);
         }
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #394

## 📝작업 내용

- `GET /api/users/list` 엔드포인트에 `excludeSuspended` 필터 파라미터 추가
  - 기본값 `false`: AVAILABLE + SUSPENDED 상태 직원 모두 반환 (PENDING 제외)
  - `true`: SUSPENDED 상태 제외, AVAILABLE 상태만 반환
- `UserQueryRepository.findAllAvailableWithFilters`에 `Boolean excludeSuspended` 파라미터 추가
  - 고정 필터 `user.status.eq(AVAILABLE)` → 동적 `statusFilter(excludeSuspended)` 메서드로 교체
- `UserService.getEmployeeList` 시그니처에 `excludeSuspended` 추가, 레포지토리로 전달
- `UserController.getEmployeeList`에 `@RequestParam(required=false, defaultValue="false")` 및 Swagger `@Parameter` 적용
- `@Operation.description`을 최신 필터 동작 방식을 반영한 문구로 수정

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

> `UserServiceTest` — 기존 5개 테스트에 `excludeSuspended` 인자 추가, true/false/null 흐름 검증 신규 3개 추가, BUILD SUCCESSFUL
> API 테스트 — default/false: 9명, true: 8명(SUSPENDED 1명 제외) 정상 확인