### PR TITLE
fix(397): 퇴사자 인증 차단 및 부서 계층 기반 부서교육/내방객 로직 보완

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
@@ -10,6 +10,7 @@ import kr.co.awesomelead.groupware_backend.domain.admin.dto.response.PendingUser
 import kr.co.awesomelead.groupware_backend.domain.admin.enums.AuthorityAction;
 import kr.co.awesomelead.groupware_backend.domain.admin.mapper.AdminMapper;
 import kr.co.awesomelead.groupware_backend.domain.aligo.service.PhoneAuthService;
+import kr.co.awesomelead.groupware_backend.domain.auth.service.RefreshTokenService;
 import kr.co.awesomelead.groupware_backend.domain.department.entity.Department;
 import kr.co.awesomelead.groupware_backend.domain.department.repository.DepartmentRepository;
 import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationDomainType;
@@ -50,6 +51,7 @@ public class AdminService {
     private final DepartmentRepository departmentRepository;
     private final MyInfoUpdateRequestRepository myInfoUpdateRequestRepository;
     private final PhoneAuthService phoneAuthService;
+    private final RefreshTokenService refreshTokenService;
     private final NotificationService notificationService;
     private final AdminMapper adminMapper;
 
@@ -323,6 +325,9 @@ public class AdminService {
             user.setHireDate(requestDto.getHireDate());
         }
         user.updateResignationInfo(requestDto.getResignationDate());
+        if (user.getStatus() == Status.SUSPENDED) {
+            refreshTokenService.deleteRefreshTokenByEmail(user.getEmail());
+        }
 
         userRepository.save(user);
     }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
@@ -37,6 +37,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -161,6 +162,12 @@ public class AuthService {
         Authentication authentication;
         try {
             authentication = authenticationManager.authenticate(authToken);
+        } catch (DisabledException e) {
+            User user = userRepository.findByEmail(requestDto.getEmail()).orElse(null);
+            if (user != null && user.getStatus() == Status.SUSPENDED) {
+                throw new CustomException(ErrorCode.SUSPENDED_ACCOUNT);
+            }
+            throw new CustomException(ErrorCode.INVALID_LOGIN_CREDENTIALS);
         } catch (AuthenticationException e) {
             throw new CustomException(ErrorCode.INVALID_LOGIN_CREDENTIALS);
         }
@@ -228,6 +235,12 @@ public class AuthService {
         // 2. 토큰에서 사용자 정보 추출
         String username = jwtUtil.getUsername(storedToken.getTokenValue());
         String role = jwtUtil.getRole(storedToken.getTokenValue());
+
+        User user = userRepository.findByEmail(username).orElse(null);
+        if (user != null && user.getStatus() == Status.SUSPENDED) {
+            refreshTokenService.deleteRefreshTokenByEmail(username);
+            throw new CustomException(ErrorCode.SUSPENDED_ACCOUNT);
+        }
 
         // 3. 새로운 Access Token 생성
         String newAccessToken = jwtUtil.createJwt(username, role, accessTokenValidation);

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/RefreshTokenService.java
@@ -69,6 +69,11 @@ public class RefreshTokenService {
     }
 
     @Transactional
+    public void deleteRefreshTokenByEmail(String email) {
+        refreshTokenRepository.findByEmail(email).ifPresent(refreshTokenRepository::delete);
+    }
+
+    @Transactional
     public RefreshToken validateRefreshToken(String tokenValue) {
         // DB에서 토큰을 찾지 못하면 예외 발생
         RefreshToken token =

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
@@ -21,6 +21,7 @@ import kr.co.awesomelead.groupware_backend.domain.education.dto.request.SafetyEd
 import kr.co.awesomelead.groupware_backend.domain.education.dto.response.EduReportDetailDto;
 import kr.co.awesomelead.groupware_backend.domain.education.dto.response.EduReportSignatureStatusDto;
 import kr.co.awesomelead.groupware_backend.domain.education.dto.response.EduReportSummaryDto;
+import kr.co.awesomelead.groupware_backend.domain.education.enums.EduReportStatus;
 import kr.co.awesomelead.groupware_backend.domain.education.service.EduReportService;
 import kr.co.awesomelead.groupware_backend.domain.user.dto.CustomUserDetails;
 import kr.co.awesomelead.groupware_backend.global.common.response.ApiResponse;
@@ -507,13 +508,13 @@ public class EduReportController {
             @Parameter(description = "부서명 필터(권한 사용자 전용)", example = "SALES_DEPT")
                     @RequestParam(required = false)
                     DepartmentName departmentName,
-            @Parameter(description = "제목 검색 키워드 (FULLTEXT 검색)", example = "안전교육")
+            @Parameter(description = "진행상태 필터(OPEN: 진행중, CLOSED: 종료)", example = "OPEN")
                     @RequestParam(required = false)
-                    String title,
+                    EduReportStatus status,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         List<EduReportSummaryDto> reports =
                 eduReportService.getDepartmentEduReports(
-                        departmentName, userDetails.getId(), title);
+                        departmentName, status, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(reports));
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
@@ -49,7 +49,7 @@ public class EduReportQueryRepository {
      */
     public List<EduReportSummaryDto> findEduReports(
             EduType type, Department dept, Long categoryId, Long userId, boolean hasAccess) {
-        return findEduReports(type, dept, categoryId, userId, hasAccess, null, true, null);
+        return findEduReports(type, dept, null, categoryId, userId, hasAccess, null, true, null);
     }
 
     public List<EduReportSummaryDto> findEduReports(
@@ -63,6 +63,7 @@ public class EduReportQueryRepository {
         return findEduReports(
                 type,
                 dept,
+                null,
                 categoryId,
                 userId,
                 hasAccess,
@@ -74,6 +75,7 @@ public class EduReportQueryRepository {
     public List<EduReportSummaryDto> findEduReports(
             EduType type,
             Department dept,
+            List<Long> accessibleDepartmentIds,
             Long categoryId,
             Long userId,
             boolean hasAccess,
@@ -132,7 +134,7 @@ public class EduReportQueryRepository {
                 .where(
                         eqEduType(type),
                         eqCategoryId(categoryId),
-                        deptFilter(type, hasAccess, dept),
+                        deptFilter(type, hasAccess, dept, accessibleDepartmentIds),
                         psmFilter(psmCompany, canReadAllPsmCompanies),
                         titleFilter(title))
                 // 같은 eduDate(일자) 내에서는 최신 생성건이 위로 오도록 id DESC를 타이브레이커로 사용
@@ -446,7 +448,8 @@ public class EduReportQueryRepository {
      *   <li>hasAccess=false → 기존 로직: DEPARTMENT 타입이 아니거나, 타입이 DEPARTMENT이면 자신의 부서만
      * </ul>
      */
-    private BooleanExpression deptFilter(EduType type, boolean hasAccess, Department dept) {
+    private BooleanExpression deptFilter(
+            EduType type, boolean hasAccess, Department dept, List<Long> accessibleDepartmentIds) {
         if (hasAccess) {
             // MANAGE_DEPARTMENT_EDUCATION 권한 있음:
             // - DEPARTMENT 조회일 때만 departmentName 필터 적용
@@ -458,8 +461,17 @@ public class EduReportQueryRepository {
         }
         // MANAGE_DEPARTMENT_EDUCATION 권한 없음: 기존 로직 유지
         // - DEPARTMENT 타입이 아닌 교육(PSM, SAFETY)은 모두 보임
-        // - DEPARTMENT 타입이면 자신의 부서 교육만 보임
-        return eduReport.eduType.ne(EduType.DEPARTMENT).or(eduReport.department.eq(dept));
+        // - DEPARTMENT 타입이면 자신의 부서 + 하위 부서 교육을 보임
+        if (accessibleDepartmentIds == null) {
+            return eduReport.eduType.ne(EduType.DEPARTMENT).or(eduReport.department.eq(dept));
+        }
+        if (accessibleDepartmentIds.isEmpty()) {
+            return eduReport.eduType.ne(EduType.DEPARTMENT);
+        }
+        return eduReport
+                .eduType
+                .ne(EduType.DEPARTMENT)
+                .or(eduReport.department.id.in(accessibleDepartmentIds));
     }
 
     private BooleanExpression psmCompanyFilter(Company company, boolean canReadAllCompanies) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
@@ -49,7 +49,8 @@ public class EduReportQueryRepository {
      */
     public List<EduReportSummaryDto> findEduReports(
             EduType type, Department dept, Long categoryId, Long userId, boolean hasAccess) {
-        return findEduReports(type, dept, null, categoryId, userId, hasAccess, null, true, null);
+        return findEduReports(
+                type, dept, null, null, categoryId, userId, hasAccess, null, true, null);
     }
 
     public List<EduReportSummaryDto> findEduReports(
@@ -64,6 +65,7 @@ public class EduReportQueryRepository {
                 type,
                 dept,
                 null,
+                null,
                 categoryId,
                 userId,
                 hasAccess,
@@ -76,6 +78,7 @@ public class EduReportQueryRepository {
             EduType type,
             Department dept,
             List<Long> accessibleDepartmentIds,
+            EduReportStatus status,
             Long categoryId,
             Long userId,
             boolean hasAccess,
@@ -133,6 +136,7 @@ public class EduReportQueryRepository {
                 .leftJoin(eduReport.createdBy, creatorUser)
                 .where(
                         eqEduType(type),
+                        statusFilter(status),
                         eqCategoryId(categoryId),
                         deptFilter(type, hasAccess, dept, accessibleDepartmentIds),
                         psmFilter(psmCompany, canReadAllPsmCompanies),
@@ -437,6 +441,10 @@ public class EduReportQueryRepository {
 
     private BooleanExpression eqCategoryId(Long categoryId) {
         return categoryId != null ? educationCategory.id.eq(categoryId) : null;
+    }
+
+    private BooleanExpression statusFilter(EduReportStatus status) {
+        return status != null ? eduReport.status.eq(status) : null;
     }
 
     /**

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -237,7 +237,12 @@ public class EduReportService {
 
     @Transactional(readOnly = true)
     public List<EduReportSummaryDto> getEduReports(
-            EduType type, DepartmentName departmentName, Long categoryId, Long id, String title) {
+            EduType type,
+            DepartmentName departmentName,
+            EduReportStatus status,
+            Long categoryId,
+            Long id,
+            String title) {
 
         User user =
                 userRepository
@@ -272,6 +277,7 @@ public class EduReportService {
                         type,
                         dept,
                         accessibleDepartmentIds,
+                        status,
                         categoryId,
                         id,
                         hasAccess,
@@ -289,8 +295,8 @@ public class EduReportService {
 
     @Transactional(readOnly = true)
     public List<EduReportSummaryDto> getDepartmentEduReports(
-            DepartmentName departmentName, Long id, String title) {
-        return getEduReports(EduType.DEPARTMENT, departmentName, null, id, title);
+            DepartmentName departmentName, EduReportStatus status, Long id) {
+        return getEduReports(EduType.DEPARTMENT, departmentName, status, null, id, null);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -1135,7 +1135,8 @@ public class EduReportService {
                 .build();
     }
 
-    private boolean isSameOrAncestorDepartment(Department ancestorCandidate, Department department) {
+    private boolean isSameOrAncestorDepartment(
+            Department ancestorCandidate, Department department) {
         if (ancestorCandidate == null || department == null) {
             return false;
         }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -179,7 +179,7 @@ public class EduReportService {
                 targetUserIds = userRepository.findAllIdsByCompany(report.getCompany());
             }
         } else {
-            targetUserIds = userRepository.findAllIdsByDepartmentId(requestDto.getDepartmentId());
+            targetUserIds = findDepartmentNotificationTargetUserIds(department);
         }
         Map<String, Object> metadata =
                 requestDto.getEduType() == EduType.SAFETY
@@ -249,6 +249,7 @@ public class EduReportService {
         Company psmCompanyFilter = canReadAllPsmCompanies ? null : user.getWorkLocation();
 
         Department dept;
+        List<Long> accessibleDepartmentIds = null;
         if (hasAccess) {
             // 권한 있음: departmentName이 지정되면 해당 부서, 없으면 null(전체 조회)
             dept =
@@ -263,12 +264,14 @@ public class EduReportService {
         } else {
             // 권한 없음: 자신의 부서로 제한
             dept = user.getDepartment();
+            accessibleDepartmentIds = collectDepartmentAndChildrenIds(dept);
         }
 
         List<EduReportSummaryDto> summaries =
                 eduReportQueryRepository.findEduReports(
                         type,
                         dept,
+                        accessibleDepartmentIds,
                         categoryId,
                         id,
                         hasAccess,
@@ -359,7 +362,7 @@ public class EduReportService {
         if (!hasAccess) {
             if (user.getDepartment() == null
                     || report.getDepartment() == null
-                    || !report.getDepartment().getId().equals(user.getDepartment().getId())) {
+                    || !isSameOrAncestorDepartment(user.getDepartment(), report.getDepartment())) {
                 throw new CustomException(ErrorCode.EDU_REPORT_NOT_FOUND);
             }
         }
@@ -1126,6 +1129,61 @@ public class EduReportService {
                 .build();
     }
 
+    private boolean isSameOrAncestorDepartment(Department ancestorCandidate, Department department) {
+        if (ancestorCandidate == null || department == null) {
+            return false;
+        }
+
+        Department cursor = department;
+        while (cursor != null) {
+            if (ancestorCandidate.getId().equals(cursor.getId())) {
+                return true;
+            }
+            cursor = cursor.getParent();
+        }
+        return false;
+    }
+
+    private List<Long> collectDepartmentAndChildrenIds(Department department) {
+        if (department == null) {
+            return List.of();
+        }
+
+        LinkedHashSet<Long> departmentIds = new LinkedHashSet<>();
+        collectDepartmentAndChildrenIdsRecursive(department, departmentIds);
+        return new ArrayList<>(departmentIds);
+    }
+
+    private void collectDepartmentAndChildrenIdsRecursive(
+            Department department, LinkedHashSet<Long> departmentIds) {
+        departmentIds.add(department.getId());
+        if (department.getChildren() == null) {
+            return;
+        }
+        for (Department child : department.getChildren()) {
+            collectDepartmentAndChildrenIdsRecursive(child, departmentIds);
+        }
+    }
+
+    private List<Long> findDepartmentNotificationTargetUserIds(Department department) {
+        if (department == null) {
+            return List.of();
+        }
+
+        LinkedHashSet<Long> departmentIds = new LinkedHashSet<>();
+        collectDepartmentAndChildrenIdsRecursive(department, departmentIds);
+
+        Department cursor = department.getParent();
+        while (cursor != null) {
+            departmentIds.add(cursor.getId());
+            cursor = cursor.getParent();
+        }
+
+        return userRepository.findAllByDepartmentIdIn(new ArrayList<>(departmentIds)).stream()
+                .map(User::getId)
+                .toList();
+    }
+
     private long calculateTargetPeopleCount(EduReport report) {
         if (report.getEduType() == EduType.DEPARTMENT && report.getDepartment() != null) {
             return userRepository.countByDepartment(report.getDepartment());
@@ -1185,8 +1243,7 @@ public class EduReportService {
         } else {
             targetUserIds =
                     report.getDepartment() != null
-                            ? userRepository.findAllIdsByDepartmentId(
-                                    report.getDepartment().getId())
+                            ? findDepartmentNotificationTargetUserIds(report.getDepartment())
                             : List.of();
         }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
@@ -521,9 +521,7 @@ public class VisitService {
         Set<Long> targetDeptIds =
                 hosts.stream()
                         .filter(h -> h.getDepartment() != null)
-                        .flatMap(
-                                h ->
-                                        collectAlertTargetDepartmentIds(h.getDepartment()).stream())
+                        .flatMap(h -> collectAlertTargetDepartmentIds(h.getDepartment()).stream())
                         .collect(Collectors.toCollection(java.util.HashSet::new));
 
         if (ENVIRONMENT_SAFETY_REQUIRED_PURPOSES.contains(purpose)) {
@@ -538,7 +536,8 @@ public class VisitService {
                                 template, visitId, deptId, metadata, contentArgs));
     }
 
-    private boolean isSameOrAncestorDepartment(Department ancestorCandidate, Department department) {
+    private boolean isSameOrAncestorDepartment(
+            Department ancestorCandidate, Department department) {
         if (ancestorCandidate == null || department == null) {
             return false;
         }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
@@ -2,6 +2,7 @@ package kr.co.awesomelead.groupware_backend.domain.visit.service;
 
 import static kr.co.awesomelead.groupware_backend.domain.visit.entity.Visit.hashValue;
 
+import kr.co.awesomelead.groupware_backend.domain.department.entity.Department;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
 import kr.co.awesomelead.groupware_backend.domain.department.repository.DepartmentRepository;
 import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationDomainType;
@@ -445,10 +446,8 @@ public class VisitService {
     }
 
     private void validateManagedDepartmentAccess(User manager, Visit visit) {
-        Long managerDepartmentId =
-                manager.getDepartment() != null ? manager.getDepartment().getId() : null;
-
-        if (managerDepartmentId == null) {
+        Department managerDepartment = manager.getDepartment();
+        if (managerDepartment == null) {
             throw new CustomException(ErrorCode.VISIT_ACCESS_DENIED);
         }
 
@@ -457,10 +456,8 @@ public class VisitService {
                         .filter(h -> h.getUser() != null && h.getUser().getDepartment() != null)
                         .anyMatch(
                                 h ->
-                                        h.getUser()
-                                                .getDepartment()
-                                                .getId()
-                                                .equals(managerDepartmentId));
+                                        isSameOrAncestorDepartment(
+                                                managerDepartment, h.getUser().getDepartment()));
 
         if (!hasAccess) {
             throw new CustomException(ErrorCode.VISIT_ACCESS_DENIED);
@@ -524,7 +521,9 @@ public class VisitService {
         Set<Long> targetDeptIds =
                 hosts.stream()
                         .filter(h -> h.getDepartment() != null)
-                        .map(h -> h.getDepartment().getId())
+                        .flatMap(
+                                h ->
+                                        collectAlertTargetDepartmentIds(h.getDepartment()).stream())
                         .collect(Collectors.toCollection(java.util.HashSet::new));
 
         if (ENVIRONMENT_SAFETY_REQUIRED_PURPOSES.contains(purpose)) {
@@ -537,5 +536,34 @@ public class VisitService {
                 deptId ->
                         notificationService.sendVisitAlertToDepartment(
                                 template, visitId, deptId, metadata, contentArgs));
+    }
+
+    private boolean isSameOrAncestorDepartment(Department ancestorCandidate, Department department) {
+        if (ancestorCandidate == null || department == null) {
+            return false;
+        }
+
+        Department cursor = department;
+        while (cursor != null) {
+            if (ancestorCandidate.getId().equals(cursor.getId())) {
+                return true;
+            }
+            cursor = cursor.getParent();
+        }
+        return false;
+    }
+
+    private Set<Long> collectAlertTargetDepartmentIds(Department hostDepartment) {
+        Set<Long> departmentIds = new java.util.HashSet<>();
+        Department cursor = hostDepartment;
+        while (cursor != null) {
+            boolean isRootDepartment = cursor.getParent() == null;
+            // Root 부서는 직접 담당자로 선택된 경우에만 알림 대상으로 포함한다.
+            if (!isRootDepartment || cursor.getId().equals(hostDepartment.getId())) {
+                departmentIds.add(cursor.getId());
+            }
+            cursor = cursor.getParent();
+        }
+        return departmentIds;
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
@@ -82,6 +82,7 @@ public enum ErrorCode {
     AUTH_CODE_EXPIRED(HttpStatus.UNAUTHORIZED, "인증번호가 만료되었습니다."),
     VISITOR_AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "내방객 인증에 실패했습니다."),
     INVALID_LOGIN_CREDENTIALS(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 올바르지 않습니다."),
+    SUSPENDED_ACCOUNT(HttpStatus.UNAUTHORIZED, "퇴사 처리된 계정입니다."),
     HANBIRO_REAUTH_REQUIRED(HttpStatus.UNAUTHORIZED, "한비로 재인증이 필요합니다."),
     HANBIRO_INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "한비로 아이디 또는 비밀번호가 올바르지 않습니다."),
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
@@ -17,6 +17,7 @@ import kr.co.awesomelead.groupware_backend.domain.admin.enums.AuthorityAction;
 import kr.co.awesomelead.groupware_backend.domain.admin.mapper.AdminMapper;
 import kr.co.awesomelead.groupware_backend.domain.admin.service.AdminService;
 import kr.co.awesomelead.groupware_backend.domain.aligo.service.PhoneAuthService;
+import kr.co.awesomelead.groupware_backend.domain.auth.service.RefreshTokenService;
 import kr.co.awesomelead.groupware_backend.domain.department.entity.Department;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
@@ -64,6 +65,7 @@ class AdminServiceTest {
     @Mock private DepartmentRepository departmentRepository;
     @Mock private MyInfoUpdateRequestRepository myInfoUpdateRequestRepository;
     @Mock private PhoneAuthService phoneAuthService;
+    @Mock private RefreshTokenService refreshTokenService;
     @Mock private NotificationService notificationService;
     @Mock private AdminMapper adminMapper;
     @InjectMocks private AdminService adminService;

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
@@ -663,7 +663,8 @@ public class EduReportServiceTest {
 
         // hasAccess=true, dept=null + PSM 조회 범위는 본인 회사 제한
         verify(eduReportQueryRepository, times(1))
-                .findEduReports(null, null, null, null, null, 1L, true, Company.AWESOME, false, null);
+                .findEduReports(
+                        null, null, null, null, null, 1L, true, Company.AWESOME, false, null);
     }
 
     @Test

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
@@ -592,12 +592,21 @@ public class EduReportServiceTest {
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
         when(eduReportQueryRepository.findEduReports(
-                        EduType.SAFETY, department, null, 1L, false, Company.AWESOME, false, null))
+                        EduType.SAFETY,
+                        department,
+                        List.of(1L),
+                        null,
+                        null,
+                        1L,
+                        false,
+                        Company.AWESOME,
+                        false,
+                        null))
                 .thenReturn(mockList);
 
         // when
         List<EduReportSummaryDto> result =
-                eduReportService.getEduReports(EduType.SAFETY, null, null, 1L, null);
+                eduReportService.getEduReports(EduType.SAFETY, null, null, null, 1L, null);
 
         // then
         assertThat(result).isNotNull();
@@ -606,7 +615,16 @@ public class EduReportServiceTest {
 
         verify(eduReportQueryRepository, times(1))
                 .findEduReports(
-                        EduType.SAFETY, department, null, 1L, false, Company.AWESOME, false, null);
+                        EduType.SAFETY,
+                        department,
+                        List.of(1L),
+                        null,
+                        null,
+                        1L,
+                        false,
+                        Company.AWESOME,
+                        false,
+                        null);
     }
 
     @Test
@@ -632,12 +650,12 @@ public class EduReportServiceTest {
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
         // dept=null + PSM 조회 범위는 본인 회사 제한
         when(eduReportQueryRepository.findEduReports(
-                        null, null, null, 1L, true, Company.AWESOME, false, null))
+                        null, null, null, null, null, 1L, true, Company.AWESOME, false, null))
                 .thenReturn(mockList);
 
         // when
         List<EduReportSummaryDto> result =
-                eduReportService.getEduReports(null, null, null, 1L, null);
+                eduReportService.getEduReports(null, null, null, null, 1L, null);
 
         // then
         assertThat(result).isNotNull();
@@ -645,7 +663,7 @@ public class EduReportServiceTest {
 
         // hasAccess=true, dept=null + PSM 조회 범위는 본인 회사 제한
         verify(eduReportQueryRepository, times(1))
-                .findEduReports(null, null, null, 1L, true, Company.AWESOME, false, null);
+                .findEduReports(null, null, null, null, null, 1L, true, Company.AWESOME, false, null);
     }
 
     @Test
@@ -675,6 +693,8 @@ public class EduReportServiceTest {
                         EduType.DEPARTMENT,
                         salesDept,
                         null,
+                        null,
+                        null,
                         1L,
                         true,
                         Company.AWESOME,
@@ -685,7 +705,7 @@ public class EduReportServiceTest {
         // when
         List<EduReportSummaryDto> result =
                 eduReportService.getEduReports(
-                        EduType.DEPARTMENT, DepartmentName.SALES_DEPT, null, 1L, null);
+                        EduType.DEPARTMENT, DepartmentName.SALES_DEPT, null, null, 1L, null);
 
         // then
         assertThat(result).isNotNull();
@@ -697,6 +717,8 @@ public class EduReportServiceTest {
                 .findEduReports(
                         EduType.DEPARTMENT,
                         salesDept,
+                        null,
+                        null,
                         null,
                         1L,
                         true,
@@ -713,14 +735,25 @@ public class EduReportServiceTest {
 
         // when & then
         assertThatThrownBy(
-                        () -> eduReportService.getEduReports(EduType.SAFETY, null, null, 1L, null))
+                        () ->
+                                eduReportService.getEduReports(
+                                        EduType.SAFETY, null, null, null, 1L, null))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.USER_NOT_FOUND);
 
         verify(eduReportQueryRepository, never())
                 .findEduReports(
-                        any(), any(), any(), anyLong(), anyBoolean(), any(), anyBoolean(), any());
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        anyLong(),
+                        anyBoolean(),
+                        any(),
+                        anyBoolean(),
+                        any());
     }
 
     @Test
@@ -2226,8 +2259,8 @@ public class EduReportServiceTest {
         }
 
         @Test
-        @DisplayName("DEPARTMENT 타입 - department가 있으면 findAllIdsByDepartmentId 호출")
-        void remindEduReport_departmentType_withDepartment_callsFindAllIdsByDepartmentId() {
+        @DisplayName("DEPARTMENT 타입 - department가 있으면 findAllByDepartmentIdIn 호출")
+        void remindEduReport_departmentType_withDepartment_callsFindAllByDepartmentIdIn() {
             // given
             User user = createNormalUser();
             user.addAuthority(Authority.MANAGE_DEPARTMENT_EDUCATION);
@@ -2243,14 +2276,17 @@ public class EduReportServiceTest {
             List<Long> targetIds = List.of(1L, 2L);
             when(userRepository.findById(1L)).thenReturn(Optional.of(user));
             when(eduReportRepository.findById(10L)).thenReturn(Optional.of(report));
-            when(userRepository.findAllIdsByDepartmentId(defaultDept.getId()))
-                    .thenReturn(targetIds);
+            when(userRepository.findAllByDepartmentIdIn(List.of(defaultDept.getId())))
+                    .thenReturn(
+                            targetIds.stream()
+                                    .map(targetId -> User.builder().id(targetId).build())
+                                    .toList());
 
             // when
             eduReportService.remindEduReport(10L, 1L);
 
             // then
-            verify(userRepository, times(1)).findAllIdsByDepartmentId(defaultDept.getId());
+            verify(userRepository, times(1)).findAllByDepartmentIdIn(List.of(defaultDept.getId()));
             verify(notificationService, times(1))
                     .sendEduReportRemindAlertToTargets(
                             anyString(), anyString(), anyLong(), any(), any(Map.class));


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #397 

## 📝작업 내용
- 퇴사자 로그인/토큰 재발급 정책 강화
  - 로그인 시 퇴사자 계정은 `SUSPENDED_ACCOUNT` 반환
  - `reissue` 시 퇴사자 계정 차단
  - 퇴사 처리 시 해당 사용자 refresh token 즉시 폐기
- 부서 계층 기반 접근/알림 로직 보완
  - 부서교육/내방객 권한 및 알림 범위를 부서 계층 기준으로 확장
  - 최상위 부서 사용자에게 전체 하위 부서 방문 알림이 과도하게 전달되지 않도록 차단 (ex.대표이사)
- 부서교육 조회 필터 정리
  - 목록 필터를 `부서(departmentName)` + `진행상태(status: OPEN/CLOSED)`로 변경
  - 기존 제목 검색 필터 제거

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X