### PR TITLE
feat(401): 직원 목록 조회 API의 Status 다중 필터링 전환

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
@@ -27,6 +27,7 @@ import kr.co.awesomelead.groupware_backend.domain.user.enums.Authority;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.JobType;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
 import kr.co.awesomelead.groupware_backend.global.common.response.ApiResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -133,9 +134,9 @@ public class AdminController {
             @Parameter(description = "역할 필터", required = false, example = "일반 사용자")
                     @RequestParam(required = false)
                     Role role,
-            @Parameter(description = "퇴사자(SUSPENDED) 제외 여부", required = false, example = "false")
-                    @RequestParam(required = false, defaultValue = "false")
-                    Boolean excludeSuspended,
+            @Parameter(description = "상태 필터 (AVAILABLE, SUSPENDED, PENDING 등 다중 선택 가능)")
+                    @RequestParam(required = false)
+                    List<Status> statuses,
             @ParameterObject @PageableDefault(page = 0, size = 20) Pageable pageable) {
 
         Page<AdminUserSummaryResponseDto> result =
@@ -146,7 +147,7 @@ public class AdminController {
                         departmentId,
                         jobType,
                         role,
-                        excludeSuspended,
+                        statuses,
                         pageable);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(result));

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
@@ -185,7 +185,7 @@ public class AdminService {
             Long departmentId,
             JobType jobType,
             Role role,
-            Boolean excludeSuspended,
+            List<Status> statuses,
             Pageable pageable) {
         User admin =
                 userRepository
@@ -208,7 +208,7 @@ public class AdminService {
                         departmentId,
                         jobType,
                         role,
-                        excludeSuspended,
+                        statuses,
                         pageable)
                 .map(
                         u ->

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/controller/UserController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/controller/UserController.java
@@ -16,6 +16,7 @@ import kr.co.awesomelead.groupware_backend.domain.user.dto.response.UserSummaryR
 import kr.co.awesomelead.groupware_backend.domain.user.enums.JobType;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
 import kr.co.awesomelead.groupware_backend.domain.user.service.UserService;
 import kr.co.awesomelead.groupware_backend.global.common.response.ApiResponse;
 
@@ -34,6 +35,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @Tag(
         name = "User",
@@ -136,12 +139,10 @@ public class UserController {
             @RequestParam(required = false)
                     @io.swagger.v3.oas.annotations.Parameter(description = "역할 필터")
                     Role role,
-            @RequestParam(required = false, defaultValue = "false")
+            @RequestParam(required = false)
                     @io.swagger.v3.oas.annotations.Parameter(
-                            description = "퇴사자(SUSPENDED) 제외 여부",
-                            required = false,
-                            example = "false")
-                    Boolean excludeSuspended,
+                            description = "상태 필터 (AVAILABLE, SUSPENDED)")
+                    List<Status> statuses,
             @PageableDefault(size = 20) Pageable pageable) {
         return ResponseEntity.ok(
                 ApiResponse.onSuccess(
@@ -151,7 +152,7 @@ public class UserController {
                                 departmentId,
                                 jobType,
                                 role,
-                                excludeSuspended,
+                                statuses,
                                 pageable)));
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/querydsl/UserQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/querydsl/UserQueryRepository.java
@@ -12,8 +12,6 @@ import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
 
-import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.data.domain.Page;
@@ -21,6 +19,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -75,8 +75,7 @@ public class UserQueryRepository {
         if (statuses == null || statuses.isEmpty()) {
             return user.status.in(Status.AVAILABLE, Status.SUSPENDED);
         }
-        List<Status> safeStatuses =
-                statuses.stream().filter(s -> s != Status.PENDING).toList();
+        List<Status> safeStatuses = statuses.stream().filter(s -> s != Status.PENDING).toList();
         if (safeStatuses.isEmpty()) {
             return user.id.isNull();
         }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/querydsl/UserQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/querydsl/UserQueryRepository.java
@@ -12,6 +12,8 @@ import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
 
+import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.data.domain.Page;
@@ -19,8 +21,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
-
-import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -34,7 +34,7 @@ public class UserQueryRepository {
             Long departmentId,
             JobType jobType,
             Role role,
-            Boolean excludeSuspended,
+            List<Status> statuses,
             Pageable pageable) {
 
         List<User> content =
@@ -43,7 +43,7 @@ public class UserQueryRepository {
                         .leftJoin(user.department, QDepartment.department)
                         .fetchJoin()
                         .where(
-                                statusFilter(excludeSuspended),
+                                statusFilter(statuses),
                                 keywordFilter(keyword),
                                 positionFilter(position),
                                 departmentFilter(departmentId),
@@ -62,7 +62,7 @@ public class UserQueryRepository {
                                 .select(user.count())
                                 .from(user)
                                 .where(
-                                        statusFilter(excludeSuspended),
+                                        statusFilter(statuses),
                                         keywordFilter(keyword),
                                         positionFilter(position),
                                         departmentFilter(departmentId),
@@ -71,11 +71,16 @@ public class UserQueryRepository {
                                 .fetchOne());
     }
 
-    private BooleanExpression statusFilter(Boolean excludeSuspended) {
-        if (Boolean.TRUE.equals(excludeSuspended)) {
-            return user.status.eq(Status.AVAILABLE);
+    private BooleanExpression statusFilter(List<Status> statuses) {
+        if (statuses == null || statuses.isEmpty()) {
+            return user.status.in(Status.AVAILABLE, Status.SUSPENDED);
         }
-        return user.status.in(Status.AVAILABLE, Status.SUSPENDED);
+        List<Status> safeStatuses =
+                statuses.stream().filter(s -> s != Status.PENDING).toList();
+        if (safeStatuses.isEmpty()) {
+            return user.id.isNull();
+        }
+        return user.status.in(safeStatuses);
     }
 
     public Page<User> findAllForAdminWithFilters(
@@ -84,7 +89,7 @@ public class UserQueryRepository {
             Long departmentId,
             JobType jobType,
             Role role,
-            Boolean excludeSuspended,
+            List<Status> statuses,
             Pageable pageable) {
         List<User> content =
                 queryFactory
@@ -97,7 +102,7 @@ public class UserQueryRepository {
                                 departmentFilter(departmentId),
                                 jobTypeFilter(jobType),
                                 roleFilter(role),
-                                excludeSuspendedFilter(excludeSuspended))
+                                adminStatusFilter(statuses))
                         .orderBy(user.id.desc())
                         .offset(pageable.getOffset())
                         .limit(pageable.getPageSize())
@@ -116,12 +121,15 @@ public class UserQueryRepository {
                                         departmentFilter(departmentId),
                                         jobTypeFilter(jobType),
                                         roleFilter(role),
-                                        excludeSuspendedFilter(excludeSuspended))
+                                        adminStatusFilter(statuses))
                                 .fetchOne());
     }
 
-    private BooleanExpression excludeSuspendedFilter(Boolean excludeSuspended) {
-        return Boolean.TRUE.equals(excludeSuspended) ? user.status.ne(Status.SUSPENDED) : null;
+    private BooleanExpression adminStatusFilter(List<Status> statuses) {
+        if (statuses == null || statuses.isEmpty()) {
+            return null;
+        }
+        return user.status.in(statuses);
     }
 
     private BooleanExpression keywordFilter(String keyword) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserService.java
@@ -14,6 +14,7 @@ import kr.co.awesomelead.groupware_backend.domain.user.enums.JobType;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.MyInfoUpdateRequestStatus;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.MyInfoUpdateRequestRepository;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.querydsl.UserQueryRepository;
@@ -30,6 +31,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Map;
 
 @Slf4j
@@ -182,7 +184,7 @@ public class UserService {
         log.info("내 정보 수정 요청 취소 - 사용자 ID: {}, 요청 ID: {}", user.getId(), requestId);
     }
 
-    // 전 직원 목록 조회 (AVAILABLE 상태)
+    // 전 직원 목록 조회
     @Transactional(readOnly = true)
     public Page<UserSummaryResponseDto> getEmployeeList(
             String keyword,
@@ -190,12 +192,12 @@ public class UserService {
             Long departmentId,
             JobType jobType,
             Role role,
-            Boolean excludeSuspended,
+            List<Status> statuses,
             Pageable pageable) {
         Pageable unsorted = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
         return userQueryRepository
                 .findAllAvailableWithFilters(
-                        keyword, position, departmentId, jobType, role, excludeSuspended, unsorted)
+                        keyword, position, departmentId, jobType, role, statuses, unsorted)
                 .map(UserSummaryResponseDto::from);
     }
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
@@ -358,11 +358,13 @@ class AdminServiceTest {
                     .thenReturn(Page.empty());
 
             // when
-            adminService.getUsers(adminId, null, null, null, null, null, (List<Status>) null, pageable);
+            adminService.getUsers(
+                    adminId, null, null, null, null, null, (List<Status>) null, pageable);
 
             // then
             verify(userQueryRepository)
-                    .findAllForAdminWithFilters(null, null, null, null, null, (List<Status>) null, pageable);
+                    .findAllForAdminWithFilters(
+                            null, null, null, null, null, (List<Status>) null, pageable);
         }
 
         @Test

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
@@ -291,7 +291,7 @@ class AdminServiceTest {
                             11L,
                             JobType.MANAGEMENT,
                             Role.USER,
-                            false,
+                            null,
                             pageable))
                     .thenReturn(userPage);
             when(myInfoUpdateRequestRepository.findDistinctUserIdsByStatus(
@@ -307,7 +307,7 @@ class AdminServiceTest {
                             11L,
                             JobType.MANAGEMENT,
                             Role.USER,
-                            false,
+                            null,
                             pageable);
 
             // then
@@ -339,7 +339,7 @@ class AdminServiceTest {
                                             null,
                                             null,
                                             null,
-                                            false,
+                                            null,
                                             PageRequest.of(0, 20)))
                     .isInstanceOf(CustomException.class)
                     .extracting("errorCode")
@@ -347,41 +347,81 @@ class AdminServiceTest {
         }
 
         @Test
-        @DisplayName("excludeSuspended가 false이면 false로 repository를 호출한다")
-        void getUsers_excludeSuspended가_false이면_excludeSuspended_false로_repository_호출() {
+        @DisplayName("statuses가 null이면 repository에 null을 전달한다")
+        void getUsers_statuses가_null이면_repository에_null을_전달한다() {
             // given
             Pageable pageable = PageRequest.of(0, 20);
             when(myInfoUpdateRequestRepository.findDistinctUserIdsByStatus(any()))
                     .thenReturn(List.of());
             when(userQueryRepository.findAllForAdminWithFilters(
-                            null, null, null, null, null, false, pageable))
+                            null, null, null, null, null, (List<Status>) null, pageable))
                     .thenReturn(Page.empty());
 
             // when
-            adminService.getUsers(adminId, null, null, null, null, null, false, pageable);
+            adminService.getUsers(adminId, null, null, null, null, null, (List<Status>) null, pageable);
 
             // then
             verify(userQueryRepository)
-                    .findAllForAdminWithFilters(null, null, null, null, null, false, pageable);
+                    .findAllForAdminWithFilters(null, null, null, null, null, (List<Status>) null, pageable);
         }
 
         @Test
-        @DisplayName("excludeSuspended가 true이면 true로 repository를 호출한다")
-        void getUsers_excludeSuspended가_true이면_excludeSuspended_true로_repository_호출() {
+        @DisplayName("statuses가 비어있으면 repository에 빈 리스트를 전달한다")
+        void getUsers_statuses가_비어있으면_repository에_빈_리스트를_전달한다() {
             // given
             Pageable pageable = PageRequest.of(0, 20);
             when(myInfoUpdateRequestRepository.findDistinctUserIdsByStatus(any()))
                     .thenReturn(List.of());
             when(userQueryRepository.findAllForAdminWithFilters(
-                            null, null, null, null, null, true, pageable))
+                            null, null, null, null, null, List.of(), pageable))
                     .thenReturn(Page.empty());
 
             // when
-            adminService.getUsers(adminId, null, null, null, null, null, true, pageable);
+            adminService.getUsers(adminId, null, null, null, null, null, List.of(), pageable);
 
             // then
             verify(userQueryRepository)
-                    .findAllForAdminWithFilters(null, null, null, null, null, true, pageable);
+                    .findAllForAdminWithFilters(null, null, null, null, null, List.of(), pageable);
+        }
+
+        @Test
+        @DisplayName("statuses에 AVAILABLE이 포함되면 repository에 그대로 전달한다")
+        void getUsers_statuses에_AVAILABLE이_포함되면_repository에_그대로_전달한다() {
+            // given
+            Pageable pageable = PageRequest.of(0, 20);
+            List<Status> statuses = List.of(Status.AVAILABLE);
+            when(myInfoUpdateRequestRepository.findDistinctUserIdsByStatus(any()))
+                    .thenReturn(List.of());
+            when(userQueryRepository.findAllForAdminWithFilters(
+                            null, null, null, null, null, statuses, pageable))
+                    .thenReturn(Page.empty());
+
+            // when
+            adminService.getUsers(adminId, null, null, null, null, null, statuses, pageable);
+
+            // then
+            verify(userQueryRepository)
+                    .findAllForAdminWithFilters(null, null, null, null, null, statuses, pageable);
+        }
+
+        @Test
+        @DisplayName("statuses에 PENDING이 포함되면 repository에 그대로 전달한다")
+        void getUsers_statuses에_PENDING이_포함되면_repository에_그대로_전달한다() {
+            // given
+            Pageable pageable = PageRequest.of(0, 20);
+            List<Status> statuses = List.of(Status.PENDING);
+            when(myInfoUpdateRequestRepository.findDistinctUserIdsByStatus(any()))
+                    .thenReturn(List.of());
+            when(userQueryRepository.findAllForAdminWithFilters(
+                            null, null, null, null, null, statuses, pageable))
+                    .thenReturn(Page.empty());
+
+            // when
+            adminService.getUsers(adminId, null, null, null, null, null, statuses, pageable);
+
+            // then
+            verify(userQueryRepository)
+                    .findAllForAdminWithFilters(null, null, null, null, null, statuses, pageable);
         }
     }
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserServiceTest.java
@@ -624,7 +624,13 @@ class UserServiceTest {
 
             given(
                             userQueryRepository.findAllAvailableWithFilters(
-                                    null, null, null, null, null, List.of(Status.AVAILABLE), unsorted))
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    List.of(Status.AVAILABLE),
+                                    unsorted))
                     .willReturn(userPage);
 
             // when
@@ -651,7 +657,13 @@ class UserServiceTest {
 
             given(
                             userQueryRepository.findAllAvailableWithFilters(
-                                    null, null, null, null, null, List.of(Status.PENDING), unsorted))
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    List.of(Status.PENDING),
+                                    unsorted))
                     .willReturn(userPage);
 
             // when

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserServiceTest.java
@@ -440,12 +440,12 @@ class UserServiceTest {
 
             given(
                             userQueryRepository.findAllAvailableWithFilters(
-                                    null, null, null, null, null, false, unsorted))
+                                    null, null, null, null, null, null, unsorted))
                     .willReturn(userPage);
 
             // when
             Page<UserSummaryResponseDto> result =
-                    userService.getEmployeeList(null, null, null, null, null, false, pageable);
+                    userService.getEmployeeList(null, null, null, null, null, null, pageable);
 
             // then
             assertThat(result.getTotalElements()).isEqualTo(2);
@@ -459,7 +459,7 @@ class UserServiceTest {
             assertThat(result.getContent().get(1).getName()).isEqualTo("이영희");
 
             verify(userQueryRepository)
-                    .findAllAvailableWithFilters(null, null, null, null, null, false, unsorted);
+                    .findAllAvailableWithFilters(null, null, null, null, null, null, unsorted);
         }
 
         @Test
@@ -472,12 +472,12 @@ class UserServiceTest {
 
             given(
                             userQueryRepository.findAllAvailableWithFilters(
-                                    null, null, null, null, null, false, unsorted))
+                                    null, null, null, null, null, null, unsorted))
                     .willReturn(emptyPage);
 
             // when
             Page<UserSummaryResponseDto> result =
-                    userService.getEmployeeList(null, null, null, null, null, false, pageable);
+                    userService.getEmployeeList(null, null, null, null, null, null, pageable);
 
             // then
             assertThat(result.getTotalElements()).isEqualTo(0);
@@ -495,12 +495,12 @@ class UserServiceTest {
 
             given(
                             userQueryRepository.findAllAvailableWithFilters(
-                                    null, null, null, null, null, false, unsorted))
+                                    null, null, null, null, null, null, unsorted))
                     .willReturn(userPage);
 
             // when
             Page<UserSummaryResponseDto> result =
-                    userService.getEmployeeList(null, null, null, null, null, false, pageable);
+                    userService.getEmployeeList(null, null, null, null, null, null, pageable);
 
             // then
             assertThat(result.getTotalElements()).isEqualTo(3);
@@ -520,19 +520,19 @@ class UserServiceTest {
 
             given(
                             userQueryRepository.findAllAvailableWithFilters(
-                                    "김철", null, null, null, null, false, unsorted))
+                                    "김철", null, null, null, null, null, unsorted))
                     .willReturn(userPage);
 
             // when
             Page<UserSummaryResponseDto> result =
-                    userService.getEmployeeList("김철", null, null, null, null, false, pageable);
+                    userService.getEmployeeList("김철", null, null, null, null, null, pageable);
 
             // then
             assertThat(result.getTotalElements()).isEqualTo(1);
             assertThat(result.getContent().get(0).getName()).isEqualTo(TEST_NAME_KOR);
 
             verify(userQueryRepository)
-                    .findAllAvailableWithFilters("김철", null, null, null, null, false, unsorted);
+                    .findAllAvailableWithFilters("김철", null, null, null, null, null, unsorted);
         }
 
         @Test
@@ -546,13 +546,13 @@ class UserServiceTest {
 
             given(
                             userQueryRepository.findAllAvailableWithFilters(
-                                    null, null, null, JobType.MANAGEMENT, null, false, unsorted))
+                                    null, null, null, JobType.MANAGEMENT, null, null, unsorted))
                     .willReturn(userPage);
 
             // when
             Page<UserSummaryResponseDto> result =
                     userService.getEmployeeList(
-                            null, null, null, JobType.MANAGEMENT, null, false, pageable);
+                            null, null, null, JobType.MANAGEMENT, null, null, pageable);
 
             // then
             assertThat(result.getTotalElements()).isEqualTo(1);
@@ -560,62 +560,12 @@ class UserServiceTest {
 
             verify(userQueryRepository)
                     .findAllAvailableWithFilters(
-                            null, null, null, JobType.MANAGEMENT, null, false, unsorted);
+                            null, null, null, JobType.MANAGEMENT, null, null, unsorted);
         }
 
         @Test
-        @DisplayName("성공: excludeSuspended=true이면 Repository에 true를 전달한다")
-        void getEmployeeList_excludeSuspendedTrue() {
-            // given
-            Pageable pageable = PageRequest.of(0, 20);
-            Pageable unsorted = PageRequest.of(0, 20);
-            User user = createTestUser();
-            Page<User> userPage = new PageImpl<>(List.of(user), pageable, 1);
-
-            given(
-                            userQueryRepository.findAllAvailableWithFilters(
-                                    null, null, null, null, null, true, unsorted))
-                    .willReturn(userPage);
-
-            // when
-            Page<UserSummaryResponseDto> result =
-                    userService.getEmployeeList(null, null, null, null, null, true, pageable);
-
-            // then
-            assertThat(result.getTotalElements()).isEqualTo(1);
-
-            verify(userQueryRepository)
-                    .findAllAvailableWithFilters(null, null, null, null, null, true, unsorted);
-        }
-
-        @Test
-        @DisplayName("성공: excludeSuspended=false이면 Repository에 false를 전달한다")
-        void getEmployeeList_excludeSuspendedFalse() {
-            // given
-            Pageable pageable = PageRequest.of(0, 20);
-            Pageable unsorted = PageRequest.of(0, 20);
-            User user = createTestUser();
-            Page<User> userPage = new PageImpl<>(List.of(user), pageable, 1);
-
-            given(
-                            userQueryRepository.findAllAvailableWithFilters(
-                                    null, null, null, null, null, false, unsorted))
-                    .willReturn(userPage);
-
-            // when
-            Page<UserSummaryResponseDto> result =
-                    userService.getEmployeeList(null, null, null, null, null, false, pageable);
-
-            // then
-            assertThat(result.getTotalElements()).isEqualTo(1);
-
-            verify(userQueryRepository)
-                    .findAllAvailableWithFilters(null, null, null, null, null, false, unsorted);
-        }
-
-        @Test
-        @DisplayName("성공: excludeSuspended=null이면 Repository에 null을 전달한다")
-        void getEmployeeList_excludeSuspendedNull() {
+        @DisplayName("성공: statuses가 null이면 Repository에 null을 전달한다")
+        void getEmployeeList_statuses가_null이면_repository에_null을_전달한다() {
             // given
             Pageable pageable = PageRequest.of(0, 20);
             Pageable unsorted = PageRequest.of(0, 20);
@@ -636,6 +586,85 @@ class UserServiceTest {
 
             verify(userQueryRepository)
                     .findAllAvailableWithFilters(null, null, null, null, null, null, unsorted);
+        }
+
+        @Test
+        @DisplayName("성공: statuses가 비어있으면 Repository에 빈 리스트를 전달한다")
+        void getEmployeeList_statuses가_비어있으면_repository에_빈_리스트를_전달한다() {
+            // given
+            Pageable pageable = PageRequest.of(0, 20);
+            Pageable unsorted = PageRequest.of(0, 20);
+            User user = createTestUser();
+            Page<User> userPage = new PageImpl<>(List.of(user), pageable, 1);
+
+            given(
+                            userQueryRepository.findAllAvailableWithFilters(
+                                    null, null, null, null, null, List.of(), unsorted))
+                    .willReturn(userPage);
+
+            // when
+            Page<UserSummaryResponseDto> result =
+                    userService.getEmployeeList(null, null, null, null, null, List.of(), pageable);
+
+            // then
+            assertThat(result.getTotalElements()).isEqualTo(1);
+
+            verify(userQueryRepository)
+                    .findAllAvailableWithFilters(null, null, null, null, null, List.of(), unsorted);
+        }
+
+        @Test
+        @DisplayName("성공: statuses에 AVAILABLE이 포함되면 Repository에 그대로 전달한다")
+        void getEmployeeList_statuses에_AVAILABLE이_포함되면_repository에_그대로_전달한다() {
+            // given
+            Pageable pageable = PageRequest.of(0, 20);
+            Pageable unsorted = PageRequest.of(0, 20);
+            User user = createTestUser();
+            Page<User> userPage = new PageImpl<>(List.of(user), pageable, 1);
+
+            given(
+                            userQueryRepository.findAllAvailableWithFilters(
+                                    null, null, null, null, null, List.of(Status.AVAILABLE), unsorted))
+                    .willReturn(userPage);
+
+            // when
+            Page<UserSummaryResponseDto> result =
+                    userService.getEmployeeList(
+                            null, null, null, null, null, List.of(Status.AVAILABLE), pageable);
+
+            // then
+            assertThat(result.getTotalElements()).isEqualTo(1);
+
+            verify(userQueryRepository)
+                    .findAllAvailableWithFilters(
+                            null, null, null, null, null, List.of(Status.AVAILABLE), unsorted);
+        }
+
+        @Test
+        @DisplayName("성공: statuses에 PENDING이 포함되어도 Repository에 그대로 전달한다 (필터링은 Repository 책임)")
+        void getEmployeeList_statuses에_PENDING이_포함되어도_repository에_그대로_전달한다() {
+            // given
+            Pageable pageable = PageRequest.of(0, 20);
+            Pageable unsorted = PageRequest.of(0, 20);
+            User user = createTestUser();
+            Page<User> userPage = new PageImpl<>(List.of(user), pageable, 1);
+
+            given(
+                            userQueryRepository.findAllAvailableWithFilters(
+                                    null, null, null, null, null, List.of(Status.PENDING), unsorted))
+                    .willReturn(userPage);
+
+            // when
+            Page<UserSummaryResponseDto> result =
+                    userService.getEmployeeList(
+                            null, null, null, null, null, List.of(Status.PENDING), pageable);
+
+            // then
+            assertThat(result.getTotalElements()).isEqualTo(1);
+
+            verify(userQueryRepository)
+                    .findAllAvailableWithFilters(
+                            null, null, null, null, null, List.of(Status.PENDING), unsorted);
         }
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #401

## 📝작업 내용

- `GET /api/users/list`, `GET /api/admin/users`의 쿼리 파라미터 `excludeSuspended` 제거 → `statuses` (다중 선택) 로 교체
- `UserQueryRepository`: `findAllAvailableWithFilters`, `findAllForAdminWithFilters` 시그니처 변경
  - 일반 직원용 `statusFilter`: PENDING 자동 제외, PENDING-only 요청 시 `user.id.isNull()` 로 항상 빈 결과 반환 (보안 방어)
  - 어드민용 `adminStatusFilter`: null/empty → 전체 조회, 그 외 `IN(statuses)`
- `UserService.getEmployeeList`, `AdminService.getUsers` 시그니처 동기화
- Swagger `@Parameter` 설명에서 PENDING 제거 (일반 직원 API는 PENDING 차단 의도 반영)
- `UserServiceTest`, `AdminServiceTest`: `excludeSuspended` 테스트 제거 → `statuses` 기반 테스트로 교체

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)

- X