### PR TITLE
feat(404): 관리자 직원 목록 엑셀 다운로드 API 구현

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
@@ -1032,7 +1032,12 @@ public class AdminController {
             @RequestParam(required = false) List<Status> statuses) {
         byte[] excelBytes =
                 adminService.getUsersExcel(
-                        userDetails.getId(), keyword, position, departmentId, jobType, role,
+                        userDetails.getId(),
+                        keyword,
+                        position,
+                        departmentId,
+                        jobType,
+                        role,
                         statuses);
         String filename =
                 "직원명단_"

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
@@ -1011,6 +1011,48 @@ public class AdminController {
         return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
 
+    @Operation(summary = "관리자 직원 목록 엑셀 다운로드")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                content =
+                        @Content(
+                                mediaType =
+                                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
+    })
+    @GetMapping("/users/excel")
+    @PreAuthorize("hasAnyRole('ADMIN', 'MASTER_ADMIN')")
+    public ResponseEntity<byte[]> getUsersExcel(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) Position position,
+            @RequestParam(required = false) Long departmentId,
+            @RequestParam(required = false) JobType jobType,
+            @RequestParam(required = false) Role role,
+            @RequestParam(required = false) List<Status> statuses) {
+        byte[] excelBytes =
+                adminService.getUsersExcel(
+                        userDetails.getId(), keyword, position, departmentId, jobType, role,
+                        statuses);
+        String filename =
+                "직원명단_"
+                        + java.time.LocalDate.now()
+                                .format(java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd"))
+                        + ".xlsx";
+        String encodedFilename;
+        try {
+            encodedFilename = java.net.URLEncoder.encode(filename, "UTF-8");
+        } catch (java.io.UnsupportedEncodingException e) {
+            encodedFilename = filename;
+        }
+        return ResponseEntity.ok()
+                .header("Content-Disposition", "attachment; filename*=UTF-8''" + encodedFilename)
+                .header(
+                        "Content-Type",
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+                .body(excelBytes);
+    }
+
     @Operation(
             summary = "개인정보 수정 요청 상세 조회",
             description = "특정 직원의 PENDING 상태 개인정보 수정 요청을 현재 정보와 비교하여 상세 조회합니다.")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
@@ -37,6 +37,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -549,6 +554,133 @@ public class AdminService {
                                                 ErrorCode.MY_INFO_UPDATE_REQUEST_NOT_FOUND));
 
         return adminMapper.toDetailDto(request);
+    }
+
+    @Transactional(readOnly = true)
+    public byte[] getUsersExcel(
+            Long adminId,
+            String keyword,
+            Position position,
+            Long departmentId,
+            JobType jobType,
+            Role role,
+            List<Status> statuses) {
+        User admin =
+                userRepository
+                        .findById(adminId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        validateRegistrationAuthority(admin);
+
+        List<User> users =
+                userQueryRepository.findAllForAdminWithFiltersNoPaging(
+                        keyword, position, departmentId, jobType, role, statuses);
+
+        String[] headers = {
+            "No.", "한글 이름", "영문 이름", "생년월일", "국적", "우편번호", "주소1", "주소2",
+            "주민등록번호", "전화번호", "이메일", "근무사업장", "부서명", "직급", "근무직종",
+            "입사일", "퇴사일", "역할", "회원가입 상태"
+        };
+
+        try (XSSFWorkbook workbook = new XSSFWorkbook()) {
+            Sheet sheet = workbook.createSheet("직원명단");
+
+            CellStyle headerStyle = workbook.createCellStyle();
+            headerStyle.setFillForegroundColor(IndexedColors.GREY_25_PERCENT.getIndex());
+            headerStyle.setFillPattern(FillPatternType.SOLID_FOREGROUND);
+            Font headerFont = workbook.createFont();
+            headerFont.setBold(true);
+            headerStyle.setFont(headerFont);
+            headerStyle.setAlignment(HorizontalAlignment.CENTER);
+            setBorderThin(headerStyle);
+
+            CellStyle dataStyle = workbook.createCellStyle();
+            setBorderThin(dataStyle);
+
+            Row headerRow = sheet.createRow(0);
+            for (int i = 0; i < headers.length; i++) {
+                Cell cell = headerRow.createCell(i);
+                cell.setCellValue(headers[i]);
+                cell.setCellStyle(headerStyle);
+            }
+
+            for (int i = 0; i < users.size(); i++) {
+                User u = users.get(i);
+                Row row = sheet.createRow(i + 1);
+                int col = 0;
+                createDataCell(row, col++, String.valueOf(i + 1), dataStyle);
+                createDataCell(row, col++, u.getNameKor(), dataStyle);
+                createDataCell(row, col++, u.getNameEng(), dataStyle);
+                createDataCell(
+                        row,
+                        col++,
+                        u.getBirthDate() != null ? u.getBirthDate().toString() : "",
+                        dataStyle);
+                createDataCell(row, col++, u.getNationality(), dataStyle);
+                createDataCell(row, col++, u.getZipcode(), dataStyle);
+                createDataCell(row, col++, u.getAddress1(), dataStyle);
+                createDataCell(row, col++, u.getAddress2(), dataStyle);
+                createDataCell(row, col++, u.getRegistrationNumber(), dataStyle);
+                createDataCell(row, col++, u.getPhoneNumber(), dataStyle);
+                createDataCell(row, col++, u.getEmail(), dataStyle);
+                createDataCell(
+                        row,
+                        col++,
+                        u.getWorkLocation() != null ? u.getWorkLocation().name() : "",
+                        dataStyle);
+                createDataCell(
+                        row,
+                        col++,
+                        u.getDepartment() != null ? u.getDepartment().getName().getDescription() : "",
+                        dataStyle);
+                createDataCell(
+                        row,
+                        col++,
+                        u.getPosition() != null ? u.getPosition().getDescription() : "",
+                        dataStyle);
+                createDataCell(
+                        row,
+                        col++,
+                        u.getJobType() != null ? u.getJobType().getDescription() : "",
+                        dataStyle);
+                createDataCell(
+                        row,
+                        col++,
+                        u.getHireDate() != null ? u.getHireDate().toString() : "",
+                        dataStyle);
+                createDataCell(
+                        row,
+                        col++,
+                        u.getResignationDate() != null ? u.getResignationDate().toString() : "",
+                        dataStyle);
+                createDataCell(
+                        row, col++, u.getRole() != null ? u.getRole().name() : "", dataStyle);
+                createDataCell(
+                        row, col++, u.getStatus() != null ? u.getStatus().name() : "", dataStyle);
+            }
+
+            for (int i = 0; i < headers.length; i++) {
+                sheet.autoSizeColumn(i);
+            }
+
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            workbook.write(out);
+            return out.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException("엑셀 파일 생성 중 오류가 발생했습니다.", e);
+        }
+    }
+
+    private void setBorderThin(CellStyle style) {
+        style.setBorderTop(BorderStyle.THIN);
+        style.setBorderBottom(BorderStyle.THIN);
+        style.setBorderLeft(BorderStyle.THIN);
+        style.setBorderRight(BorderStyle.THIN);
+    }
+
+    private void createDataCell(Row row, int col, String value, CellStyle style) {
+        Cell cell = row.createCell(col);
+        cell.setCellValue(value != null ? value : "");
+        cell.setCellStyle(style);
     }
 
     private boolean hasText(String value) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
@@ -32,13 +32,12 @@ import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
+import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import org.apache.poi.ss.usermodel.*;
-import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -576,9 +575,8 @@ public class AdminService {
                         keyword, position, departmentId, jobType, role, statuses);
 
         String[] headers = {
-            "No.", "한글 이름", "영문 이름", "생년월일", "국적", "우편번호", "주소1", "주소2",
-            "주민등록번호", "전화번호", "이메일", "근무사업장", "부서명", "직급", "근무직종",
-            "입사일", "퇴사일", "역할", "회원가입 상태"
+            "No.", "한글 이름", "영문 이름", "생년월일", "국적", "우편번호", "주소1", "주소2", "주민등록번호", "전화번호", "이메일",
+            "근무사업장", "부서명", "직급", "근무직종", "입사일", "퇴사일", "역할", "회원가입 상태"
         };
 
         try (XSSFWorkbook workbook = new XSSFWorkbook()) {
@@ -630,7 +628,9 @@ public class AdminService {
                 createDataCell(
                         row,
                         col++,
-                        u.getDepartment() != null ? u.getDepartment().getName().getDescription() : "",
+                        u.getDepartment() != null
+                                ? u.getDepartment().getName().getDescription()
+                                : "",
                         dataStyle);
                 createDataCell(
                         row,

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/querydsl/UserQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/querydsl/UserQueryRepository.java
@@ -124,6 +124,28 @@ public class UserQueryRepository {
                                 .fetchOne());
     }
 
+    public List<User> findAllForAdminWithFiltersNoPaging(
+            String keyword,
+            Position position,
+            Long departmentId,
+            JobType jobType,
+            Role role,
+            List<Status> statuses) {
+        return queryFactory
+                .selectFrom(user)
+                .leftJoin(user.department, QDepartment.department)
+                .fetchJoin()
+                .where(
+                        keywordFilter(keyword),
+                        positionFilter(position),
+                        departmentFilter(departmentId),
+                        jobTypeFilter(jobType),
+                        roleFilter(role),
+                        adminStatusFilter(statuses))
+                .orderBy(user.id.desc())
+                .fetch();
+    }
+
     private BooleanExpression adminStatusFilter(List<Status> statuses) {
         if (statuses == null || statuses.isEmpty()) {
             return null;

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
@@ -917,6 +917,75 @@ class AdminServiceTest {
     }
 
     @Nested
+    @DisplayName("getUsersExcel 메서드는")
+    class Describe_getUsersExcel {
+
+        @Nested
+        @DisplayName("관리자 권한으로 요청하면")
+        class Context_with_admin_user {
+
+            @Test
+            @DisplayName("엑셀 바이너리를 반환한다")
+            void it_returns_excel_bytes() {
+                // given
+                Department department =
+                        Department.builder()
+                                .id(1L)
+                                .name(DepartmentName.MANAGEMENT_SUPPORT)
+                                .build();
+                User user =
+                        User.builder()
+                                .id(17L)
+                                .nameKor("홍길동")
+                                .nameEng("HONG GILDONG")
+                                .email("hong@test.com")
+                                .status(Status.AVAILABLE)
+                                .role(Role.USER)
+                                .position(Position.STAFF)
+                                .jobType(JobType.MANAGEMENT)
+                                .department(department)
+                                .hireDate(LocalDate.of(2025, 1, 1))
+                                .build();
+                when(userQueryRepository.findAllForAdminWithFiltersNoPaging(
+                                null, null, null, null, null, null))
+                        .thenReturn(List.of(user));
+
+                // when
+                byte[] result =
+                        adminService.getUsersExcel(
+                                adminId, null, null, null, null, null, null);
+
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.length).isGreaterThan(0);
+            }
+        }
+
+        @Nested
+        @DisplayName("권한 없는 사용자가 요청하면")
+        class Context_with_no_authority_user {
+
+            @Test
+            @DisplayName("NO_AUTHORITY_FOR_REGISTRATION 예외를 던진다")
+            void it_throws_no_authority_when_not_admin() {
+                // given
+                User normalUser = new User();
+                normalUser.setRole(Role.USER);
+                when(userRepository.findById(adminId)).thenReturn(Optional.of(normalUser));
+
+                // when & then
+                assertThatThrownBy(
+                                () ->
+                                        adminService.getUsersExcel(
+                                                adminId, null, null, null, null, null, null))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode")
+                        .isEqualTo(ErrorCode.NO_AUTHORITY_FOR_REGISTRATION);
+            }
+        }
+    }
+
+    @Nested
     @DisplayName("getPendingMyInfoUpdateRequestDetail 메서드는")
     class Describe_getPendingMyInfoUpdateRequestDetail {
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
@@ -929,10 +929,7 @@ class AdminServiceTest {
             void it_returns_excel_bytes() {
                 // given
                 Department department =
-                        Department.builder()
-                                .id(1L)
-                                .name(DepartmentName.MANAGEMENT_SUPPORT)
-                                .build();
+                        Department.builder().id(1L).name(DepartmentName.MANAGEMENT_SUPPORT).build();
                 User user =
                         User.builder()
                                 .id(17L)
@@ -952,8 +949,7 @@ class AdminServiceTest {
 
                 // when
                 byte[] result =
-                        adminService.getUsersExcel(
-                                adminId, null, null, null, null, null, null);
+                        adminService.getUsersExcel(adminId, null, null, null, null, null, null);
 
                 // then
                 assertThat(result).isNotNull();


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #404

## 📝작업 내용

- `UserQueryRepository`에 `findAllForAdminWithFiltersNoPaging` 추가
  - 기존 `findAllForAdminWithFilters`의 where 조건을 그대로 유지, offset/limit 제거하여 전체 목록 반환
- `AdminService`에 `getUsersExcel` 메서드 추가
  - 권한 검증 → 필터 조건으로 전체 직원 조회 → Apache POI XSSFWorkbook으로 엑셀 빌드 → `byte[]` 반환
  - 엑셀 19컬럼 구성: No. / 한글 이름 / 영문 이름 / 생년월일 / 국적 / 우편번호 / 주소1 / 주소2 / 주민등록번호 / 전화번호 / 이메일 / 근무사업장 / 부서명 / 직급 / 근무직종 / 입사일 / 퇴사일 / 역할 / 회원가입 상태
  - 부서명·직급·근무직종은 Enum `getDescription()` 한글 값 적용
  - 헤더 스타일(회색 배경, 굵게, 가운데 정렬), 얇은 테두리, 컬럼 자동 너비 적용
- `AdminController`에 `GET /api/admin/users/excel` 엔드포인트 추가
  - `@PreAuthorize("hasAnyRole('ADMIN', 'MASTER_ADMIN')")` 적용
  - `Content-Disposition` 헤더에 URL 인코딩된 파일명(`직원명단_yyyyMMdd.xlsx`) 포함
  - `ResponseEntity<byte[]>` 직접 반환

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)

- 기존 `getUsers` API와 동일한 필터 파라미터를 공유하므로 필터 동작은 기존 로직에 위임합니다.