### PR TITLE
refactor(400): 공지 에디터 본문 지원 및 교육/급여 조회 기능 개선

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
@@ -74,45 +74,55 @@ public class AuthService {
 
     @Transactional
     public SignupResponseDto signup(SignupRequestDto joinDto) {
+        return signupInternal(joinDto, true);
+    }
 
+    @Transactional
+    public SignupResponseDto signupWithoutVerification(SignupRequestDto joinDto) {
+        return signupInternal(joinDto, false);
+    }
+
+    private SignupResponseDto signupInternal(SignupRequestDto joinDto, boolean requireContactVerification) {
         // 1. 비밀번호 확인 검증
         if (!joinDto.getPassword().equals(joinDto.getPasswordConfirm())) {
             throw new CustomException(ErrorCode.PASSWORD_MISMATCH);
         }
 
-        // 2. 전화번호 인증 여부 확인
-        if (!phoneAuthService.isPhoneVerified(joinDto.getPhoneNumber())) {
-            throw new CustomException(ErrorCode.PHONE_NOT_VERIFIED);
+        // 2. 전화번호/이메일 인증 여부 확인 (테스트 전용 회원가입에서는 생략)
+        if (requireContactVerification) {
+            if (!phoneAuthService.isPhoneVerified(joinDto.getPhoneNumber())) {
+                throw new CustomException(ErrorCode.PHONE_NOT_VERIFIED);
+            }
+            if (!emailAuthService.isEmailVerified(joinDto.getEmail())) {
+                throw new CustomException(ErrorCode.EMAIL_NOT_VERIFIED);
+            }
         }
 
-        // 3. 이메일 인증 여부 확인
-        if (!emailAuthService.isEmailVerified(joinDto.getEmail())) {
-            throw new CustomException(ErrorCode.EMAIL_NOT_VERIFIED);
-        }
-
-        // 4. 이메일 중복 검사
+        // 3. 이메일 중복 검사
         if (userRepository.existsByEmail(joinDto.getEmail())) {
             throw new CustomException(ErrorCode.DUPLICATE_LOGIN_ID);
         }
 
-        // 5. 주민등록번호 중복 검사
+        // 4. 주민등록번호 중복 검사
         if (userRepository.existsByRegistrationNumber(joinDto.getRegistrationNumber())) {
             throw new CustomException(ErrorCode.DUPLICATE_REGISTRATION_NUMBER);
         }
 
-        // 6. DTO를 Entity로 변환
+        // 5. DTO를 Entity로 변환
         User user = userMapper.toEntity(joinDto);
         // Mapper에서 처리 안 되는 필드만 설정
         user.setPassword(bCryptPasswordEncoder.encode(joinDto.getPassword()));
 
-        // 7. DB에 저장
+        // 6. DB에 저장
         User savedUser = userRepository.save(user);
 
-        // 8. 인증 완료 플래그 삭제
-        emailAuthService.clearVerification(joinDto.getEmail());
-        phoneAuthService.clearVerification(joinDto.getPhoneNumber());
+        // 7. 인증 완료 플래그 삭제
+        if (requireContactVerification) {
+            emailAuthService.clearVerification(joinDto.getEmail());
+            phoneAuthService.clearVerification(joinDto.getPhoneNumber());
+        }
 
-        // 10. Admin 유저에게 신규 가입 알림 전송 (FCM + Notification DB)
+        // 8. Admin 유저에게 신규 가입 알림 전송 (FCM + Notification DB)
         notificationService.sendAlertToAdminsRequiringApproval(
                 NotificationMessage.SIGNUP_ADMIN_ALERT,
                 NotificationDomainType.AUTH,

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
@@ -82,7 +82,8 @@ public class AuthService {
         return signupInternal(joinDto, false);
     }
 
-    private SignupResponseDto signupInternal(SignupRequestDto joinDto, boolean requireContactVerification) {
+    private SignupResponseDto signupInternal(
+            SignupRequestDto joinDto, boolean requireContactVerification) {
         // 1. 비밀번호 확인 검증
         if (!joinDto.getPassword().equals(joinDto.getPasswordConfirm())) {
             throw new CustomException(ErrorCode.PASSWORD_MISMATCH);

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
@@ -593,12 +593,19 @@ public class EduReportController {
             @Parameter(description = "카테고리 ID 필터(PSM)", example = "1")
                     @RequestParam(required = false)
                     Long categoryId,
+            @Parameter(description = "대상 회사 필터", example = "AWESOME")
+                    @RequestParam(required = false)
+                    Company company,
+            @Parameter(description = "진행상태 필터(OPEN: 진행중, CLOSED: 종료)", example = "OPEN")
+                    @RequestParam(required = false)
+                    EduReportStatus status,
             @Parameter(description = "제목 검색 키워드 (부분 일치 검색)", example = "변경관리")
                     @RequestParam(required = false)
                     String title,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         List<EduReportSummaryDto> reports =
-                eduReportService.getPsmEduReports(categoryId, userDetails.getId(), title);
+                eduReportService.getPsmEduReports(
+                        categoryId, company, status, userDetails.getId(), title);
         return ResponseEntity.ok(ApiResponse.onSuccess(reports));
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
@@ -511,10 +511,13 @@ public class EduReportController {
             @Parameter(description = "진행상태 필터(OPEN: 진행중, CLOSED: 종료)", example = "OPEN")
                     @RequestParam(required = false)
                     EduReportStatus status,
+            @Parameter(description = "제목 검색 키워드 (부분 일치 검색)", example = "안전교육")
+                    @RequestParam(required = false)
+                    String title,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         List<EduReportSummaryDto> reports =
                 eduReportService.getDepartmentEduReports(
-                        departmentName, status, userDetails.getId());
+                        departmentName, status, userDetails.getId(), title);
         return ResponseEntity.ok(ApiResponse.onSuccess(reports));
     }
 
@@ -589,7 +592,7 @@ public class EduReportController {
             @Parameter(description = "카테고리 ID 필터(PSM)", example = "1")
                     @RequestParam(required = false)
                     Long categoryId,
-            @Parameter(description = "제목 검색 키워드 (FULLTEXT 검색)", example = "변경관리")
+            @Parameter(description = "제목 검색 키워드 (부분 일치 검색)", example = "변경관리")
                     @RequestParam(required = false)
                     String title,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -669,7 +672,7 @@ public class EduReportController {
             @Parameter(description = "카테고리 ID 필터(안전 보건)", example = "1")
                     @RequestParam(required = false)
                     Long categoryId,
-            @Parameter(description = "제목 검색 키워드 (FULLTEXT 검색)", example = "정기교육")
+            @Parameter(description = "제목 검색 키워드 (부분 일치 검색)", example = "정기교육")
                     @RequestParam(required = false)
                     String title,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 import jakarta.validation.Valid;
 
+import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
 import kr.co.awesomelead.groupware_backend.domain.education.dto.request.DepartmentEduReportCreateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.education.dto.request.EduReportStatusUpdateRequestDto;
@@ -672,12 +673,19 @@ public class EduReportController {
             @Parameter(description = "카테고리 ID 필터(안전 보건)", example = "1")
                     @RequestParam(required = false)
                     Long categoryId,
+            @Parameter(description = "대상 회사 필터", example = "AWESOME")
+                    @RequestParam(required = false)
+                    Company company,
+            @Parameter(description = "진행상태 필터(OPEN: 진행중, CLOSED: 종료)", example = "OPEN")
+                    @RequestParam(required = false)
+                    EduReportStatus status,
             @Parameter(description = "제목 검색 키워드 (부분 일치 검색)", example = "정기교육")
                     @RequestParam(required = false)
                     String title,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         List<EduReportSummaryDto> reports =
-                eduReportService.getSafetyEduReports(categoryId, userDetails.getId(), title);
+                eduReportService.getSafetyEduReports(
+                        categoryId, company, status, userDetails.getId(), title);
         return ResponseEntity.ok(ApiResponse.onSuccess(reports));
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
@@ -148,7 +148,7 @@ public class EduReportQueryRepository {
 
     public List<EduReportSummaryDto> findPsmEduReports(
             Long categoryId, Long userId, Company company, boolean canReadAllCompanies) {
-        return findPsmEduReports(categoryId, userId, company, canReadAllCompanies, null);
+        return findPsmEduReports(categoryId, userId, company, canReadAllCompanies, null, null, null);
     }
 
     public List<EduReportSummaryDto> findPsmEduReports(
@@ -156,6 +156,18 @@ public class EduReportQueryRepository {
             Long userId,
             Company company,
             boolean canReadAllCompanies,
+            String title) {
+        return findPsmEduReports(
+                categoryId, userId, company, canReadAllCompanies, null, null, title);
+    }
+
+    public List<EduReportSummaryDto> findPsmEduReports(
+            Long categoryId,
+            Long userId,
+            Company company,
+            boolean canReadAllCompanies,
+            Company targetCompany,
+            EduReportStatus status,
             String title) {
         QUser creatorUser = new QUser("creatorUserForPsm");
         BooleanExpression attendanceExists =
@@ -197,6 +209,8 @@ public class EduReportQueryRepository {
                         eduReport.eduType.eq(EduType.PSM),
                         eqCategoryId(categoryId),
                         psmCompanyFilter(company, canReadAllCompanies),
+                        psmTargetCompanyFilter(targetCompany),
+                        statusFilter(status),
                         titleFilter(title))
                 .orderBy(eduReport.pinned.desc(), eduReport.eduDate.desc(), eduReport.id.desc())
                 .fetch();
@@ -501,6 +515,13 @@ public class EduReportQueryRepository {
             return eduReport.company.isNull();
         }
 
+        return eduReport.company.eq(company).or(eduReport.company.isNull());
+    }
+
+    private BooleanExpression psmTargetCompanyFilter(Company company) {
+        if (company == null) {
+            return null;
+        }
         return eduReport.company.eq(company).or(eduReport.company.isNull());
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
@@ -148,7 +148,8 @@ public class EduReportQueryRepository {
 
     public List<EduReportSummaryDto> findPsmEduReports(
             Long categoryId, Long userId, Company company, boolean canReadAllCompanies) {
-        return findPsmEduReports(categoryId, userId, company, canReadAllCompanies, null, null, null);
+        return findPsmEduReports(
+                categoryId, userId, company, canReadAllCompanies, null, null, null);
     }
 
     public List<EduReportSummaryDto> findPsmEduReports(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
@@ -204,7 +204,8 @@ public class EduReportQueryRepository {
 
     public List<EduReportSummaryDto> findSafetyEduReports(
             Long categoryId, Long userId, Company company, boolean canReadAllCompanies) {
-        return findSafetyEduReports(categoryId, userId, company, canReadAllCompanies, null);
+        return findSafetyEduReports(
+                categoryId, userId, company, canReadAllCompanies, null, null, null);
     }
 
     public List<EduReportSummaryDto> findSafetyEduReports(
@@ -212,6 +213,18 @@ public class EduReportQueryRepository {
             Long userId,
             Company company,
             boolean canReadAllCompanies,
+            String title) {
+        return findSafetyEduReports(
+                categoryId, userId, company, canReadAllCompanies, null, null, title);
+    }
+
+    public List<EduReportSummaryDto> findSafetyEduReports(
+            Long categoryId,
+            Long userId,
+            Company company,
+            boolean canReadAllCompanies,
+            Company targetCompany,
+            EduReportStatus status,
             String title) {
         QUser creatorUser = new QUser("creatorUserForSafety");
         BooleanExpression attendanceExists =
@@ -253,6 +266,8 @@ public class EduReportQueryRepository {
                         eduReport.eduType.eq(EduType.SAFETY),
                         eqCategoryId(categoryId),
                         psmCompanyFilter(company, canReadAllCompanies),
+                        safetyTargetCompanyFilter(targetCompany),
+                        statusFilter(status),
                         titleFilter(title))
                 .orderBy(eduReport.pinned.desc(), eduReport.eduDate.desc(), eduReport.id.desc())
                 .fetch();
@@ -486,6 +501,13 @@ public class EduReportQueryRepository {
             return eduReport.company.isNull();
         }
 
+        return eduReport.company.eq(company).or(eduReport.company.isNull());
+    }
+
+    private BooleanExpression safetyTargetCompanyFilter(Company company) {
+        if (company == null) {
+            return null;
+        }
         return eduReport.company.eq(company).or(eduReport.company.isNull());
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EduReportQueryRepository.java
@@ -426,12 +426,7 @@ public class EduReportQueryRepository {
         if (!StringUtils.hasText(title)) {
             return null;
         }
-        return Expressions.numberTemplate(
-                        Double.class,
-                        "function('match_against', {0}, {1})",
-                        eduReport.title,
-                        Expressions.constant(title))
-                .gt(0);
+        return eduReport.title.contains(title);
     }
 
     /** 교육 유형 필터 — null 이면 조건 없음 (전체) */

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -295,8 +295,8 @@ public class EduReportService {
 
     @Transactional(readOnly = true)
     public List<EduReportSummaryDto> getDepartmentEduReports(
-            DepartmentName departmentName, EduReportStatus status, Long id) {
-        return getEduReports(EduType.DEPARTMENT, departmentName, status, null, id, null);
+            DepartmentName departmentName, EduReportStatus status, Long id, String title) {
+        return getEduReports(EduType.DEPARTMENT, departmentName, status, null, id, title);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -316,7 +316,8 @@ public class EduReportService {
     }
 
     @Transactional(readOnly = true)
-    public List<EduReportSummaryDto> getSafetyEduReports(Long categoryId, Long id, String title) {
+    public List<EduReportSummaryDto> getSafetyEduReports(
+            Long categoryId, Company company, EduReportStatus status, Long id, String title) {
         User user =
                 userRepository
                         .findById(id)
@@ -324,9 +325,14 @@ public class EduReportService {
 
         boolean canReadAllCompanies = user.hasAuthority(Authority.MANAGE_SAFETY);
         Company companyFilter = canReadAllCompanies ? null : user.getWorkLocation();
+        if (!canReadAllCompanies
+                && company != null
+                && (companyFilter == null || company != companyFilter)) {
+            return List.of();
+        }
         List<EduReportSummaryDto> summaries =
                 eduReportQueryRepository.findSafetyEduReports(
-                        categoryId, id, companyFilter, canReadAllCompanies, title);
+                        categoryId, id, companyFilter, canReadAllCompanies, company, status, title);
         summaries.forEach(this::applyCompanyScopeToSummary);
         return summaries;
     }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -300,7 +300,8 @@ public class EduReportService {
     }
 
     @Transactional(readOnly = true)
-    public List<EduReportSummaryDto> getPsmEduReports(Long categoryId, Long id, String title) {
+    public List<EduReportSummaryDto> getPsmEduReports(
+            Long categoryId, Company company, EduReportStatus status, Long id, String title) {
         User user =
                 userRepository
                         .findById(id)
@@ -308,9 +309,14 @@ public class EduReportService {
 
         boolean canReadAllCompanies = user.hasAuthority(Authority.MANAGE_PSM);
         Company companyFilter = canReadAllCompanies ? null : user.getWorkLocation();
+        if (!canReadAllCompanies
+                && company != null
+                && (companyFilter == null || company != companyFilter)) {
+            return List.of();
+        }
         List<EduReportSummaryDto> summaries =
                 eduReportQueryRepository.findPsmEduReports(
-                        categoryId, id, companyFilter, canReadAllCompanies, title);
+                        categoryId, id, companyFilter, canReadAllCompanies, company, status, title);
         summaries.forEach(this::applyCompanyScopeToSummary);
         return summaries;
     }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/controller/NoticeController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/controller/NoticeController.java
@@ -73,6 +73,9 @@ public class NoticeController {
                     """
                 새로운 공지를 생성합니다. 첨부파일을 포함할 수 있습니다.
 
+                본문은 `contentDelta`(Quill Delta JSON 문자열) 또는 `contentHtml`을 사용할 수 있습니다.
+                하위 호환을 위해 기존 `content`도 함께 지원합니다.
+
                 **공지 대상 설정 로직**:
                 1. **회사(targetCompanies)**: 선택된 회사 소속 전체 인원을 대상으로 합니다.
                 2. **부서(targetDepartmentIds)**: 선택된 부서 및 그 하위 부서의 모든 인원을 대상으로 합니다.
@@ -86,6 +89,11 @@ public class NoticeController {
                             content =
                                     @Content(
                                             mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                                            schema =
+                                                    @Schema(
+                                                            implementation =
+                                                                    NoticeCreateMultipartRequestDoc
+                                                                            .class),
                                             encoding = {
                                                 @Encoding(
                                                         name = "requestDto",
@@ -205,7 +213,8 @@ public class NoticeController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Long>> createNotice(
             @Parameter(
-                            description = "공지사항 생성 정보 (JSON)",
+                            description =
+                                    "공지사항 생성 정보(JSON). 권장: contentDelta(에디터 원본) + contentHtml(렌더링용) 함께 전달",
                             required = true,
                             schema = @Schema(implementation = NoticeCreateRequestDto.class))
                     @RequestPart("requestDto")
@@ -345,6 +354,8 @@ public class NoticeController {
                                 "type": "REGULAR",
                                 "title": "2025년 1월 전체 회의 안내",
                                 "content": "오는 1월 15일 오후 2시에 전체 회의가 있습니다.",
+                                "contentDelta": "{\"ops\":[{\"insert\":\"오는 1월 15일 오후 2시에 전체 회의가 있습니다.\\n\"}]}",
+                                "contentHtml": "<p>오는 1월 15일 오후 2시에 전체 회의가 있습니다.</p>",
                                 "authorName": "홍길동",
                                 "createdDate": "2025-01-10T14:30:00",
                                 "viewCount": 43,
@@ -467,7 +478,7 @@ public class NoticeController {
 
     @Operation(
             summary = "공지 수정",
-            description = "특정 공지를 수정합니다. multipart/form-data 기반으로 제목/내용/유형/대상자/첨부파일을 수정할 수 있습니다.",
+            description = "특정 공지를 수정합니다. multipart/form-data 기반으로 제목/본문(content/contentDelta/contentHtml)/유형/대상자/첨부파일을 수정할 수 있습니다.",
             requestBody =
                     @io.swagger.v3.oas.annotations.parameters.RequestBody(
                             required = true,
@@ -495,8 +506,11 @@ public class NoticeController {
                                     {
                                       "notice": {
                                         "title": "2025년 2월 전체 회의 안내 (수정)",
-                                        "content": "회의 시간이 오후 3시로 변경되었습니다.",
+                                        "type": "상시공지",
                                         "pinned": true,
+                                        "contentDelta": "{\"ops\":[{\"insert\":\"회의 시간이 오후 3시로 변경되었습니다.\\n\"}]}",
+                                        "contentHtml": "<p>회의 시간이 오후 3시로 변경되었습니다.</p>",
+                                        "content": "회의 시간이 오후 3시로 변경되었습니다.",
                                         "attachmentsIdsToRemove": [1]
                                       }
                                     }
@@ -521,8 +535,11 @@ public class NoticeController {
                                     {
                                       "notice": {
                                         "title": "2025년 2월 전체 회의 안내 (수정)",
-                                        "content": "회의 시간이 오후 3시로 변경되었습니다.",
+                                        "type": "상시공지",
                                         "pinned": true,
+                                        "contentDelta": "{\"ops\":[{\"insert\":\"회의 시간이 오후 3시로 변경되었습니다.\\n\"}]}",
+                                        "contentHtml": "<p>회의 시간이 오후 3시로 변경되었습니다.</p>",
+                                        "content": "회의 시간이 오후 3시로 변경되었습니다.",
                                         "attachmentsIdsToRemove": [1]
                                       },
                                       "files": ["(binary)"]
@@ -588,7 +605,14 @@ public class NoticeController {
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "수정할 공지사항 ID", example = "1", required = true) @PathVariable
                     Long noticeId,
-            @Valid @RequestPart("notice") NoticeUpdateRequestDto dto,
+            @Parameter(
+                            description =
+                                    "공지 수정 정보(JSON). content/contentDelta/contentHtml 중 필요한 필드만 부분 수정 가능",
+                            required = true,
+                            schema = @Schema(implementation = NoticeUpdateRequestDto.class))
+                    @Valid
+                    @RequestPart("notice")
+                    NoticeUpdateRequestDto dto,
             @RequestPart(value = "files", required = false) List<MultipartFile> files)
             throws IOException {
 
@@ -655,8 +679,49 @@ public class NoticeController {
 @Schema(name = "NoticeUpdateMultipartRequest")
 class NoticeUpdateMultipartRequestDoc {
 
-    @Schema(description = "공지 수정 정보(JSON 파트)")
+    @Schema(
+            description = "공지 수정 정보(JSON 파트)",
+            example =
+                    """
+                    {
+                      "title": "2025년 1월 전체 회의 안내 (수정)",
+                      "type": "상시공지",
+                      "pinned": true,
+                      "contentDelta": "{\\"ops\\":[{\\"insert\\":\\"회의 시간이 오후 3시로 변경되었습니다.\\\\n\\"}]}",
+                      "contentHtml": "<p>회의 시간이 오후 3시로 변경되었습니다.</p>",
+                      "content": "회의 시간이 오후 3시로 변경되었습니다.",
+                      "targetCompanies": ["어썸리드"],
+                      "targetDepartmentIds": [11, 12],
+                      "targetUserIds": [17, 22],
+                      "attachmentsIdsToRemove": [1, 2]
+                    }
+                    """)
     public NoticeUpdateRequestDto notice;
+
+    @ArraySchema(schema = @Schema(type = "string", format = "binary"))
+    public List<String> files;
+}
+
+@Schema(name = "NoticeCreateMultipartRequest")
+class NoticeCreateMultipartRequestDoc {
+
+    @Schema(
+            description = "공지사항 생성 정보(JSON 파트)",
+            example =
+                    """
+                    {
+                      "title": "2025년 1월 전체 회의 안내",
+                      "type": "상시공지",
+                      "pinned": false,
+                      "contentDelta": "{\\"ops\\":[{\\"insert\\":\\"공지 본문입니다.\\\\n\\"}]}",
+                      "contentHtml": "<p>오는 1월 15일 오후 2시에 전체 회의가 있습니다.</p>",
+                      "content": "오는 1월 15일 오후 2시에 전체 회의가 있습니다.",
+                      "targetCompanies": ["어썸리드"],
+                      "targetDepartmentIds": [1, 5, 12],
+                      "targetUserIds": [101, 205]
+                    }
+                    """)
+    public NoticeCreateRequestDto requestDto;
 
     @ArraySchema(schema = @Schema(type = "string", format = "binary"))
     public List<String> files;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/controller/NoticeController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/controller/NoticeController.java
@@ -214,7 +214,8 @@ public class NoticeController {
     public ResponseEntity<ApiResponse<Long>> createNotice(
             @Parameter(
                             description =
-                                    "공지사항 생성 정보(JSON). 권장: contentDelta(에디터 원본) + contentHtml(렌더링용) 함께 전달",
+                                    "공지사항 생성 정보(JSON). 권장: contentDelta(에디터 원본) + contentHtml(렌더링용)"
+                                        + " 함께 전달",
                             required = true,
                             schema = @Schema(implementation = NoticeCreateRequestDto.class))
                     @RequestPart("requestDto")
@@ -478,7 +479,9 @@ public class NoticeController {
 
     @Operation(
             summary = "공지 수정",
-            description = "특정 공지를 수정합니다. multipart/form-data 기반으로 제목/본문(content/contentDelta/contentHtml)/유형/대상자/첨부파일을 수정할 수 있습니다.",
+            description =
+                    "특정 공지를 수정합니다. multipart/form-data 기반으로"
+                        + " 제목/본문(content/contentDelta/contentHtml)/유형/대상자/첨부파일을 수정할 수 있습니다.",
             requestBody =
                     @io.swagger.v3.oas.annotations.parameters.RequestBody(
                             required = true,
@@ -607,7 +610,8 @@ public class NoticeController {
                     Long noticeId,
             @Parameter(
                             description =
-                                    "공지 수정 정보(JSON). content/contentDelta/contentHtml 중 필요한 필드만 부분 수정 가능",
+                                    "공지 수정 정보(JSON). content/contentDelta/contentHtml 중 필요한 필드만 부분"
+                                        + " 수정 가능",
                             required = true,
                             schema = @Schema(implementation = NoticeUpdateRequestDto.class))
                     @Valid

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/dto/request/NoticeCreateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/dto/request/NoticeCreateRequestDto.java
@@ -1,5 +1,7 @@
 package kr.co.awesomelead.groupware_backend.domain.notice.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import jakarta.validation.constraints.NotBlank;
@@ -19,15 +21,53 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@Schema(description = "공지사항 생성 요청")
+@JsonPropertyOrder({
+    "title",
+    "type",
+    "pinned",
+    "contentDelta",
+    "contentHtml",
+    "content",
+    "targetCompanies",
+    "targetDepartmentIds",
+    "targetUserIds"
+})
+@Schema(
+        description = "공지사항 생성 요청",
+        example =
+                """
+                {
+                  "title": "2025년 1월 전체 회의 안내",
+                  "type": "상시공지",
+                  "pinned": false,
+                  "contentDelta": "{\\"ops\\":[{\\"insert\\":\\"공지 본문입니다.\\\\n\\"}]}",
+                  "contentHtml": "<p>오는 1월 15일 오후 2시에 전체 회의가 있습니다.</p>",
+                  "content": "오는 1월 15일 오후 2시에 전체 회의가 있습니다.",
+                  "targetCompanies": ["어썸리드"],
+                  "targetDepartmentIds": [1, 5, 12],
+                  "targetUserIds": [101, 205]
+                }
+                """)
 public class NoticeCreateRequestDto {
 
     @NotBlank(message = "공지사항 제목은 필수입니다.")
     @Schema(description = "공지사항 제목", example = "2025년 1월 전체 회의 안내", required = true)
     private String title;
 
-    @Schema(description = "공지사항 내용 (식단표의 경우 null 가능)", example = "오는 1월 15일 오후 2시에 전체 회의가 있습니다.")
+    @Schema(
+            description = "레거시 평문 본문(하위 호환용). 신규 개발은 contentDelta + contentHtml 사용 권장",
+            example = "오는 1월 15일 오후 2시에 전체 회의가 있습니다.")
     private String content;
+
+    @Schema(
+            description = "Quill Delta JSON 문자열(에디터 원본). 프론트 저장 기준으로 권장",
+            example = "{\"ops\":[{\"insert\":\"공지 본문입니다.\\n\"}]}")
+    private String contentDelta;
+
+    @Schema(
+            description = "HTML 본문(선택). 상세 렌더링/미리보기 호환용",
+            example = "<p>오는 1월 15일 오후 2시에 전체 회의가 있습니다.</p>")
+    private String contentHtml;
 
     @NotNull(message = "공지 유형은 필수입니다.")
     @Schema(description = "공지 유형", example = "상시공지", required = true)

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/dto/request/NoticeUpdateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/dto/request/NoticeUpdateRequestDto.java
@@ -62,9 +62,7 @@ public class NoticeUpdateRequestDto {
             example = "{\"ops\":[{\"insert\":\"회의 시간이 오후 3시로 변경되었습니다.\\n\"}]}")
     private String contentDelta;
 
-    @Schema(
-            description = "HTML 본문(수정하지 않으려면 null)",
-            example = "<p>회의 시간이 오후 3시로 변경되었습니다.</p>")
+    @Schema(description = "HTML 본문(수정하지 않으려면 null)", example = "<p>회의 시간이 오후 3시로 변경되었습니다.</p>")
     private String contentHtml;
 
     @Schema(description = "공지 유형 (수정하지 않으려면 null)", example = "상시공지")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/dto/request/NoticeUpdateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/dto/request/NoticeUpdateRequestDto.java
@@ -1,5 +1,7 @@
 package kr.co.awesomelead.groupware_backend.domain.notice.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
@@ -16,14 +18,54 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@Schema(description = "공지사항 수정 요청")
+@JsonPropertyOrder({
+    "title",
+    "type",
+    "pinned",
+    "contentDelta",
+    "contentHtml",
+    "content",
+    "targetCompanies",
+    "targetDepartmentIds",
+    "targetUserIds",
+    "attachmentsIdsToRemove"
+})
+@Schema(
+        description = "공지사항 수정 요청",
+        example =
+                """
+                {
+                  "title": "2025년 1월 전체 회의 안내 (수정)",
+                  "type": "상시공지",
+                  "pinned": true,
+                  "contentDelta": "{\\"ops\\":[{\\"insert\\":\\"회의 시간이 오후 3시로 변경되었습니다.\\\\n\\"}]}",
+                  "contentHtml": "<p>회의 시간이 오후 3시로 변경되었습니다.</p>",
+                  "content": "회의 시간이 오후 3시로 변경되었습니다.",
+                  "targetCompanies": ["어썸리드"],
+                  "targetDepartmentIds": [11, 12],
+                  "targetUserIds": [17, 22],
+                  "attachmentsIdsToRemove": [1, 2]
+                }
+                """)
 public class NoticeUpdateRequestDto {
 
     @Schema(description = "공지사항 제목 (수정하지 않으려면 null)", example = "2025년 1월 전체 회의 안내 (수정)")
     private String title;
 
-    @Schema(description = "공지사항 내용 (수정하지 않으려면 null)", example = "회의 시간이 오후 3시로 변경되었습니다.")
+    @Schema(
+            description = "레거시 평문 본문(수정하지 않으려면 null). 신규 개발은 contentDelta + contentHtml 사용 권장",
+            example = "회의 시간이 오후 3시로 변경되었습니다.")
     private String content;
+
+    @Schema(
+            description = "Quill Delta JSON 문자열(에디터 원본, 수정하지 않으려면 null)",
+            example = "{\"ops\":[{\"insert\":\"회의 시간이 오후 3시로 변경되었습니다.\\n\"}]}")
+    private String contentDelta;
+
+    @Schema(
+            description = "HTML 본문(수정하지 않으려면 null)",
+            example = "<p>회의 시간이 오후 3시로 변경되었습니다.</p>")
+    private String contentHtml;
 
     @Schema(description = "공지 유형 (수정하지 않으려면 null)", example = "상시공지")
     private NoticeType type;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/dto/response/NoticeDetailDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/dto/response/NoticeDetailDto.java
@@ -29,6 +29,14 @@ public class NoticeDetailDto {
     @Schema(description = "공지사항 내용", example = "오는 1월 15일 오후 2시에 전체 회의가 있습니다.")
     private String content;
 
+    @Schema(
+            description = "Quill Delta JSON 문자열",
+            example = "{\"ops\":[{\"insert\":\"오는 1월 15일 오후 2시에 전체 회의가 있습니다.\\n\"}]}")
+    private String contentDelta;
+
+    @Schema(description = "공지 HTML 본문")
+    private String contentHtml;
+
     @Schema(description = "작성자 이름", example = "홍길동")
     private String authorName;
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/entity/Notice.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/entity/Notice.java
@@ -66,6 +66,21 @@ public class Notice {
     @Column(columnDefinition = "TEXT")
     private String content;
 
+    // Quill Delta 본문(JSON 문자열)
+    @Lob
+    @Column(name = "content_delta", columnDefinition = "TEXT")
+    private String contentDelta;
+
+    // HTML 본문
+    @Lob
+    @Column(name = "content_html", columnDefinition = "TEXT")
+    private String contentHtml;
+
+    // 본문 검색용 평문
+    @Lob
+    @Column(name = "content_text", columnDefinition = "TEXT")
+    private String contentText;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "author_id", nullable = false)
     @JsonBackReference
@@ -122,7 +137,7 @@ public class Notice {
         if (StringUtils.hasText(title)) {
             this.title = title;
         }
-        if (StringUtils.hasText(content)) {
+        if (content != null) {
             this.content = content;
         }
         if (pinned != null) {
@@ -134,6 +149,9 @@ public class Notice {
             NoticeType type,
             String title,
             String content,
+            String contentDelta,
+            String contentHtml,
+            String contentText,
             Boolean pinned,
             List<Company> targetCompanies,
             List<Long> targetDepartments,
@@ -144,8 +162,17 @@ public class Notice {
         if (StringUtils.hasText(title)) {
             this.title = title;
         }
-        if (StringUtils.hasText(content)) {
+        if (content != null) {
             this.content = content;
+        }
+        if (contentDelta != null) {
+            this.contentDelta = contentDelta;
+        }
+        if (contentHtml != null) {
+            this.contentHtml = contentHtml;
+        }
+        if (contentText != null) {
+            this.contentText = contentText;
         }
         if (pinned != null) {
             this.pinned = pinned;
@@ -158,6 +185,22 @@ public class Notice {
         }
         if (targetUsers != null) {
             this.targetUsers = new ArrayList<>(targetUsers);
+        }
+    }
+
+    public void updateEditorContent(
+            String content, String contentDelta, String contentHtml, String contentText) {
+        if (content != null) {
+            this.content = content;
+        }
+        if (contentDelta != null) {
+            this.contentDelta = contentDelta;
+        }
+        if (contentHtml != null) {
+            this.contentHtml = contentHtml;
+        }
+        if (contentText != null) {
+            this.contentText = contentText;
         }
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/mapper/NoticeMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/mapper/NoticeMapper.java
@@ -20,10 +20,16 @@ public interface NoticeMapper {
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "author", source = "author")
     @Mapping(target = "attachments", ignore = true)
+    @Mapping(target = "contentText", ignore = true)
+    @Mapping(target = "createdDate", ignore = true)
+    @Mapping(target = "updatedDate", ignore = true)
+    @Mapping(target = "viewCount", ignore = true)
     @Mapping(target = "targetDepartments", source = "dto.targetDepartmentIds")
     @Mapping(target = "targetUsers", source = "dto.targetUserIds")
     Notice toNoticeEntity(NoticeCreateRequestDto dto, User author);
 
+    @Mapping(target = "isPinned", source = "pinned")
+    @Mapping(target = "authorName", expression = "java(notice.getAuthor().getDisplayName())")
     NoticeSummaryDto toNoticeSummaryDto(Notice notice);
 
     List<NoticeSummaryDto> toNoticeSummaryDtoList(List<Notice> notices);

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/respository/NoticeQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/respository/NoticeQueryRepository.java
@@ -205,9 +205,12 @@ public class NoticeQueryRepository {
 
         return switch (type) {
             case TITLE -> n.title.contains(keyword);
-            case CONTENT -> n.content.contains(keyword);
+            case CONTENT -> n.contentText.contains(keyword).or(n.content.contains(keyword));
             case AUTHOR -> author.nameKor.contains(keyword);
-            default -> n.title.contains(keyword).or(n.content.contains(keyword));
+            default ->
+                    n.title.contains(keyword)
+                            .or(n.contentText.contains(keyword))
+                            .or(n.content.contains(keyword));
         };
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/respository/NoticeQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/respository/NoticeQueryRepository.java
@@ -207,10 +207,10 @@ public class NoticeQueryRepository {
             case TITLE -> n.title.contains(keyword);
             case CONTENT -> n.contentText.contains(keyword).or(n.content.contains(keyword));
             case AUTHOR -> author.nameKor.contains(keyword);
-            default ->
-                    n.title.contains(keyword)
-                            .or(n.contentText.contains(keyword))
-                            .or(n.content.contains(keyword));
+            default -> n.title
+                    .contains(keyword)
+                    .or(n.contentText.contains(keyword))
+                    .or(n.content.contains(keyword));
         };
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/service/NoticeService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/service/NoticeService.java
@@ -340,11 +340,15 @@ public class NoticeService {
 
         String contentText =
                 resolveSearchableText(requestContentDelta, requestContentHtml, content, null);
-        return new NoticeContentFields(content, requestContentDelta, requestContentHtml, contentText);
+        return new NoticeContentFields(
+                content, requestContentDelta, requestContentHtml, contentText);
     }
 
     private NoticeContentFields resolveUpdateContentFields(
-            Notice notice, String requestContent, String requestContentDelta, String requestContentHtml) {
+            Notice notice,
+            String requestContent,
+            String requestContentDelta,
+            String requestContentHtml) {
         String resolvedContentDelta =
                 requestContentDelta != null ? requestContentDelta : notice.getContentDelta();
         String resolvedContentHtml =

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/service/NoticeService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/service/NoticeService.java
@@ -1,5 +1,8 @@
 package kr.co.awesomelead.groupware_backend.domain.notice.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import kr.co.awesomelead.groupware_backend.domain.department.dto.response.UserSummaryResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.department.service.DepartmentService;
@@ -30,6 +33,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -40,6 +44,8 @@ import java.util.Set;
 @Service
 @RequiredArgsConstructor
 public class NoticeService {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final NoticeRepository noticeRepository;
     private final NoticeQueryRepository noticeQueryRepository;
@@ -70,6 +76,16 @@ public class NoticeService {
         User author = validateAndGetAuthor(userId);
 
         Notice notice = noticeMapper.toNoticeEntity(requestDto, author);
+        NoticeContentFields contentFields =
+                resolveCreateContentFields(
+                        requestDto.getContent(),
+                        requestDto.getContentDelta(),
+                        requestDto.getContentHtml());
+        notice.updateEditorContent(
+                contentFields.content(),
+                contentFields.contentDelta(),
+                contentFields.contentHtml(),
+                contentFields.contentText());
         noticeRepository.save(notice);
 
         Set<Long> finalTargetUserIds = new HashSet<>();
@@ -196,10 +212,17 @@ public class NoticeService {
                         .findByIdWithDetails(noticeId)
                         .orElseThrow(() -> new CustomException(ErrorCode.NOTICE_NOT_FOUND));
 
+        NoticeContentFields contentFields =
+                resolveUpdateContentFields(
+                        notice, dto.getContent(), dto.getContentDelta(), dto.getContentHtml());
+
         notice.update(
                 dto.getType(),
                 dto.getTitle(),
-                dto.getContent(),
+                contentFields.content(),
+                contentFields.contentDelta(),
+                contentFields.contentHtml(),
+                contentFields.contentText(),
                 dto.getPinned(),
                 dto.getTargetCompanies(),
                 dto.getTargetDepartmentIds(),
@@ -303,6 +326,140 @@ public class NoticeService {
             throw new CustomException(ErrorCode.NOTICE_TARGET_REQUIRED);
         }
     }
+
+    private NoticeContentFields resolveCreateContentFields(
+            String requestContent, String requestContentDelta, String requestContentHtml) {
+        String content = requestContent;
+        if (content == null) {
+            if (StringUtils.hasText(requestContentHtml)) {
+                content = requestContentHtml;
+            } else if (StringUtils.hasText(requestContentDelta)) {
+                content = extractPlainTextFromDelta(requestContentDelta);
+            }
+        }
+
+        String contentText =
+                resolveSearchableText(requestContentDelta, requestContentHtml, content, null);
+        return new NoticeContentFields(content, requestContentDelta, requestContentHtml, contentText);
+    }
+
+    private NoticeContentFields resolveUpdateContentFields(
+            Notice notice, String requestContent, String requestContentDelta, String requestContentHtml) {
+        String resolvedContentDelta =
+                requestContentDelta != null ? requestContentDelta : notice.getContentDelta();
+        String resolvedContentHtml =
+                requestContentHtml != null ? requestContentHtml : notice.getContentHtml();
+
+        String resolvedContent;
+        if (requestContent != null) {
+            resolvedContent = requestContent;
+        } else if (requestContentHtml != null) {
+            resolvedContent = requestContentHtml;
+        } else if (requestContentDelta != null) {
+            resolvedContent = extractPlainTextFromDelta(requestContentDelta);
+        } else {
+            resolvedContent = notice.getContent();
+        }
+
+        String resolvedContentText =
+                resolveSearchableText(
+                        resolvedContentDelta,
+                        resolvedContentHtml,
+                        resolvedContent,
+                        notice.getContentText());
+
+        return new NoticeContentFields(
+                resolvedContent, resolvedContentDelta, resolvedContentHtml, resolvedContentText);
+    }
+
+    private String resolveSearchableText(
+            String contentDelta, String contentHtml, String content, String fallbackContentText) {
+        String deltaText = extractPlainTextFromDelta(contentDelta);
+        if (StringUtils.hasText(deltaText)) {
+            return deltaText;
+        }
+
+        String htmlText = extractPlainTextFromHtml(contentHtml);
+        if (StringUtils.hasText(htmlText)) {
+            return htmlText;
+        }
+
+        String contentText = extractPlainTextFromHtml(content);
+        if (StringUtils.hasText(contentText)) {
+            return contentText;
+        }
+
+        if (StringUtils.hasText(content)) {
+            return content.trim();
+        }
+
+        if (StringUtils.hasText(fallbackContentText)) {
+            return fallbackContentText;
+        }
+        return "";
+    }
+
+    private String extractPlainTextFromDelta(String contentDelta) {
+        if (!StringUtils.hasText(contentDelta)) {
+            return "";
+        }
+
+        try {
+            JsonNode root = OBJECT_MAPPER.readTree(contentDelta);
+            JsonNode ops = root.path("ops");
+            if (!ops.isArray()) {
+                return "";
+            }
+
+            StringBuilder plain = new StringBuilder();
+            for (JsonNode op : ops) {
+                JsonNode insert = op.get("insert");
+                if (insert == null) {
+                    continue;
+                }
+                if (insert.isTextual()) {
+                    plain.append(insert.asText());
+                } else if (insert.isObject() && insert.has("image")) {
+                    plain.append(' ');
+                }
+            }
+            return normalizeWhitespace(plain.toString());
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    private String extractPlainTextFromHtml(String html) {
+        if (!StringUtils.hasText(html)) {
+            return "";
+        }
+        String text =
+                html.replaceAll("(?is)<script[^>]*>.*?</script>", " ")
+                        .replaceAll("(?is)<style[^>]*>.*?</style>", " ")
+                        .replaceAll("(?is)<br\\s*/?>", "\n")
+                        .replaceAll("(?is)</p>", "\n")
+                        .replaceAll("(?is)</tr>", "\n")
+                        .replaceAll("(?is)<[^>]+>", " ")
+                        .replace("&nbsp;", " ")
+                        .replace("&amp;", "&")
+                        .replace("&lt;", "<")
+                        .replace("&gt;", ">");
+        return normalizeWhitespace(text);
+    }
+
+    private String normalizeWhitespace(String text) {
+        if (!StringUtils.hasText(text)) {
+            return "";
+        }
+        return text.replace('\u00A0', ' ')
+                .replaceAll("[\\t\\x0B\\f\\r ]+", " ")
+                .replaceAll(" *\\n *", "\n")
+                .replaceAll("\\n{3,}", "\n\n")
+                .trim();
+    }
+
+    private record NoticeContentFields(
+            String content, String contentDelta, String contentHtml, String contentText) {}
 
     private void uploadFiles(List<MultipartFile> files, Notice notice) throws IOException {
         if (files != null && !files.isEmpty()) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/controller/PayslipController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/controller/PayslipController.java
@@ -53,8 +53,7 @@ public class PayslipController {
 
     @Operation(
             summary = "급여명세서 일괄 발송 (관리자)",
-            description =
-                    "관리자가 다수의 PDF 파일을 업로드하여 발송합니다. 파일명 형식: '성명_생년월일_급여명세서.pdf'")
+            description = "관리자가 다수의 PDF 파일을 업로드하여 발송합니다. 파일명 형식: '성명_생년월일_급여명세서.pdf'")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/controller/PayslipController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/controller/PayslipController.java
@@ -53,7 +53,8 @@ public class PayslipController {
 
     @Operation(
             summary = "급여명세서 일괄 발송 (관리자)",
-            description = "관리자가 다수의 PDF 파일을 업로드하여 발송합니다. 파일명 형식: '성명_입사일_급여명세서.pdf'")
+            description =
+                    "관리자가 다수의 PDF 파일을 업로드하여 발송합니다. 파일명 형식: '성명_생년월일_급여명세서.pdf'")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/service/PayslipService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/service/PayslipService.java
@@ -61,18 +61,18 @@ public class PayslipService {
             }
 
             String fileName =
-                    file.getOriginalFilename(); // 파일명은 "name_yyyyMMdd_급여명세서.ext" 형식으로 고정된 것으로 가정
+                    file.getOriginalFilename(); // 파일명은 "name_yyyyMMdd_급여명세서.ext" (생년월일) 형식으로 고정
             String[] split = fileName.split("_");
 
             String name = split[0].trim();
             String normalizedName = Normalizer.normalize(name, Normalizer.Form.NFC);
-            String hireDateStr = split[1];
-            LocalDate hireDate =
-                    LocalDate.parse(hireDateStr, DateTimeFormatter.ofPattern("yyyyMMdd"));
+            String birthDateStr = split[1];
+            LocalDate birthDate =
+                    LocalDate.parse(birthDateStr, DateTimeFormatter.ofPattern("yyyyMMdd"));
 
             User target =
                     userRepository
-                            .findByNameAndJoinDate(normalizedName, hireDate)
+                            .findByNameAndBirthDate(normalizedName, birthDate)
                             .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
             String s3Key = s3Service.uploadFile(file);

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/UserRepository.java
@@ -40,6 +40,12 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByNameAndJoinDate(
             @Param("name") String name, @Param("joinDate") LocalDate joinDate);
 
+    @Query(
+            "SELECT u FROM User u WHERE (u.nameKor = :name OR u.nameEng = :name) AND u.birthDate ="
+                    + " :birthDate")
+    Optional<User> findByNameAndBirthDate(
+            @Param("name") String name, @Param("birthDate") LocalDate birthDate);
+
     boolean existsByPhoneNumberHash(String phoneNumberHash);
 
     List<User> findAllByRole(Role role);

--- a/src/main/java/kr/co/awesomelead/groupware_backend/test/controller/TestController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/test/controller/TestController.java
@@ -6,7 +6,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.FindEmailRequestDto;
+import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.SignupRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.response.FindEmailResponseDto;
+import kr.co.awesomelead.groupware_backend.domain.auth.dto.response.SignupResponseDto;
 import kr.co.awesomelead.groupware_backend.global.common.response.ApiResponse;
 import kr.co.awesomelead.groupware_backend.test.dto.request.DummyUsersCreateRequestDto;
 import kr.co.awesomelead.groupware_backend.test.dto.response.DummyUsersCreateResponseDto;
@@ -70,6 +72,14 @@ public class TestController {
     public ResponseEntity<ApiResponse<DummyUsersCreateResponseDto>> createDummyUsers(
             @Valid @RequestBody DummyUsersCreateRequestDto request) {
         DummyUsersCreateResponseDto result = testService.createDummyUsers(request);
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
+    }
+
+    @Operation(summary = "[테스트] 인증 우회 회원가입", description = "전화번호/이메일 인증 없이 테스트용 계정을 생성합니다.")
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<SignupResponseDto>> signupWithoutVerification(
+            @Valid @RequestBody SignupRequestDto requestDto) {
+        SignupResponseDto result = testService.signupWithoutVerification(requestDto);
         return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/test/service/TestService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/test/service/TestService.java
@@ -1,5 +1,8 @@
 package kr.co.awesomelead.groupware_backend.test.service;
 
+import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.SignupRequestDto;
+import kr.co.awesomelead.groupware_backend.domain.auth.dto.response.SignupResponseDto;
+import kr.co.awesomelead.groupware_backend.domain.auth.service.AuthService;
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.response.FindEmailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.department.entity.Department;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
@@ -30,6 +33,7 @@ public class TestService {
     private final UserRepository userRepository;
     private final DepartmentRepository departmentRepository;
     private final BCryptPasswordEncoder passwordEncoder;
+    private final AuthService authService;
 
     // 테스트용 (인증 없음)
 
@@ -149,5 +153,9 @@ public class TestService {
         }
 
         return new DummyUsersCreateResponseDto(requested, created, skipped);
+    }
+
+    public SignupResponseDto signupWithoutVerification(SignupRequestDto requestDto) {
+        return authService.signupWithoutVerification(requestDto);
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/test/service/TestService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/test/service/TestService.java
@@ -1,9 +1,9 @@
 package kr.co.awesomelead.groupware_backend.test.service;
 
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.request.SignupRequestDto;
+import kr.co.awesomelead.groupware_backend.domain.auth.dto.response.FindEmailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.auth.dto.response.SignupResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.auth.service.AuthService;
-import kr.co.awesomelead.groupware_backend.domain.auth.dto.response.FindEmailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.department.entity.Department;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.department.repository.DepartmentRepository;

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
@@ -225,6 +225,85 @@ class AuthServiceTest {
     }
 
     @Test
+    @DisplayName("[테스트용] 인증 우회 회원가입 성공 테스트")
+    void signupWithoutVerification_Success() {
+        // given
+        SignupRequestDto signupDto = new SignupRequestDto();
+        signupDto.setEmail("test-no-verify@example.com");
+        signupDto.setPassword("password123!");
+        signupDto.setPasswordConfirm("password123!");
+        signupDto.setNameKor("김테스트");
+        signupDto.setNameEng("Test Kim");
+        signupDto.setNationality("대한민국");
+        signupDto.setZipcode("06234");
+        signupDto.setAddress1("서울특별시 강남구 테헤란로 123");
+        signupDto.setAddress2("테스트빌딩 5층");
+        signupDto.setRegistrationNumber("9601011234567");
+        signupDto.setPhoneNumber("01098765432");
+        signupDto.setCompany(Company.AWESOME);
+
+        User mockUser =
+                User.builder()
+                        .email(signupDto.getEmail())
+                        .nameKor(signupDto.getNameKor())
+                        .nameEng(signupDto.getNameEng())
+                        .nationality(signupDto.getNationality())
+                        .zipcode(signupDto.getZipcode())
+                        .address1(signupDto.getAddress1())
+                        .address2(signupDto.getAddress2())
+                        .registrationNumber(signupDto.getRegistrationNumber())
+                        .phoneNumber(signupDto.getPhoneNumber())
+                        .workLocation(Company.AWESOME)
+                        .role(Role.USER)
+                        .status(Status.PENDING)
+                        .build();
+        mockUser.onPrePersist();
+
+        User savedMockUser =
+                User.builder()
+                        .id(2L)
+                        .email(signupDto.getEmail())
+                        .nameKor(signupDto.getNameKor())
+                        .nameEng(signupDto.getNameEng())
+                        .nationality(signupDto.getNationality())
+                        .zipcode(signupDto.getZipcode())
+                        .address1(signupDto.getAddress1())
+                        .address2(signupDto.getAddress2())
+                        .registrationNumber(signupDto.getRegistrationNumber())
+                        .phoneNumber(signupDto.getPhoneNumber())
+                        .password("encodedPassword")
+                        .workLocation(Company.AWESOME)
+                        .role(Role.USER)
+                        .status(Status.PENDING)
+                        .birthDate(LocalDate.of(1996, 1, 1))
+                        .phoneNumberHash(User.hashValue(signupDto.getPhoneNumber()))
+                        .build();
+
+        when(userRepository.existsByEmail(signupDto.getEmail())).thenReturn(false);
+        when(userRepository.existsByRegistrationNumber(signupDto.getRegistrationNumber()))
+                .thenReturn(false);
+        when(userMapper.toEntity(signupDto)).thenReturn(mockUser);
+        when(bCryptPasswordEncoder.encode(signupDto.getPassword())).thenReturn("encodedPassword");
+        when(userRepository.save(any(User.class))).thenReturn(savedMockUser);
+
+        // when
+        SignupResponseDto result = authService.signupWithoutVerification(signupDto);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getUserId()).isEqualTo(2L);
+        assertThat(result.getEmail()).isEqualTo(signupDto.getEmail());
+
+        verify(phoneAuthService, never()).isPhoneVerified(anyString());
+        verify(emailAuthService, never()).isEmailVerified(anyString());
+        verify(emailAuthService, never()).clearVerification(anyString());
+        verify(phoneAuthService, never()).clearVerification(anyString());
+        verify(userRepository, times(1)).save(any(User.class));
+        verify(notificationService, times(1))
+                .sendAlertToAdminsRequiringApproval(any(), any(), any(), any(Map.class), any());
+    }
+
+    @Test
     @DisplayName("회원가입 실패 테스트 - 비밀번호 불일치")
     void signup_Fail_PasswordMismatch() {
         // given

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
@@ -773,18 +773,21 @@ public class EduReportServiceTest {
                         .build();
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-        when(eduReportQueryRepository.findPsmEduReports(null, 1L, null, true, null))
+        when(eduReportQueryRepository.findPsmEduReports(
+                        null, 1L, null, true, null, null, null))
                 .thenReturn(List.of(psmReport));
 
         // when
-        List<EduReportSummaryDto> result = eduReportService.getPsmEduReports(null, 1L, null);
+        List<EduReportSummaryDto> result =
+                eduReportService.getPsmEduReports(null, null, null, 1L, null);
 
         // then
         assertThat(result).isNotNull();
         assertThat(result.size()).isEqualTo(1);
         assertThat(result.get(0).getEduType()).isEqualTo(EduType.PSM);
         assertThat(result.get(0).getCompanyScope()).isEqualTo(List.of("AWESOME", "MARUI"));
-        verify(eduReportQueryRepository, times(1)).findPsmEduReports(null, 1L, null, true, null);
+        verify(eduReportQueryRepository, times(1))
+                .findPsmEduReports(null, 1L, null, true, null, null, null);
     }
 
     @Test
@@ -802,18 +805,38 @@ public class EduReportServiceTest {
                         .company(Company.AWESOME)
                         .build();
 
-        when(eduReportQueryRepository.findPsmEduReports(null, 1L, Company.AWESOME, false, null))
+        when(eduReportQueryRepository.findPsmEduReports(
+                        null, 1L, Company.AWESOME, false, null, null, null))
                 .thenReturn(List.of(psmReport));
 
         // when
-        List<EduReportSummaryDto> result = eduReportService.getPsmEduReports(null, 1L, null);
+        List<EduReportSummaryDto> result =
+                eduReportService.getPsmEduReports(null, null, null, 1L, null);
 
         // then
         assertThat(result).isNotNull();
         assertThat(result.size()).isEqualTo(1);
         assertThat(result.get(0).getCompanyScope()).isEqualTo(List.of("AWESOME"));
         verify(eduReportQueryRepository, times(1))
-                .findPsmEduReports(null, 1L, Company.AWESOME, false, null);
+                .findPsmEduReports(null, 1L, Company.AWESOME, false, null, null, null);
+    }
+
+    @Test
+    @DisplayName("PSM 게시물 목록 조회 - MANAGE_PSM 권한 없고 타 회사 필터면 빈 목록")
+    void getPsmEduReports_WithoutManagePsm_FilterOtherCompany_ReturnsEmpty() {
+        // given
+        User user = createNormalUser(); // workLocation=AWESOME
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        // when
+        List<EduReportSummaryDto> result =
+                eduReportService.getPsmEduReports(null, Company.MARUI, null, 1L, "변경");
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.size()).isEqualTo(0);
+        verify(eduReportQueryRepository, never())
+                .findPsmEduReports(any(), anyLong(), any(), anyBoolean(), any(), any(), any());
     }
 
     @Test

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
@@ -832,18 +832,21 @@ public class EduReportServiceTest {
                         .build();
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-        when(eduReportQueryRepository.findSafetyEduReports(null, 1L, null, true, null))
+        when(eduReportQueryRepository.findSafetyEduReports(
+                        null, 1L, null, true, null, null, null))
                 .thenReturn(List.of(safetyReport));
 
         // when
-        List<EduReportSummaryDto> result = eduReportService.getSafetyEduReports(null, 1L, null);
+        List<EduReportSummaryDto> result =
+                eduReportService.getSafetyEduReports(null, null, null, 1L, null);
 
         // then
         assertThat(result).isNotNull();
         assertThat(result.size()).isEqualTo(1);
         assertThat(result.get(0).getEduType()).isEqualTo(EduType.SAFETY);
         assertThat(result.get(0).getCompanyScope()).isEqualTo(List.of("AWESOME", "MARUI"));
-        verify(eduReportQueryRepository, times(1)).findSafetyEduReports(null, 1L, null, true, null);
+        verify(eduReportQueryRepository, times(1))
+                .findSafetyEduReports(null, 1L, null, true, null, null, null);
     }
 
     @Test
@@ -861,18 +864,38 @@ public class EduReportServiceTest {
                         .company(Company.AWESOME)
                         .build();
 
-        when(eduReportQueryRepository.findSafetyEduReports(null, 1L, Company.AWESOME, false, null))
+        when(eduReportQueryRepository.findSafetyEduReports(
+                        null, 1L, Company.AWESOME, false, null, null, null))
                 .thenReturn(List.of(safetyReport));
 
         // when
-        List<EduReportSummaryDto> result = eduReportService.getSafetyEduReports(null, 1L, null);
+        List<EduReportSummaryDto> result =
+                eduReportService.getSafetyEduReports(null, null, null, 1L, null);
 
         // then
         assertThat(result).isNotNull();
         assertThat(result.size()).isEqualTo(1);
         assertThat(result.get(0).getCompanyScope()).isEqualTo(List.of("AWESOME"));
         verify(eduReportQueryRepository, times(1))
-                .findSafetyEduReports(null, 1L, Company.AWESOME, false, null);
+                .findSafetyEduReports(null, 1L, Company.AWESOME, false, null, null, null);
+    }
+
+    @Test
+    @DisplayName("안전 보건 게시물 목록 조회 - MANAGE_SAFETY 권한 없고 타 회사 필터면 빈 목록")
+    void getSafetyEduReports_WithoutManageSafety_FilterOtherCompany_ReturnsEmpty() {
+        // given
+        User user = createNormalUser(); // workLocation=AWESOME
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        // when
+        List<EduReportSummaryDto> result =
+                eduReportService.getSafetyEduReports(null, Company.MARUI, null, 1L, "정기");
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.size()).isEqualTo(0);
+        verify(eduReportQueryRepository, never())
+                .findSafetyEduReports(any(), anyLong(), any(), anyBoolean(), any(), any(), any());
     }
 
     @Test

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
@@ -773,8 +773,7 @@ public class EduReportServiceTest {
                         .build();
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-        when(eduReportQueryRepository.findPsmEduReports(
-                        null, 1L, null, true, null, null, null))
+        when(eduReportQueryRepository.findPsmEduReports(null, 1L, null, true, null, null, null))
                 .thenReturn(List.of(psmReport));
 
         // when
@@ -855,8 +854,7 @@ public class EduReportServiceTest {
                         .build();
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-        when(eduReportQueryRepository.findSafetyEduReports(
-                        null, 1L, null, true, null, null, null))
+        when(eduReportQueryRepository.findSafetyEduReports(null, 1L, null, true, null, null, null))
                 .thenReturn(List.of(safetyReport));
 
         // when

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipServiceTest.java
@@ -118,11 +118,11 @@ public class PayslipServiceTest {
                 MockMultipartFile pdfFile =
                         new MockMultipartFile(
                                 "payslipFiles",
-                                "홍길동_20240101_급여명세서.pdf",
+                                "홍길동_19900101_급여명세서.pdf",
                                 "application/pdf",
                                 "pdf content".getBytes());
 
-                given(userRepository.findByNameAndJoinDate("홍길동", LocalDate.of(2024, 1, 1)))
+                given(userRepository.findByNameAndBirthDate("홍길동", LocalDate.of(1990, 1, 1)))
                         .willReturn(Optional.of(employee));
                 given(s3Service.uploadFile(pdfFile)).willReturn("s3-key");
                 Payslip savedPayslip = Payslip.builder().id(99L).user(employee).build();


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #400 

## 📝작업 내용
- 공지사항 본문 구조를 에디터 기반으로 확장
- contentDelta/contentHtml 저장 지원 및 검색용 contentText 확장
- 부서교육 목록 조회에 제목 검색 복원 + 부서/진행상태 복합 필터 반영
- 안전보건/PSM 목록 조회에 대상회사/상태 필터 추가 및 제목 검색 동시 지원
- 급여명세서 수신자 매핑 기준을 이름/생년월일로 변경
- 테스트용 인증 우회 회원가입 API(/api/test/signup) 추가

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X