### PR TITLE
fix(412): 급여명세서 관리 기능 고도화 및 직원 목록 근무사업장 확장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,7 @@ dependencies {
     // Apache POI 엑셀
     implementation 'org.apache.poi:poi:5.2.5'
     implementation 'org.apache.poi:poi-ooxml:5.2.5'
+    implementation 'org.apache.pdfbox:pdfbox:2.0.32'
 
     // Spring Retry
     implementation 'org.springframework.retry:spring-retry'

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
@@ -92,6 +92,7 @@ public class AdminController {
                                               "nameKor": "홍길동",
                                               "position": "사원",
                                               "jobType": "관리직",
+                                              "workLocation": "어썸리드",
                                               "departmentName": "경영지원부",
                                               "signupStatus": "AVAILABLE",
                                               "hasPendingMyInfoRequest": true

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/dto/response/AdminUserSummaryResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/dto/response/AdminUserSummaryResponseDto.java
@@ -2,6 +2,7 @@ package kr.co.awesomelead.groupware_backend.domain.admin.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.JobType;
@@ -30,6 +31,9 @@ public class AdminUserSummaryResponseDto {
     @Schema(description = "근무직종")
     private JobType jobType;
 
+    @Schema(description = "근무사업장")
+    private Company workLocation;
+
     @Schema(description = "부서명")
     private DepartmentName departmentName;
 
@@ -51,6 +55,7 @@ public class AdminUserSummaryResponseDto {
                 .nameKor(user.getNameKor())
                 .position(user.getPosition())
                 .jobType(user.getJobType())
+                .workLocation(user.getWorkLocation())
                 .departmentName(
                         user.getDepartment() != null ? user.getDepartment().getName() : null)
                 .signupStatus(user.getStatus())

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/controller/PayslipController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/controller/PayslipController.java
@@ -22,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -170,6 +171,28 @@ public class PayslipController {
 
         payslipService.updatePayslip(payslipId, payslipFile, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onNoContent("급여명세서가 성공적으로 수정되었습니다."));
+    }
+
+    @Operation(summary = "보낸 명세서 삭제 (관리자)", description = "관리자가 특정 급여명세서를 삭제합니다.")
+    @ApiResponses(
+        value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "삭제 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "명세서 없음")
+        })
+    @DeleteMapping("/admin/{payslipId}")
+    public ResponseEntity<ApiResponse<Void>> deletePayslip(
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+        @Parameter(description = "명세서 ID", example = "1") @PathVariable Long payslipId) {
+
+        payslipService.deletePayslip(payslipId, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onNoContent("급여명세서가 성공적으로 삭제되었습니다."));
     }
 
     @Operation(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/controller/PayslipController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/controller/PayslipController.java
@@ -146,7 +146,7 @@ public class PayslipController {
     }
 
     @Operation(
-            summary = "보낸 명세서 월별 그룹 조회 (관리자)",
+            summary = "보낸 명세서 목록 조회",
             description = "관리자가 상태별로 발송한 명세서를 급여지급월(YYYYMM) 기준으로 그룹 조회합니다.")
     @ApiResponses(
             value = {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/controller/PayslipController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/controller/PayslipController.java
@@ -11,6 +11,7 @@ import jakarta.validation.Valid;
 
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.request.PayslipViewPasswordRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.AdminPayslipDetailDto;
+import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.AdminPayslipGroupDto;
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.AdminPayslipSummaryDto;
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.EmployeePayslipDetailDto;
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.EmployeePayslipSummaryDto;
@@ -178,6 +179,30 @@ public class PayslipController {
 
         List<AdminPayslipSummaryDto> response =
                 payslipService.getPayslipsForAdmin(userDetails.getId(), status);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @Operation(
+            summary = "보낸 명세서 월별 그룹 조회 (관리자)",
+            description = "관리자가 상태별로 발송한 명세서를 급여지급월(YYYYMM) 기준으로 그룹 조회합니다.")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "조회 성공"),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "401",
+                        description = "권한 없음")
+            })
+    @GetMapping("/admin/grouped")
+    public ResponseEntity<ApiResponse<List<AdminPayslipGroupDto>>> getPayslipsForAdminGrouped(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "명세서 상태 (생략 시 전체 조회)", example = "SENT")
+                    @RequestParam(required = false)
+                    PayslipStatus status) {
+
+        List<AdminPayslipGroupDto> response =
+                payslipService.getPayslipsForAdminGrouped(userDetails.getId(), status);
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/controller/PayslipController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/controller/PayslipController.java
@@ -25,6 +25,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -138,6 +139,37 @@ public class PayslipController {
 
         payslipService.sendPayslip(payslipFiles, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onNoContent("급여명세서가 성공적으로 발송되었습니다."));
+    }
+
+    @Operation(
+        summary = "보낸 명세서 수정 (관리자)",
+        description = "관리자가 특정 급여명세서를 새로운 PDF로 교체합니다.")
+    @ApiResponses(
+        value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "수정 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "400",
+                description = "잘못된 파일 형식"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "명세서 없음")
+        })
+    @PutMapping(value = "/admin/{payslipId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Void>> updatePayslip(
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+        @Parameter(description = "명세서 ID", example = "1") @PathVariable Long payslipId,
+        @Parameter(description = "교체할 급여명세서 PDF", required = true)
+        @RequestPart("payslipFile")
+        MultipartFile payslipFile)
+        throws IOException {
+
+        payslipService.updatePayslip(payslipId, payslipFile, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onNoContent("급여명세서가 성공적으로 수정되었습니다."));
     }
 
     @Operation(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/controller/PayslipController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/controller/PayslipController.java
@@ -7,6 +7,9 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+import jakarta.validation.Valid;
+
+import kr.co.awesomelead.groupware_backend.domain.payslip.dto.request.PayslipViewPasswordRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.AdminPayslipDetailDto;
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.AdminPayslipSummaryDto;
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.EmployeePayslipDetailDto;
@@ -25,6 +28,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -243,12 +247,31 @@ public class PayslipController {
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
-    @Operation(summary = "내 명세서 상세 조회 (직원)", description = "직원이 특정 급여명세서의 상세 내용을 확인합니다.")
+    @Operation(
+            summary = "내 명세서 상세 조회 (직원)",
+            description = "직원이 로그인 비밀번호를 입력한 뒤 특정 급여명세서의 상세 내용을 확인합니다.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
                         responseCode = "200",
                         description = "조회 성공"),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "400",
+                        description = "비밀번호 불일치",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
+                                {
+                                "isSuccess": false,
+                                "code": "PASSWORD_MISMATCH",
+                                "message": "비밀번호가 일치하지 않습니다.",
+                                "result": null
+                                }
+                                """))),
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
                         responseCode = "401",
                         description = "접근 권한 없음",
@@ -284,13 +307,14 @@ public class PayslipController {
                                 }
                                 """)))
             })
-    @GetMapping("/me/{payslipId}")
+    @PostMapping("/me/{payslipId}")
     public ResponseEntity<ApiResponse<EmployeePayslipDetailDto>> getMyPayslipDetail(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
-            @Parameter(description = "명세서 ID", example = "1") @PathVariable Long payslipId) {
+            @Parameter(description = "명세서 ID", example = "1") @PathVariable Long payslipId,
+            @Valid @RequestBody PayslipViewPasswordRequestDto requestDto) {
 
         EmployeePayslipDetailDto response =
-                payslipService.getPayslip(userDetails.getId(), payslipId);
+                payslipService.getPayslip(userDetails.getId(), payslipId, requestDto.getPassword());
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/controller/PayslipController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/controller/PayslipController.java
@@ -6,9 +6,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
 import jakarta.validation.Valid;
-import java.io.IOException;
-import java.util.List;
+
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.request.PayslipViewPasswordRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.AdminPayslipDetailDto;
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.AdminPayslipGroupDto;
@@ -18,7 +18,9 @@ import kr.co.awesomelead.groupware_backend.domain.payslip.enums.PayslipStatus;
 import kr.co.awesomelead.groupware_backend.domain.payslip.service.PayslipService;
 import kr.co.awesomelead.groupware_backend.domain.user.dto.CustomUserDetails;
 import kr.co.awesomelead.groupware_backend.global.common.response.ApiResponse;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -34,17 +36,20 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/payslips")
 @RequiredArgsConstructor
 @Tag(
-    name = "Payslip",
-    description =
-        """
+        name = "Payslip",
+        description =
+                """
             ## 급여명세서 관리 API
-            
+
             관리자의 급여명세서 일괄 발송, 목록 조회 및 직원의 명세서 열람 기능을 수행합니다.
-            
+
             ### 사용되는 Enum 타입
             - **PayslipStatus**: 명세서 상태 (SENT: 발송 완료, READ: 열람 완료)
             """)
@@ -53,22 +58,22 @@ public class PayslipController {
     private final PayslipService payslipService;
 
     @Operation(
-        summary = "급여명세서 일괄 발송 (관리자)",
-        description =
-            "관리자가 다수의 PDF 파일을 업로드하여 발송합니다. 파일명 형식:"
-                + " '급여명세서(근로기준1)_더존직원코드_직원명_급여지급월.pdf'")
+            summary = "급여명세서 일괄 발송 (관리자)",
+            description =
+                    "관리자가 다수의 PDF 파일을 업로드하여 발송합니다. 파일명 형식:"
+                            + " '급여명세서(근로기준1)_더존직원코드_직원명_급여지급월.pdf'")
     @ApiResponses(
-        value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "발송 성공",
-                content =
-                @Content(
-                    mediaType = "application/json",
-                    examples =
-                    @ExampleObject(
-                        value =
-                            """
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "발송 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                 {
                                 "isSuccess": true,
                                 "code": "COMMON204",
@@ -76,17 +81,17 @@ public class PayslipController {
                                 "result": null
                                 }
                                 """))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "400",
-                description = "잘못된 파일 형식",
-                content =
-                @Content(
-                    mediaType = "application/json",
-                    examples =
-                    @ExampleObject(
-                        name = "PDF 형식 위반",
-                        value =
-                            """
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "400",
+                        description = "잘못된 파일 형식",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        name = "PDF 형식 위반",
+                                                        value =
+                                                                """
                                 {
                                 "isSuccess": false,
                                 "code": "ONLY_PDF_ALLOWED",
@@ -94,17 +99,17 @@ public class PayslipController {
                                 "result": null
                                 }
                                 """))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "401",
-                description = "권한 없음",
-                content =
-                @Content(
-                    mediaType = "application/json",
-                    examples =
-                    @ExampleObject(
-                        name = "발송 권한 없음",
-                        value =
-                            """
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "401",
+                        description = "권한 없음",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        name = "발송 권한 없음",
+                                                        value =
+                                                                """
                                 {
                                 "isSuccess": false,
                                 "code": "NO_AUTHORITY_FOR_PAYSLIP",
@@ -112,17 +117,17 @@ public class PayslipController {
                                 "result": null
                                 }
                                 """))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "사용자 찾을 수 없음",
-                content =
-                @Content(
-                    mediaType = "application/json",
-                    examples =
-                    @ExampleObject(
-                        name = "대상자 없음",
-                        value =
-                            """
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "404",
+                        description = "사용자 찾을 수 없음",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        name = "대상자 없음",
+                                                        value =
+                                                                """
                                 {
                                 "isSuccess": false,
                                 "code": "USER_NOT_FOUND",
@@ -130,44 +135,41 @@ public class PayslipController {
                                 "result": null
                                 }
                                 """)))
-        })
+            })
     @PostMapping(value = "/send", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Void>> sendPayslips(
-        @Parameter(description = "급여명세서 PDF 파일들", required = true) @RequestPart("payslipFiles")
-        List<MultipartFile> payslipFiles,
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
-        throws IOException {
+            @Parameter(description = "급여명세서 PDF 파일들", required = true) @RequestPart("payslipFiles")
+                    List<MultipartFile> payslipFiles,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
+            throws IOException {
 
         payslipService.sendPayslip(payslipFiles, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onNoContent("급여명세서가 성공적으로 발송되었습니다."));
     }
 
-    @Operation(
-        summary = "보낸 명세서 수정 (관리자)",
-        description = "관리자가 특정 급여명세서를 새로운 PDF로 교체합니다.")
+    @Operation(summary = "보낸 명세서 수정 (관리자)", description = "관리자가 특정 급여명세서를 새로운 PDF로 교체합니다.")
     @ApiResponses(
-        value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "수정 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "400",
-                description = "잘못된 파일 형식"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "401",
-                description = "권한 없음"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "명세서 없음")
-        })
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "수정 성공"),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "400",
+                        description = "잘못된 파일 형식"),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "401",
+                        description = "권한 없음"),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "404",
+                        description = "명세서 없음")
+            })
     @PutMapping(value = "/admin/{payslipId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Void>> updatePayslip(
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
-        @Parameter(description = "명세서 ID", example = "1") @PathVariable Long payslipId,
-        @Parameter(description = "교체할 급여명세서 PDF", required = true)
-        @RequestPart("payslipFile")
-        MultipartFile payslipFile)
-        throws IOException {
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "명세서 ID", example = "1") @PathVariable Long payslipId,
+            @Parameter(description = "교체할 급여명세서 PDF", required = true) @RequestPart("payslipFile")
+                    MultipartFile payslipFile)
+            throws IOException {
 
         payslipService.updatePayslip(payslipId, payslipFile, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onNoContent("급여명세서가 성공적으로 수정되었습니다."));
@@ -175,66 +177,66 @@ public class PayslipController {
 
     @Operation(summary = "보낸 명세서 삭제 (관리자)", description = "관리자가 특정 급여명세서를 삭제합니다.")
     @ApiResponses(
-        value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "삭제 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "401",
-                description = "권한 없음"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "명세서 없음")
-        })
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "삭제 성공"),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "401",
+                        description = "권한 없음"),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "404",
+                        description = "명세서 없음")
+            })
     @DeleteMapping("/admin/{payslipId}")
     public ResponseEntity<ApiResponse<Void>> deletePayslip(
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
-        @Parameter(description = "명세서 ID", example = "1") @PathVariable Long payslipId) {
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "명세서 ID", example = "1") @PathVariable Long payslipId) {
 
         payslipService.deletePayslip(payslipId, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onNoContent("급여명세서가 성공적으로 삭제되었습니다."));
     }
 
     @Operation(
-        summary = "보낸 명세서 목록 조회 (관리자)",
-        description = "관리자가 상태별로 발송한 명세서를 급여지급월(YYYYMM) 기준으로 그룹 조회합니다.")
+            summary = "보낸 명세서 목록 조회 (관리자)",
+            description = "관리자가 상태별로 발송한 명세서를 급여지급월(YYYYMM) 기준으로 그룹 조회합니다.")
     @ApiResponses(
-        value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "조회 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "401",
-                description = "권한 없음")
-        })
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "조회 성공"),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "401",
+                        description = "권한 없음")
+            })
     @GetMapping("/admin")
     public ResponseEntity<ApiResponse<List<AdminPayslipGroupDto>>> getPayslipsForAdminGrouped(
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
-        @Parameter(description = "명세서 상태 (생략 시 전체 조회)", example = "SENT")
-        @RequestParam(required = false)
-        PayslipStatus status) {
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "명세서 상태 (생략 시 전체 조회)", example = "SENT")
+                    @RequestParam(required = false)
+                    PayslipStatus status) {
 
         List<AdminPayslipGroupDto> response =
-            payslipService.getPayslipsForAdminGrouped(userDetails.getId(), status);
+                payslipService.getPayslipsForAdminGrouped(userDetails.getId(), status);
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
     @Operation(summary = "보낸 명세서 상세 조회 (관리자)", description = "관리자가 특정 명세서의 상세 정보를 조회합니다.")
     @ApiResponses(
-        value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "조회 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "명세서 없음",
-                content =
-                @Content(
-                    mediaType = "application/json",
-                    examples =
-                    @ExampleObject(
-                        value =
-                            """
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "조회 성공"),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "404",
+                        description = "명세서 없음",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                 {
                                 "isSuccess": false,
                                 "code": "PAYSLIP_NOT_FOUND",
@@ -242,33 +244,33 @@ public class PayslipController {
                                 "result": null
                                 }
                                 """)))
-        })
+            })
     @GetMapping("/admin/{payslipId}")
     public ResponseEntity<ApiResponse<AdminPayslipDetailDto>> getPayslipDetailForAdmin(
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
-        @Parameter(description = "명세서 ID", example = "1") @PathVariable Long payslipId) {
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "명세서 ID", example = "1") @PathVariable Long payslipId) {
 
         AdminPayslipDetailDto response =
-            payslipService.getPayslipForAdmin(userDetails.getId(), payslipId);
+                payslipService.getPayslipForAdmin(userDetails.getId(), payslipId);
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
     @Operation(summary = "내 명세서 목록 조회 (직원)", description = "직원이 본인의 명세서 목록을 조회합니다.")
     @ApiResponses(
-        value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "조회 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "사용자 없음",
-                content =
-                @Content(
-                    mediaType = "application/json",
-                    examples =
-                    @ExampleObject(
-                        value =
-                            """
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "조회 성공"),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "404",
+                        description = "사용자 없음",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                 {
                                 "isSuccess": false,
                                 "code": "USER_NOT_FOUND",
@@ -276,33 +278,33 @@ public class PayslipController {
                                 "result": null
                                 }
                                 """)))
-        })
+            })
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<List<EmployeePayslipSummaryDto>>> getMyPayslips(
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         List<EmployeePayslipSummaryDto> response = payslipService.getPayslips(userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
     @Operation(
-        summary = "내 명세서 상세 조회 (직원)",
-        description = "직원이 로그인 비밀번호를 입력한 뒤 특정 급여명세서의 상세 내용을 확인합니다.")
+            summary = "내 명세서 상세 조회 (직원)",
+            description = "직원이 로그인 비밀번호를 입력한 뒤 특정 급여명세서의 상세 내용을 확인합니다.")
     @ApiResponses(
-        value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "조회 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "400",
-                description = "비밀번호 불일치",
-                content =
-                @Content(
-                    mediaType = "application/json",
-                    examples =
-                    @ExampleObject(
-                        value =
-                            """
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "조회 성공"),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "400",
+                        description = "비밀번호 불일치",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                 {
                                 "isSuccess": false,
                                 "code": "PASSWORD_MISMATCH",
@@ -310,16 +312,16 @@ public class PayslipController {
                                 "result": null
                                 }
                                 """))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "401",
-                description = "접근 권한 없음",
-                content =
-                @Content(
-                    mediaType = "application/json",
-                    examples =
-                    @ExampleObject(
-                        value =
-                            """
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "401",
+                        description = "접근 권한 없음",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                 {
                                 "isSuccess": false,
                                 "code": "NO_AUTHORITY_FOR_VIEW_PAYSLIP",
@@ -327,16 +329,16 @@ public class PayslipController {
                                 "result": null
                                 }
                                 """))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "404",
-                description = "명세서 없음",
-                content =
-                @Content(
-                    mediaType = "application/json",
-                    examples =
-                    @ExampleObject(
-                        value =
-                            """
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "404",
+                        description = "명세서 없음",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
                                 {
                                 "isSuccess": false,
                                 "code": "PAYSLIP_NOT_FOUND",
@@ -344,15 +346,15 @@ public class PayslipController {
                                 "result": null
                                 }
                                 """)))
-        })
+            })
     @PostMapping("/me/{payslipId}")
     public ResponseEntity<ApiResponse<EmployeePayslipDetailDto>> getMyPayslipDetail(
-        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
-        @Parameter(description = "명세서 ID", example = "1") @PathVariable Long payslipId,
-        @Valid @RequestBody PayslipViewPasswordRequestDto requestDto) {
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "명세서 ID", example = "1") @PathVariable Long payslipId,
+            @Valid @RequestBody PayslipViewPasswordRequestDto requestDto) {
 
         EmployeePayslipDetailDto response =
-            payslipService.getPayslip(userDetails.getId(), payslipId, requestDto.getPassword());
+                payslipService.getPayslip(userDetails.getId(), payslipId, requestDto.getPassword());
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/controller/PayslipController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/controller/PayslipController.java
@@ -12,7 +12,6 @@ import jakarta.validation.Valid;
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.request.PayslipViewPasswordRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.AdminPayslipDetailDto;
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.AdminPayslipGroupDto;
-import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.AdminPayslipSummaryDto;
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.EmployeePayslipDetailDto;
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.EmployeePayslipSummaryDto;
 import kr.co.awesomelead.groupware_backend.domain.payslip.enums.PayslipStatus;
@@ -146,42 +145,6 @@ public class PayslipController {
         return ResponseEntity.ok(ApiResponse.onNoContent("급여명세서가 성공적으로 발송되었습니다."));
     }
 
-    @Operation(summary = "보낸 명세서 목록 조회 (관리자)", description = "관리자가 상태별로 발송한 명세서 목록을 조회합니다.")
-    @ApiResponses(
-            value = {
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "200",
-                        description = "조회 성공"),
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "401",
-                        description = "권한 없음",
-                        content =
-                                @Content(
-                                        mediaType = "application/json",
-                                        examples =
-                                                @ExampleObject(
-                                                        value =
-                                                                """
-                                {
-                                "isSuccess": false,
-                                "code": "NO_AUTHORITY_FOR_PAYSLIP",
-                                "message": "급여명세서 발송 권한이 없습니다.",
-                                "result": null
-                                }
-                                """)))
-            })
-    @GetMapping("/admin")
-    public ResponseEntity<ApiResponse<List<AdminPayslipSummaryDto>>> getPayslipsForAdmin(
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
-            @Parameter(description = "명세서 상태 (생략 시 전체 조회)", example = "SENT")
-                    @RequestParam(required = false)
-                    PayslipStatus status) {
-
-        List<AdminPayslipSummaryDto> response =
-                payslipService.getPayslipsForAdmin(userDetails.getId(), status);
-        return ResponseEntity.ok(ApiResponse.onSuccess(response));
-    }
-
     @Operation(
             summary = "보낸 명세서 월별 그룹 조회 (관리자)",
             description = "관리자가 상태별로 발송한 명세서를 급여지급월(YYYYMM) 기준으로 그룹 조회합니다.")
@@ -194,7 +157,7 @@ public class PayslipController {
                         responseCode = "401",
                         description = "권한 없음")
             })
-    @GetMapping("/admin/grouped")
+    @GetMapping("/admin")
     public ResponseEntity<ApiResponse<List<AdminPayslipGroupDto>>> getPayslipsForAdminGrouped(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "명세서 상태 (생략 시 전체 조회)", example = "SENT")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/controller/PayslipController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/controller/PayslipController.java
@@ -6,9 +6,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-
 import jakarta.validation.Valid;
-
+import java.io.IOException;
+import java.util.List;
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.request.PayslipViewPasswordRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.AdminPayslipDetailDto;
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.AdminPayslipGroupDto;
@@ -18,36 +18,31 @@ import kr.co.awesomelead.groupware_backend.domain.payslip.enums.PayslipStatus;
 import kr.co.awesomelead.groupware_backend.domain.payslip.service.PayslipService;
 import kr.co.awesomelead.groupware_backend.domain.user.dto.CustomUserDetails;
 import kr.co.awesomelead.groupware_backend.global.common.response.ApiResponse;
-
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
-import java.util.List;
-
 @RestController
 @RequestMapping("/api/payslips")
 @RequiredArgsConstructor
 @Tag(
-        name = "Payslip",
-        description =
-                """
+    name = "Payslip",
+    description =
+        """
             ## 급여명세서 관리 API
-
+            
             관리자의 급여명세서 일괄 발송, 목록 조회 및 직원의 명세서 열람 기능을 수행합니다.
-
+            
             ### 사용되는 Enum 타입
             - **PayslipStatus**: 명세서 상태 (SENT: 발송 완료, READ: 열람 완료)
             """)
@@ -56,22 +51,22 @@ public class PayslipController {
     private final PayslipService payslipService;
 
     @Operation(
-            summary = "급여명세서 일괄 발송 (관리자)",
-            description =
-                    "관리자가 다수의 PDF 파일을 업로드하여 발송합니다. 파일명 형식:"
-                            + " '급여명세서(근로기준1)_더존직원코드_직원명_급여지급월.pdf'")
+        summary = "급여명세서 일괄 발송 (관리자)",
+        description =
+            "관리자가 다수의 PDF 파일을 업로드하여 발송합니다. 파일명 형식:"
+                + " '급여명세서(근로기준1)_더존직원코드_직원명_급여지급월.pdf'")
     @ApiResponses(
-            value = {
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "200",
-                        description = "발송 성공",
-                        content =
-                                @Content(
-                                        mediaType = "application/json",
-                                        examples =
-                                                @ExampleObject(
-                                                        value =
-                                                                """
+        value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "발송 성공",
+                content =
+                @Content(
+                    mediaType = "application/json",
+                    examples =
+                    @ExampleObject(
+                        value =
+                            """
                                 {
                                 "isSuccess": true,
                                 "code": "COMMON204",
@@ -79,17 +74,17 @@ public class PayslipController {
                                 "result": null
                                 }
                                 """))),
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "400",
-                        description = "잘못된 파일 형식",
-                        content =
-                                @Content(
-                                        mediaType = "application/json",
-                                        examples =
-                                                @ExampleObject(
-                                                        name = "PDF 형식 위반",
-                                                        value =
-                                                                """
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "400",
+                description = "잘못된 파일 형식",
+                content =
+                @Content(
+                    mediaType = "application/json",
+                    examples =
+                    @ExampleObject(
+                        name = "PDF 형식 위반",
+                        value =
+                            """
                                 {
                                 "isSuccess": false,
                                 "code": "ONLY_PDF_ALLOWED",
@@ -97,17 +92,17 @@ public class PayslipController {
                                 "result": null
                                 }
                                 """))),
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "401",
-                        description = "권한 없음",
-                        content =
-                                @Content(
-                                        mediaType = "application/json",
-                                        examples =
-                                                @ExampleObject(
-                                                        name = "발송 권한 없음",
-                                                        value =
-                                                                """
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "권한 없음",
+                content =
+                @Content(
+                    mediaType = "application/json",
+                    examples =
+                    @ExampleObject(
+                        name = "발송 권한 없음",
+                        value =
+                            """
                                 {
                                 "isSuccess": false,
                                 "code": "NO_AUTHORITY_FOR_PAYSLIP",
@@ -115,17 +110,17 @@ public class PayslipController {
                                 "result": null
                                 }
                                 """))),
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "404",
-                        description = "사용자 찾을 수 없음",
-                        content =
-                                @Content(
-                                        mediaType = "application/json",
-                                        examples =
-                                                @ExampleObject(
-                                                        name = "대상자 없음",
-                                                        value =
-                                                                """
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "사용자 찾을 수 없음",
+                content =
+                @Content(
+                    mediaType = "application/json",
+                    examples =
+                    @ExampleObject(
+                        name = "대상자 없음",
+                        value =
+                            """
                                 {
                                 "isSuccess": false,
                                 "code": "USER_NOT_FOUND",
@@ -133,58 +128,58 @@ public class PayslipController {
                                 "result": null
                                 }
                                 """)))
-            })
+        })
     @PostMapping(value = "/send", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Void>> sendPayslips(
-            @Parameter(description = "급여명세서 PDF 파일들", required = true) @RequestPart("payslipFiles")
-                    List<MultipartFile> payslipFiles,
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
-            throws IOException {
+        @Parameter(description = "급여명세서 PDF 파일들", required = true) @RequestPart("payslipFiles")
+        List<MultipartFile> payslipFiles,
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
+        throws IOException {
 
         payslipService.sendPayslip(payslipFiles, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onNoContent("급여명세서가 성공적으로 발송되었습니다."));
     }
 
     @Operation(
-            summary = "보낸 명세서 목록 조회",
-            description = "관리자가 상태별로 발송한 명세서를 급여지급월(YYYYMM) 기준으로 그룹 조회합니다.")
+        summary = "보낸 명세서 목록 조회 (관리자)",
+        description = "관리자가 상태별로 발송한 명세서를 급여지급월(YYYYMM) 기준으로 그룹 조회합니다.")
     @ApiResponses(
-            value = {
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "200",
-                        description = "조회 성공"),
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "401",
-                        description = "권한 없음")
-            })
+        value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "권한 없음")
+        })
     @GetMapping("/admin")
     public ResponseEntity<ApiResponse<List<AdminPayslipGroupDto>>> getPayslipsForAdminGrouped(
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
-            @Parameter(description = "명세서 상태 (생략 시 전체 조회)", example = "SENT")
-                    @RequestParam(required = false)
-                    PayslipStatus status) {
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+        @Parameter(description = "명세서 상태 (생략 시 전체 조회)", example = "SENT")
+        @RequestParam(required = false)
+        PayslipStatus status) {
 
         List<AdminPayslipGroupDto> response =
-                payslipService.getPayslipsForAdminGrouped(userDetails.getId(), status);
+            payslipService.getPayslipsForAdminGrouped(userDetails.getId(), status);
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
     @Operation(summary = "보낸 명세서 상세 조회 (관리자)", description = "관리자가 특정 명세서의 상세 정보를 조회합니다.")
     @ApiResponses(
-            value = {
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "200",
-                        description = "조회 성공"),
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "404",
-                        description = "명세서 없음",
-                        content =
-                                @Content(
-                                        mediaType = "application/json",
-                                        examples =
-                                                @ExampleObject(
-                                                        value =
-                                                                """
+        value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "명세서 없음",
+                content =
+                @Content(
+                    mediaType = "application/json",
+                    examples =
+                    @ExampleObject(
+                        value =
+                            """
                                 {
                                 "isSuccess": false,
                                 "code": "PAYSLIP_NOT_FOUND",
@@ -192,33 +187,33 @@ public class PayslipController {
                                 "result": null
                                 }
                                 """)))
-            })
+        })
     @GetMapping("/admin/{payslipId}")
     public ResponseEntity<ApiResponse<AdminPayslipDetailDto>> getPayslipDetailForAdmin(
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
-            @Parameter(description = "명세서 ID", example = "1") @PathVariable Long payslipId) {
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+        @Parameter(description = "명세서 ID", example = "1") @PathVariable Long payslipId) {
 
         AdminPayslipDetailDto response =
-                payslipService.getPayslipForAdmin(userDetails.getId(), payslipId);
+            payslipService.getPayslipForAdmin(userDetails.getId(), payslipId);
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
     @Operation(summary = "내 명세서 목록 조회 (직원)", description = "직원이 본인의 명세서 목록을 조회합니다.")
     @ApiResponses(
-            value = {
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "200",
-                        description = "조회 성공"),
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "404",
-                        description = "사용자 없음",
-                        content =
-                                @Content(
-                                        mediaType = "application/json",
-                                        examples =
-                                                @ExampleObject(
-                                                        value =
-                                                                """
+        value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "사용자 없음",
+                content =
+                @Content(
+                    mediaType = "application/json",
+                    examples =
+                    @ExampleObject(
+                        value =
+                            """
                                 {
                                 "isSuccess": false,
                                 "code": "USER_NOT_FOUND",
@@ -226,33 +221,33 @@ public class PayslipController {
                                 "result": null
                                 }
                                 """)))
-            })
+        })
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<List<EmployeePayslipSummaryDto>>> getMyPayslips(
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         List<EmployeePayslipSummaryDto> response = payslipService.getPayslips(userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
     @Operation(
-            summary = "내 명세서 상세 조회 (직원)",
-            description = "직원이 로그인 비밀번호를 입력한 뒤 특정 급여명세서의 상세 내용을 확인합니다.")
+        summary = "내 명세서 상세 조회 (직원)",
+        description = "직원이 로그인 비밀번호를 입력한 뒤 특정 급여명세서의 상세 내용을 확인합니다.")
     @ApiResponses(
-            value = {
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "200",
-                        description = "조회 성공"),
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "400",
-                        description = "비밀번호 불일치",
-                        content =
-                                @Content(
-                                        mediaType = "application/json",
-                                        examples =
-                                                @ExampleObject(
-                                                        value =
-                                                                """
+        value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "400",
+                description = "비밀번호 불일치",
+                content =
+                @Content(
+                    mediaType = "application/json",
+                    examples =
+                    @ExampleObject(
+                        value =
+                            """
                                 {
                                 "isSuccess": false,
                                 "code": "PASSWORD_MISMATCH",
@@ -260,16 +255,16 @@ public class PayslipController {
                                 "result": null
                                 }
                                 """))),
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "401",
-                        description = "접근 권한 없음",
-                        content =
-                                @Content(
-                                        mediaType = "application/json",
-                                        examples =
-                                                @ExampleObject(
-                                                        value =
-                                                                """
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "접근 권한 없음",
+                content =
+                @Content(
+                    mediaType = "application/json",
+                    examples =
+                    @ExampleObject(
+                        value =
+                            """
                                 {
                                 "isSuccess": false,
                                 "code": "NO_AUTHORITY_FOR_VIEW_PAYSLIP",
@@ -277,16 +272,16 @@ public class PayslipController {
                                 "result": null
                                 }
                                 """))),
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "404",
-                        description = "명세서 없음",
-                        content =
-                                @Content(
-                                        mediaType = "application/json",
-                                        examples =
-                                                @ExampleObject(
-                                                        value =
-                                                                """
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "명세서 없음",
+                content =
+                @Content(
+                    mediaType = "application/json",
+                    examples =
+                    @ExampleObject(
+                        value =
+                            """
                                 {
                                 "isSuccess": false,
                                 "code": "PAYSLIP_NOT_FOUND",
@@ -294,15 +289,15 @@ public class PayslipController {
                                 "result": null
                                 }
                                 """)))
-            })
+        })
     @PostMapping("/me/{payslipId}")
     public ResponseEntity<ApiResponse<EmployeePayslipDetailDto>> getMyPayslipDetail(
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
-            @Parameter(description = "명세서 ID", example = "1") @PathVariable Long payslipId,
-            @Valid @RequestBody PayslipViewPasswordRequestDto requestDto) {
+        @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+        @Parameter(description = "명세서 ID", example = "1") @PathVariable Long payslipId,
+        @Valid @RequestBody PayslipViewPasswordRequestDto requestDto) {
 
         EmployeePayslipDetailDto response =
-                payslipService.getPayslip(userDetails.getId(), payslipId, requestDto.getPassword());
+            payslipService.getPayslip(userDetails.getId(), payslipId, requestDto.getPassword());
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/controller/PayslipController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/controller/PayslipController.java
@@ -53,7 +53,9 @@ public class PayslipController {
 
     @Operation(
             summary = "급여명세서 일괄 발송 (관리자)",
-            description = "관리자가 다수의 PDF 파일을 업로드하여 발송합니다. 파일명 형식: '성명_생년월일_급여명세서.pdf'")
+            description =
+                    "관리자가 다수의 PDF 파일을 업로드하여 발송합니다. 파일명 형식:"
+                            + " '급여명세서(근로기준1)_더존직원코드_직원명_급여지급월.pdf'")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/request/PayslipViewPasswordRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/request/PayslipViewPasswordRequestDto.java
@@ -1,0 +1,18 @@
+package kr.co.awesomelead.groupware_backend.domain.payslip.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import jakarta.validation.constraints.NotBlank;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Schema(description = "급여명세서 열람 비밀번호 확인 요청")
+public class PayslipViewPasswordRequestDto {
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Schema(description = "서비스 로그인 비밀번호", example = "MyP@ssw0rd!")
+    private String password;
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/AdminPayslipDetailDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/AdminPayslipDetailDto.java
@@ -32,7 +32,7 @@ public class AdminPayslipDetailDto {
             example = "https://bucket.s3.amazonaws.com/payslips/unique-file-key.pdf")
     private String presignedUrl;
 
-    @Schema(description = "원본 파일명", example = "홍길동_20251231_급여명세서.pdf")
+    @Schema(description = "원본 파일명", example = "급여명세서(근로기준1)_10001_홍길동_202605.pdf")
     private String originalFileName;
 
     @Schema(description = "생성 일시", example = "2025-12-31T10:15:30")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/AdminPayslipDetailDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/AdminPayslipDetailDto.java
@@ -35,6 +35,9 @@ public class AdminPayslipDetailDto {
     @Schema(description = "원본 파일명", example = "급여명세서(근로기준1)_10001_홍길동_202605.pdf")
     private String originalFileName;
 
+    @Schema(description = "급여명세서 제목", example = "2026년 5월 급여명세서")
+    private String payslipTitle;
+
     @Schema(description = "생성 일시", example = "2025-12-31T10:15:30")
     private LocalDateTime createdAt;
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/AdminPayslipGroupDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/AdminPayslipGroupDto.java
@@ -1,0 +1,30 @@
+package kr.co.awesomelead.groupware_backend.domain.payslip.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Schema(description = "관리자용 급여명세서 월별 그룹 응답")
+public class AdminPayslipGroupDto {
+
+    @Schema(description = "급여지급월(YYYYMM)", example = "202606")
+    private String yearMonth;
+
+    @Schema(description = "월별 그룹 제목", example = "2026년 6월 급여명세서")
+    private String title;
+
+    @Schema(description = "해당 월 명세서 건수", example = "18")
+    private int totalCount;
+
+    @Schema(description = "해당 월 명세서 목록")
+    private List<AdminPayslipSummaryDto> items;
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/AdminPayslipSummaryDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/AdminPayslipSummaryDto.java
@@ -30,6 +30,9 @@ public class AdminPayslipSummaryDto {
     @Schema(description = "원본 파일명", example = "급여명세서(근로기준1)_10001_홍길동_202605.pdf")
     private String originalFileName;
 
+    @Schema(description = "급여명세서 제목", example = "2026년 5월 급여명세서")
+    private String payslipTitle;
+
     @Schema(description = "생성 일시", example = "2025-12-31T10:15:30")
     private LocalDateTime createdAt;
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/AdminPayslipSummaryDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/AdminPayslipSummaryDto.java
@@ -27,7 +27,7 @@ public class AdminPayslipSummaryDto {
     @Schema(description = "직원 직급", example = "대리")
     private String employPosition;
 
-    @Schema(description = "원본 파일명", example = "홍길동_20251231_급여명세서.pdf")
+    @Schema(description = "원본 파일명", example = "급여명세서(근로기준1)_10001_홍길동_202605.pdf")
     private String originalFileName;
 
     @Schema(description = "생성 일시", example = "2025-12-31T10:15:30")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/EmployeePayslipDetailDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/EmployeePayslipDetailDto.java
@@ -27,6 +27,9 @@ public class EmployeePayslipDetailDto {
     @Schema(description = "원본 파일명", example = "급여명세서(근로기준1)_10001_홍길동_202605.pdf")
     private String originalFileName;
 
+    @Schema(description = "급여명세서 제목", example = "2026년 5월 급여명세서")
+    private String payslipTitle;
+
     @Schema(description = "생성 일시", example = "2025-12-31T10:15:30")
     private LocalDateTime createdAt;
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/EmployeePayslipDetailDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/EmployeePayslipDetailDto.java
@@ -24,7 +24,7 @@ public class EmployeePayslipDetailDto {
             example = "https://bucket.s3.amazonaws.com/payslips/unique-file-key.pdf")
     private String presignedUrl;
 
-    @Schema(description = "원본 파일명", example = "홍길동_20251231_급여명세서.pdf")
+    @Schema(description = "원본 파일명", example = "급여명세서(근로기준1)_10001_홍길동_202605.pdf")
     private String originalFileName;
 
     @Schema(description = "생성 일시", example = "2025-12-31T10:15:30")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/EmployeePayslipSummaryDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/EmployeePayslipSummaryDto.java
@@ -22,6 +22,9 @@ public class EmployeePayslipSummaryDto {
     @Schema(description = "원본 파일명", example = "급여명세서(근로기준1)_10001_홍길동_202605.pdf")
     private String originalFileName;
 
+    @Schema(description = "급여명세서 제목", example = "2026년 5월 급여명세서")
+    private String payslipTitle;
+
     @Schema(description = "생성 일시", example = "2025-12-31T10:15:30")
     private LocalDateTime createdAt;
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/EmployeePayslipSummaryDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/EmployeePayslipSummaryDto.java
@@ -19,7 +19,7 @@ public class EmployeePayslipSummaryDto {
     @Schema(description = "급여명세서 ID", example = "1")
     private Long payslipId;
 
-    @Schema(description = "원본 파일명", example = "홍길동_20251231_급여명세서.pdf")
+    @Schema(description = "원본 파일명", example = "급여명세서(근로기준1)_10001_홍길동_202605.pdf")
     private String originalFileName;
 
     @Schema(description = "생성 일시", example = "2025-12-31T10:15:30")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/mapper/PayslipMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/mapper/PayslipMapper.java
@@ -12,13 +12,23 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Mapper(componentModel = "spring")
 public interface PayslipMapper {
 
+    Pattern PAYSLIP_MONTH_PATTERN =
+            Pattern.compile(
+                    "^급여명세서\\(근로기준1\\)_[^_]+_[^_]+_([0-9]{6})\\.pdf$",
+                    Pattern.CASE_INSENSITIVE);
+
     @Mapping(target = "payslipId", source = "payslip.id")
     @Mapping(target = "employeeName", source = "user.displayName")
     @Mapping(target = "employPosition", source = "user.position")
+    @Mapping(
+            target = "payslipTitle",
+            expression = "java(buildPayslipTitle(payslip.getOriginalFileName()))")
     AdminPayslipSummaryDto toAdminPayslipSummaryDto(Payslip payslip);
 
     List<AdminPayslipSummaryDto> toAdminPayslipSummaryDtoList(List<Payslip> payslips);
@@ -32,6 +42,9 @@ public interface PayslipMapper {
     AdminPayslipDetailDto toAdminPayslipDetailDto(Payslip payslip, @Context S3Service s3Service);
 
     @Mapping(target = "payslipId", source = "payslip.id")
+    @Mapping(
+            target = "payslipTitle",
+            expression = "java(buildPayslipTitle(payslip.getOriginalFileName()))")
     EmployeePayslipSummaryDto toEmployeePayslipSummaryDto(Payslip payslip);
 
     List<EmployeePayslipSummaryDto> toEmployeePayslipSummaryDtoList(List<Payslip> payslips);
@@ -42,4 +55,28 @@ public interface PayslipMapper {
     @Mapping(target = "payslipId", source = "payslip.id")
     EmployeePayslipDetailDto toEmployeePayslipDetailDto(
             Payslip payslip, @Context S3Service s3Service);
+
+    default String buildPayslipTitle(String originalFileName) {
+        if (originalFileName == null || originalFileName.isBlank()) {
+            return "급여명세서";
+        }
+
+        String normalizedPath = originalFileName.replace("\\", "/");
+        String baseFileName = normalizedPath.substring(normalizedPath.lastIndexOf('/') + 1);
+
+        Matcher matcher = PAYSLIP_MONTH_PATTERN.matcher(baseFileName);
+        if (!matcher.matches()) {
+            return "급여명세서";
+        }
+
+        String yearMonth = matcher.group(1);
+        int year = Integer.parseInt(yearMonth.substring(0, 4));
+        int month = Integer.parseInt(yearMonth.substring(4, 6));
+
+        if (month < 1 || month > 12) {
+            return "급여명세서";
+        }
+
+        return year + "년 " + month + "월 급여명세서";
+    }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/mapper/PayslipMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/mapper/PayslipMapper.java
@@ -11,6 +11,7 @@ import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
+import java.text.Normalizer;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -28,7 +29,7 @@ public interface PayslipMapper {
     @Mapping(target = "employPosition", source = "user.position")
     @Mapping(
             target = "payslipTitle",
-            expression = "java(buildPayslipTitle(payslip.getOriginalFileName()))")
+            expression = "java(buildPayslipTitle(payslip))")
     AdminPayslipSummaryDto toAdminPayslipSummaryDto(Payslip payslip);
 
     List<AdminPayslipSummaryDto> toAdminPayslipSummaryDtoList(List<Payslip> payslips);
@@ -38,7 +39,7 @@ public interface PayslipMapper {
     @Mapping(target = "employPosition", source = "user.position")
     @Mapping(
             target = "payslipTitle",
-            expression = "java(buildPayslipTitle(payslip.getOriginalFileName()))")
+            expression = "java(buildPayslipTitle(payslip))")
     @Mapping(
             target = "presignedUrl",
             expression = "java(s3Service.getPresignedViewUrl(payslip.getFileKey()))")
@@ -47,7 +48,7 @@ public interface PayslipMapper {
     @Mapping(target = "payslipId", source = "payslip.id")
     @Mapping(
             target = "payslipTitle",
-            expression = "java(buildPayslipTitle(payslip.getOriginalFileName()))")
+            expression = "java(buildPayslipTitle(payslip))")
     EmployeePayslipSummaryDto toEmployeePayslipSummaryDto(Payslip payslip);
 
     List<EmployeePayslipSummaryDto> toEmployeePayslipSummaryDtoList(List<Payslip> payslips);
@@ -58,17 +59,25 @@ public interface PayslipMapper {
     @Mapping(target = "payslipId", source = "payslip.id")
     @Mapping(
             target = "payslipTitle",
-            expression = "java(buildPayslipTitle(payslip.getOriginalFileName()))")
+            expression = "java(buildPayslipTitle(payslip))")
     EmployeePayslipDetailDto toEmployeePayslipDetailDto(
             Payslip payslip, @Context S3Service s3Service);
 
-    default String buildPayslipTitle(String originalFileName) {
+    default String buildPayslipTitle(Payslip payslip) {
+        if (payslip == null) {
+            return "급여명세서";
+        }
+        return buildPayslipTitleFromOriginalFileName(payslip.getOriginalFileName());
+    }
+
+    private static String buildPayslipTitleFromOriginalFileName(String originalFileName) {
         if (originalFileName == null || originalFileName.isBlank()) {
             return "급여명세서";
         }
 
         String normalizedPath = originalFileName.replace("\\", "/");
         String baseFileName = normalizedPath.substring(normalizedPath.lastIndexOf('/') + 1);
+        baseFileName = Normalizer.normalize(baseFileName, Normalizer.Form.NFC);
 
         Matcher matcher = PAYSLIP_MONTH_PATTERN.matcher(baseFileName);
         if (!matcher.matches()) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/mapper/PayslipMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/mapper/PayslipMapper.java
@@ -37,6 +37,9 @@ public interface PayslipMapper {
     @Mapping(target = "employeeName", source = "user.displayName")
     @Mapping(target = "employPosition", source = "user.position")
     @Mapping(
+            target = "payslipTitle",
+            expression = "java(buildPayslipTitle(payslip.getOriginalFileName()))")
+    @Mapping(
             target = "presignedUrl",
             expression = "java(s3Service.getPresignedViewUrl(payslip.getFileKey()))")
     AdminPayslipDetailDto toAdminPayslipDetailDto(Payslip payslip, @Context S3Service s3Service);
@@ -53,6 +56,9 @@ public interface PayslipMapper {
             target = "presignedUrl",
             expression = "java(s3Service.getPresignedViewUrl(payslip.getFileKey()))")
     @Mapping(target = "payslipId", source = "payslip.id")
+    @Mapping(
+            target = "payslipTitle",
+            expression = "java(buildPayslipTitle(payslip.getOriginalFileName()))")
     EmployeePayslipDetailDto toEmployeePayslipDetailDto(
             Payslip payslip, @Context S3Service s3Service);
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/mapper/PayslipMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/mapper/PayslipMapper.java
@@ -22,15 +22,12 @@ public interface PayslipMapper {
 
     Pattern PAYSLIP_MONTH_PATTERN =
             Pattern.compile(
-                    "^급여명세서\\(근로기준1\\)_[^_]+_[^_]+_([0-9]{6})\\.pdf$",
-                    Pattern.CASE_INSENSITIVE);
+                    "^급여명세서\\(근로기준1\\)_[^_]+_[^_]+_([0-9]{6})\\.pdf$", Pattern.CASE_INSENSITIVE);
 
     @Mapping(target = "payslipId", source = "payslip.id")
     @Mapping(target = "employeeName", source = "user.displayName")
     @Mapping(target = "employPosition", expression = "java(buildPositionDescription(payslip))")
-    @Mapping(
-            target = "payslipTitle",
-            expression = "java(buildPayslipTitle(payslip))")
+    @Mapping(target = "payslipTitle", expression = "java(buildPayslipTitle(payslip))")
     AdminPayslipSummaryDto toAdminPayslipSummaryDto(Payslip payslip);
 
     List<AdminPayslipSummaryDto> toAdminPayslipSummaryDtoList(List<Payslip> payslips);
@@ -38,18 +35,14 @@ public interface PayslipMapper {
     @Mapping(target = "payslipId", source = "payslip.id")
     @Mapping(target = "employeeName", source = "user.displayName")
     @Mapping(target = "employPosition", expression = "java(buildPositionDescription(payslip))")
-    @Mapping(
-            target = "payslipTitle",
-            expression = "java(buildPayslipTitle(payslip))")
+    @Mapping(target = "payslipTitle", expression = "java(buildPayslipTitle(payslip))")
     @Mapping(
             target = "presignedUrl",
             expression = "java(s3Service.getPresignedViewUrl(payslip.getFileKey()))")
     AdminPayslipDetailDto toAdminPayslipDetailDto(Payslip payslip, @Context S3Service s3Service);
 
     @Mapping(target = "payslipId", source = "payslip.id")
-    @Mapping(
-            target = "payslipTitle",
-            expression = "java(buildPayslipTitle(payslip))")
+    @Mapping(target = "payslipTitle", expression = "java(buildPayslipTitle(payslip))")
     EmployeePayslipSummaryDto toEmployeePayslipSummaryDto(Payslip payslip);
 
     List<EmployeePayslipSummaryDto> toEmployeePayslipSummaryDtoList(List<Payslip> payslips);
@@ -58,9 +51,7 @@ public interface PayslipMapper {
             target = "presignedUrl",
             expression = "java(s3Service.getPresignedViewUrl(payslip.getFileKey()))")
     @Mapping(target = "payslipId", source = "payslip.id")
-    @Mapping(
-            target = "payslipTitle",
-            expression = "java(buildPayslipTitle(payslip))")
+    @Mapping(target = "payslipTitle", expression = "java(buildPayslipTitle(payslip))")
     EmployeePayslipDetailDto toEmployeePayslipDetailDto(
             Payslip payslip, @Context S3Service s3Service);
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/mapper/PayslipMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/mapper/PayslipMapper.java
@@ -5,6 +5,7 @@ import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.AdminPays
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.EmployeePayslipDetailDto;
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.EmployeePayslipSummaryDto;
 import kr.co.awesomelead.groupware_backend.domain.payslip.entity.Payslip;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
 import kr.co.awesomelead.groupware_backend.global.infra.s3.service.S3Service;
 
 import org.mapstruct.Context;
@@ -26,7 +27,7 @@ public interface PayslipMapper {
 
     @Mapping(target = "payslipId", source = "payslip.id")
     @Mapping(target = "employeeName", source = "user.displayName")
-    @Mapping(target = "employPosition", source = "user.position")
+    @Mapping(target = "employPosition", expression = "java(buildPositionDescription(payslip))")
     @Mapping(
             target = "payslipTitle",
             expression = "java(buildPayslipTitle(payslip))")
@@ -36,7 +37,7 @@ public interface PayslipMapper {
 
     @Mapping(target = "payslipId", source = "payslip.id")
     @Mapping(target = "employeeName", source = "user.displayName")
-    @Mapping(target = "employPosition", source = "user.position")
+    @Mapping(target = "employPosition", expression = "java(buildPositionDescription(payslip))")
     @Mapping(
             target = "payslipTitle",
             expression = "java(buildPayslipTitle(payslip))")
@@ -68,6 +69,17 @@ public interface PayslipMapper {
             return "급여명세서";
         }
         return buildPayslipTitleFromOriginalFileName(payslip.getOriginalFileName());
+    }
+
+    default String buildPositionDescription(Payslip payslip) {
+        if (payslip == null || payslip.getUser() == null) {
+            return null;
+        }
+        Position position = payslip.getUser().getPosition();
+        if (position == null) {
+            return null;
+        }
+        return position.getDescription();
     }
 
     private static String buildPayslipTitleFromOriginalFileName(String originalFileName) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/service/PayslipOcrInfoExtractor.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/service/PayslipOcrInfoExtractor.java
@@ -1,0 +1,129 @@
+package kr.co.awesomelead.groupware_backend.domain.payslip.service;
+
+import kr.co.awesomelead.groupware_backend.global.error.CustomException;
+import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.rendering.ImageType;
+import org.apache.pdfbox.rendering.PDFRenderer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.imageio.ImageIO;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PayslipOcrInfoExtractor {
+
+    private final PayslipPdfInfoExtractor payslipPdfInfoExtractor;
+
+    @Value("${payslip.ocr.enabled:true}")
+    private boolean ocrEnabled;
+
+    @Value("${payslip.ocr.tesseract-command:tesseract}")
+    private String tesseractCommand;
+
+    @Value("${payslip.ocr.language:kor+eng}")
+    private String tesseractLanguage;
+
+    @Value("${payslip.ocr.dpi:300}")
+    private int renderDpi;
+
+    @Value("${payslip.ocr.psm:6}")
+    private int tesseractPsm;
+
+    @Value("${payslip.ocr.oem:1}")
+    private int tesseractOem;
+
+    public boolean isOcrEnabled() {
+        return ocrEnabled;
+    }
+
+    public PayslipPdfInfoExtractor.PayslipPersonalInfo extract(MultipartFile file) {
+        if (!ocrEnabled) {
+            throw new CustomException(ErrorCode.INVALID_PAYSLIP_PDF_CONTENT);
+        }
+
+        String ocrText = extractOcrText(file);
+        return payslipPdfInfoExtractor.extractFromText(ocrText);
+    }
+
+    private String extractOcrText(MultipartFile file) {
+        try (PDDocument document = PDDocument.load(file.getInputStream())) {
+            if (document.getNumberOfPages() == 0) {
+                throw new CustomException(ErrorCode.INVALID_PAYSLIP_PDF_CONTENT);
+            }
+
+            PDFRenderer renderer = new PDFRenderer(document);
+            StringBuilder mergedText = new StringBuilder();
+
+            for (int pageIndex = 0; pageIndex < document.getNumberOfPages(); pageIndex++) {
+                BufferedImage pageImage =
+                        renderer.renderImageWithDPI(pageIndex, renderDpi, ImageType.RGB);
+                Path imagePath = Files.createTempFile("payslip-ocr-", ".png");
+                try {
+                    ImageIO.write(pageImage, "png", imagePath.toFile());
+                    mergedText.append(runTesseract(imagePath));
+                    mergedText.append("\n");
+                } finally {
+                    Files.deleteIfExists(imagePath);
+                }
+            }
+
+            if (mergedText.isEmpty()) {
+                throw new CustomException(ErrorCode.INVALID_PAYSLIP_PDF_CONTENT);
+            }
+            return mergedText.toString();
+        } catch (IOException e) {
+            log.warn("급여명세서 OCR 추출 실패: {}", e.getMessage());
+            throw new CustomException(ErrorCode.INVALID_PAYSLIP_PDF_CONTENT);
+        }
+    }
+
+    private String runTesseract(Path imagePath) {
+        List<String> command = new ArrayList<>();
+        command.add(tesseractCommand);
+        command.add(imagePath.toString());
+        command.add("stdout");
+        command.add("-l");
+        command.add(tesseractLanguage);
+        command.add("--oem");
+        command.add(String.valueOf(tesseractOem));
+        command.add("--psm");
+        command.add(String.valueOf(tesseractPsm));
+
+        ProcessBuilder processBuilder = new ProcessBuilder(command);
+        processBuilder.redirectErrorStream(true);
+
+        try {
+            Process process = processBuilder.start();
+            String outputText =
+                    new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            int exitCode = process.waitFor();
+            if (exitCode != 0) {
+                log.warn("Tesseract 실행 실패(exitCode={}): {}", exitCode, outputText);
+                throw new CustomException(ErrorCode.INVALID_PAYSLIP_PDF_CONTENT);
+            }
+            return outputText;
+        } catch (IOException e) {
+            log.warn("Tesseract 실행 중 I/O 오류: {}", e.getMessage());
+            throw new CustomException(ErrorCode.INVALID_PAYSLIP_PDF_CONTENT);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new CustomException(ErrorCode.INVALID_PAYSLIP_PDF_CONTENT);
+        }
+    }
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/service/PayslipPdfInfoExtractor.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/service/PayslipPdfInfoExtractor.java
@@ -1,0 +1,121 @@
+package kr.co.awesomelead.groupware_backend.domain.payslip.service;
+
+import kr.co.awesomelead.groupware_backend.global.error.CustomException;
+import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.text.Normalizer;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+public class PayslipPdfInfoExtractor {
+
+    private static final List<Pattern> NAME_PATTERNS =
+            List.of(
+                    Pattern.compile(
+                            "(?:성명|이름|사원명|직원명)\\s*[:：]?\\s*([가-힣A-Za-z\\s]{1,40}?)(?=\\s*(?:생년월일|DOB|Birth\\s*Date|부\\s*서|직\\s*급|$))",
+                            Pattern.CASE_INSENSITIVE));
+
+    private static final List<Pattern> BIRTH_DATE_PATTERNS =
+            List.of(
+                    Pattern.compile(
+                            "(?:생년월일|DOB|Birth\\s*Date)\\s*[:：]?\\s*([0-9]{8}|[0-9]{4}\\s*[./-]\\s*[0-9]{1,2}\\s*[./-]\\s*[0-9]{1,2})",
+                            Pattern.CASE_INSENSITIVE));
+
+    public PayslipPersonalInfo extract(MultipartFile file) {
+        String text = extractText(file);
+        return extractFromText(text);
+    }
+
+    public PayslipPersonalInfo extractFromText(String rawText) {
+        if (rawText == null || rawText.isBlank()) {
+            throw new CustomException(ErrorCode.INVALID_PAYSLIP_PDF_CONTENT);
+        }
+        String text = Normalizer.normalize(rawText, Normalizer.Form.NFC);
+
+        String name = extractName(text);
+        LocalDate birthDate = extractBirthDate(text);
+
+        return new PayslipPersonalInfo(name, birthDate);
+    }
+
+    public boolean isNameLikelyCorrupted(String name) {
+        String normalized = normalizeName(name).replaceAll("\\s+", "");
+        if (normalized.length() < 2) {
+            return true;
+        }
+
+        return !normalized.toLowerCase(Locale.ROOT).matches("^[가-힣a-z]+$");
+    }
+
+    private String extractText(MultipartFile file) {
+        try (PDDocument document = PDDocument.load(file.getInputStream())) {
+            PDFTextStripper textStripper = new PDFTextStripper();
+            String rawText = textStripper.getText(document);
+            if (rawText == null || rawText.isBlank()) {
+                throw new CustomException(ErrorCode.INVALID_PAYSLIP_PDF_CONTENT);
+            }
+            return rawText;
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.INVALID_PAYSLIP_PDF_CONTENT);
+        }
+    }
+
+    private String extractName(String text) {
+        for (Pattern pattern : NAME_PATTERNS) {
+            Matcher matcher = pattern.matcher(text);
+            if (matcher.find()) {
+                String candidate = matcher.group(1).trim();
+                String normalized = normalizeName(candidate);
+                if (!normalized.isBlank()) {
+                    return normalized;
+                }
+            }
+        }
+        throw new CustomException(ErrorCode.INVALID_PAYSLIP_PDF_CONTENT);
+    }
+
+    private LocalDate extractBirthDate(String text) {
+        for (Pattern pattern : BIRTH_DATE_PATTERNS) {
+            Matcher matcher = pattern.matcher(text);
+            if (matcher.find()) {
+                String raw = matcher.group(1);
+                LocalDate parsed = parseDate(raw);
+                if (parsed != null) {
+                    return parsed;
+                }
+            }
+        }
+        throw new CustomException(ErrorCode.INVALID_PAYSLIP_PDF_CONTENT);
+    }
+
+    private LocalDate parseDate(String raw) {
+        String digitsOnly = raw.replaceAll("[^0-9]", "");
+        if (digitsOnly.length() != 8) {
+            return null;
+        }
+
+        try {
+            return LocalDate.parse(digitsOnly, DateTimeFormatter.ofPattern("yyyyMMdd"));
+        } catch (DateTimeParseException e) {
+            return null;
+        }
+    }
+
+    private String normalizeName(String name) {
+        return Normalizer.normalize(name, Normalizer.Form.NFC).replaceAll("\\s+", " ").trim();
+    }
+
+    public record PayslipPersonalInfo(String name, LocalDate birthDate) {}
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/service/PayslipService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/service/PayslipService.java
@@ -67,14 +67,7 @@ public class PayslipService {
 
     @Transactional
     public void sendPayslip(List<MultipartFile> payslipFiles, Long userId) throws IOException {
-
-        User user =
-                userRepository
-                        .findById(userId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        if (!user.hasAuthority(Authority.EDIT_EMPLOYEE_INFO)) {
-            throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_PAYSLIP);
-        }
+        validatePayslipEditAuthority(userId);
 
         for (MultipartFile file : payslipFiles) {
 
@@ -102,6 +95,53 @@ public class PayslipService {
 
             Payslip savedPayslip = savePayslipInfo(s3Key, originalFileName, target);
             notificationService.sendPayslipAlertToUser(target.getId(), savedPayslip.getId());
+        }
+    }
+
+    @Transactional
+    public void updatePayslip(Long payslipId, MultipartFile payslipFile, Long userId)
+            throws IOException {
+        validatePayslipEditAuthority(userId);
+
+        Payslip payslip =
+                payslipRepository
+                        .findById(payslipId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.PAYSLIP_NOT_FOUND));
+
+        String originalFileName = payslipFile.getOriginalFilename();
+        if (!Objects.equals(payslipFile.getContentType(), "application/pdf")) {
+            throw new CustomException(ErrorCode.ONLY_PDF_ALLOWED);
+        }
+
+        String fileNameEmployeeName = parseEmployeeNameFromFileName(originalFileName);
+        PayslipPdfInfoExtractor.PayslipPersonalInfo pdfPersonalInfo =
+                extractPersonalInfoWithFallback(payslipFile, originalFileName);
+
+        if (!isSamePersonName(fileNameEmployeeName, pdfPersonalInfo.name())) {
+            throw new CustomException(ErrorCode.PAYSLIP_USER_INFO_MISMATCH);
+        }
+
+        User target =
+                findTargetUserByNameAndBirthDate(
+                        pdfPersonalInfo.name(), fileNameEmployeeName, pdfPersonalInfo.birthDate());
+
+        String oldFileKey = payslip.getFileKey();
+        String newFileKey = s3Service.uploadFile(payslipFile);
+
+        payslip.setFileKey(newFileKey);
+        payslip.setOriginalFileName(originalFileName);
+        payslip.setUser(target);
+        payslip.setStatus(PayslipStatus.SENT);
+        payslip.setReadAt(null);
+
+        notificationService.sendPayslipAlertToUser(target.getId(), payslip.getId());
+
+        if (oldFileKey != null && !oldFileKey.isBlank() && !oldFileKey.equals(newFileKey)) {
+            try {
+                s3Service.deleteFile(oldFileKey);
+            } catch (RuntimeException e) {
+                log.warn("급여명세서 기존 파일 삭제 실패 - payslipId: {}, fileKey: {}", payslipId, oldFileKey, e);
+            }
         }
     }
 
@@ -327,6 +367,16 @@ public class PayslipService {
                         .findById(adminId)
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         if (admin.getRole() != Role.ADMIN && admin.getRole() != Role.MASTER_ADMIN) {
+            throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_PAYSLIP);
+        }
+    }
+
+    private void validatePayslipEditAuthority(Long userId) {
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        if (!user.hasAuthority(Authority.EDIT_EMPLOYEE_INFO)) {
             throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_PAYSLIP);
         }
     }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/service/PayslipService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/service/PayslipService.java
@@ -21,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.stereotype.Service;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -54,6 +55,7 @@ public class PayslipService {
     private final NotificationService notificationService;
     private final PayslipPdfInfoExtractor payslipPdfInfoExtractor;
     private final PayslipOcrInfoExtractor payslipOcrInfoExtractor;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     @Transactional
     public void sendPayslip(List<MultipartFile> payslipFiles, Long userId) throws IOException {
@@ -252,7 +254,7 @@ public class PayslipService {
 
     // 직원의 급여명세서 상세 조회
     @Transactional
-    public EmployeePayslipDetailDto getPayslip(Long userId, Long payslipId) {
+    public EmployeePayslipDetailDto getPayslip(Long userId, Long payslipId, String password) {
 
         Payslip payslip =
                 payslipRepository
@@ -261,6 +263,10 @@ public class PayslipService {
 
         if (!payslip.getUser().getId().equals(userId)) {
             throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_VIEW_PAYSLIP);
+        }
+
+        if (!bCryptPasswordEncoder.matches(password, payslip.getUser().getPassword())) {
+            throw new CustomException(ErrorCode.PASSWORD_MISMATCH);
         }
 
         // 통보형 프로세스: 직원이 상세 조회하면 열람 완료 처리

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/service/PayslipService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/service/PayslipService.java
@@ -338,6 +338,7 @@ public class PayslipService {
 
         String normalizedPath = originalFileName.replace("\\", "/");
         String baseFileName = normalizedPath.substring(normalizedPath.lastIndexOf('/') + 1);
+        baseFileName = Normalizer.normalize(baseFileName, Normalizer.Form.NFC);
 
         Matcher matcher = PAYSLIP_MONTH_PATTERN.matcher(baseFileName);
         if (!matcher.matches()) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/service/PayslipService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/service/PayslipService.java
@@ -145,6 +145,27 @@ public class PayslipService {
         }
     }
 
+    @Transactional
+    public void deletePayslip(Long payslipId, Long userId) {
+        validatePayslipEditAuthority(userId);
+
+        Payslip payslip =
+                payslipRepository
+                        .findById(payslipId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.PAYSLIP_NOT_FOUND));
+
+        String fileKey = payslip.getFileKey();
+        payslipRepository.delete(payslip);
+
+        if (fileKey != null && !fileKey.isBlank()) {
+            try {
+                s3Service.deleteFile(fileKey);
+            } catch (RuntimeException e) {
+                log.warn("급여명세서 파일 삭제 실패 - payslipId: {}, fileKey: {}", payslipId, fileKey, e);
+            }
+        }
+    }
+
     private PayslipPdfInfoExtractor.PayslipPersonalInfo extractPersonalInfoWithFallback(
             MultipartFile file, String originalFileName) {
         PayslipPdfInfoExtractor.PayslipPersonalInfo primaryInfo = null;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/service/PayslipService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/service/PayslipService.java
@@ -21,8 +21,8 @@ import kr.co.awesomelead.groupware_backend.global.infra.s3.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import org.springframework.stereotype.Service;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -52,8 +52,7 @@ public class PayslipService {
                     Pattern.CASE_INSENSITIVE);
     private static final Pattern PAYSLIP_MONTH_PATTERN =
             Pattern.compile(
-                    "^급여명세서\\(근로기준1\\)_[^_]+_[^_]+_([0-9]{6})\\.pdf$",
-                    Pattern.CASE_INSENSITIVE);
+                    "^급여명세서\\(근로기준1\\)_[^_]+_[^_]+_([0-9]{6})\\.pdf$", Pattern.CASE_INSENSITIVE);
     private static final String UNKNOWN_YEAR_MONTH = "UNKNOWN";
 
     private final PayslipRepository payslipRepository;
@@ -140,7 +139,8 @@ public class PayslipService {
             try {
                 s3Service.deleteFile(oldFileKey);
             } catch (RuntimeException e) {
-                log.warn("급여명세서 기존 파일 삭제 실패 - payslipId: {}, fileKey: {}", payslipId, oldFileKey, e);
+                log.warn(
+                        "급여명세서 기존 파일 삭제 실패 - payslipId: {}, fileKey: {}", payslipId, oldFileKey, e);
             }
         }
     }
@@ -189,7 +189,8 @@ public class PayslipService {
         }
 
         try {
-            PayslipPdfInfoExtractor.PayslipPersonalInfo ocrInfo = payslipOcrInfoExtractor.extract(file);
+            PayslipPdfInfoExtractor.PayslipPersonalInfo ocrInfo =
+                    payslipOcrInfoExtractor.extract(file);
             if (!payslipPdfInfoExtractor.isNameLikelyCorrupted(ocrInfo.name())) {
                 log.info("급여명세서 OCR fallback 적용 성공 - fileName: {}", originalFileName);
                 return ocrInfo;
@@ -298,14 +299,16 @@ public class PayslipService {
     }
 
     @Transactional(readOnly = true)
-    public List<AdminPayslipGroupDto> getPayslipsForAdminGrouped(Long adminId, PayslipStatus status) {
+    public List<AdminPayslipGroupDto> getPayslipsForAdminGrouped(
+            Long adminId, PayslipStatus status) {
         List<AdminPayslipSummaryDto> summaries = getPayslipsForAdmin(adminId, status);
 
         Map<String, List<AdminPayslipSummaryDto>> groupedByYearMonth =
                 summaries.stream()
                         .collect(
                                 Collectors.groupingBy(
-                                        summary -> extractYearMonth(summary.getOriginalFileName())));
+                                        summary ->
+                                                extractYearMonth(summary.getOriginalFileName())));
 
         return groupedByYearMonth.entrySet().stream()
                 .sorted((left, right) -> compareYearMonthDesc(left.getKey(), right.getKey()))
@@ -316,14 +319,17 @@ public class PayslipService {
                                     entry.getValue().stream()
                                             .sorted(
                                                     Comparator.comparing(
-                                                                    AdminPayslipSummaryDto::getCreatedAt,
+                                                                    AdminPayslipSummaryDto
+                                                                            ::getCreatedAt,
                                                                     Comparator.nullsLast(
-                                                                            Comparator.naturalOrder()))
+                                                                            Comparator
+                                                                                    .naturalOrder()))
                                                             .reversed())
                                             .toList();
 
                             return AdminPayslipGroupDto.builder()
-                                    .yearMonth(UNKNOWN_YEAR_MONTH.equals(yearMonth) ? null : yearMonth)
+                                    .yearMonth(
+                                            UNKNOWN_YEAR_MONTH.equals(yearMonth) ? null : yearMonth)
                                     .title(buildGroupTitle(yearMonth))
                                     .totalCount(items.size())
                                     .items(items)

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/service/PayslipService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/service/PayslipService.java
@@ -2,6 +2,7 @@ package kr.co.awesomelead.groupware_backend.domain.payslip.service;
 
 import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.AdminPayslipDetailDto;
+import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.AdminPayslipGroupDto;
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.AdminPayslipSummaryDto;
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.EmployeePayslipDetailDto;
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.EmployeePayslipSummaryDto;
@@ -31,12 +32,15 @@ import java.text.Normalizer;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -47,6 +51,11 @@ public class PayslipService {
             Pattern.compile(
                     "^급여명세서\\(근로기준1\\)_([^_]+)_([^_]+)_([0-9]{6})\\.pdf$",
                     Pattern.CASE_INSENSITIVE);
+    private static final Pattern PAYSLIP_MONTH_PATTERN =
+            Pattern.compile(
+                    "^급여명세서\\(근로기준1\\)_[^_]+_[^_]+_([0-9]{6})\\.pdf$",
+                    Pattern.CASE_INSENSITIVE);
+    private static final String UNKNOWN_YEAR_MONTH = "UNKNOWN";
 
     private final PayslipRepository payslipRepository;
     private final PayslipMapper payslipMapper;
@@ -208,29 +217,52 @@ public class PayslipService {
     // 관리자용 보낸 급여명세서 목록 조회 (Status에 따라)
     @Transactional(readOnly = true)
     public List<AdminPayslipSummaryDto> getPayslipsForAdmin(Long adminId, PayslipStatus status) {
-        User admin =
-                userRepository
-                        .findById(adminId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        if (admin.getRole() != Role.ADMIN && admin.getRole() != Role.MASTER_ADMIN) {
-            throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_PAYSLIP);
-        }
+        validateAdminAuthority(adminId);
 
         List<Payslip> payslipList = payslipRepository.findAllByStatusOptionalWithUser(status);
 
         return payslipMapper.toAdminPayslipSummaryDtoList(payslipList);
     }
 
+    @Transactional(readOnly = true)
+    public List<AdminPayslipGroupDto> getPayslipsForAdminGrouped(Long adminId, PayslipStatus status) {
+        List<AdminPayslipSummaryDto> summaries = getPayslipsForAdmin(adminId, status);
+
+        Map<String, List<AdminPayslipSummaryDto>> groupedByYearMonth =
+                summaries.stream()
+                        .collect(
+                                Collectors.groupingBy(
+                                        summary -> extractYearMonth(summary.getOriginalFileName())));
+
+        return groupedByYearMonth.entrySet().stream()
+                .sorted((left, right) -> compareYearMonthDesc(left.getKey(), right.getKey()))
+                .map(
+                        entry -> {
+                            String yearMonth = entry.getKey();
+                            List<AdminPayslipSummaryDto> items =
+                                    entry.getValue().stream()
+                                            .sorted(
+                                                    Comparator.comparing(
+                                                                    AdminPayslipSummaryDto::getCreatedAt,
+                                                                    Comparator.nullsLast(
+                                                                            Comparator.naturalOrder()))
+                                                            .reversed())
+                                            .toList();
+
+                            return AdminPayslipGroupDto.builder()
+                                    .yearMonth(UNKNOWN_YEAR_MONTH.equals(yearMonth) ? null : yearMonth)
+                                    .title(buildGroupTitle(yearMonth))
+                                    .totalCount(items.size())
+                                    .items(items)
+                                    .build();
+                        })
+                .toList();
+    }
+
     // 관리자용 보낸 급여명세서 상세 조회
     @Transactional(readOnly = true)
     public AdminPayslipDetailDto getPayslipForAdmin(Long adminId, Long payslipId) {
-        User admin =
-                userRepository
-                        .findById(adminId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        if (admin.getRole() != Role.ADMIN && admin.getRole() != Role.MASTER_ADMIN) {
-            throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_PAYSLIP);
-        }
+        validateAdminAuthority(adminId);
 
         Payslip payslip =
                 payslipRepository
@@ -275,5 +307,57 @@ public class PayslipService {
             payslip.setReadAt(LocalDateTime.now());
         }
         return payslipMapper.toEmployeePayslipDetailDto(payslip, s3Service);
+    }
+
+    private void validateAdminAuthority(Long adminId) {
+        User admin =
+                userRepository
+                        .findById(adminId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        if (admin.getRole() != Role.ADMIN && admin.getRole() != Role.MASTER_ADMIN) {
+            throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_PAYSLIP);
+        }
+    }
+
+    private String extractYearMonth(String originalFileName) {
+        if (originalFileName == null || originalFileName.isBlank()) {
+            return UNKNOWN_YEAR_MONTH;
+        }
+
+        String normalizedPath = originalFileName.replace("\\", "/");
+        String baseFileName = normalizedPath.substring(normalizedPath.lastIndexOf('/') + 1);
+
+        Matcher matcher = PAYSLIP_MONTH_PATTERN.matcher(baseFileName);
+        if (!matcher.matches()) {
+            return UNKNOWN_YEAR_MONTH;
+        }
+        return matcher.group(1);
+    }
+
+    private String buildGroupTitle(String yearMonth) {
+        if (UNKNOWN_YEAR_MONTH.equals(yearMonth) || yearMonth == null || yearMonth.length() != 6) {
+            return "미분류 급여명세서";
+        }
+
+        int year = Integer.parseInt(yearMonth.substring(0, 4));
+        int month = Integer.parseInt(yearMonth.substring(4, 6));
+        if (month < 1 || month > 12) {
+            return "미분류 급여명세서";
+        }
+
+        return year + "년 " + month + "월 급여명세서";
+    }
+
+    private int compareYearMonthDesc(String first, String second) {
+        if (UNKNOWN_YEAR_MONTH.equals(first) && UNKNOWN_YEAR_MONTH.equals(second)) {
+            return 0;
+        }
+        if (UNKNOWN_YEAR_MONTH.equals(first)) {
+            return 1;
+        }
+        if (UNKNOWN_YEAR_MONTH.equals(second)) {
+            return -1;
+        }
+        return second.compareTo(first);
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/service/PayslipService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/service/PayslipService.java
@@ -18,28 +18,42 @@ import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
 import kr.co.awesomelead.groupware_backend.global.infra.s3.service.S3Service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.text.Normalizer;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class PayslipService {
+
+    private static final Pattern PAYSLIP_FILE_NAME_PATTERN =
+            Pattern.compile(
+                    "^급여명세서\\(근로기준1\\)_([^_]+)_([^_]+)_([0-9]{6})\\.pdf$",
+                    Pattern.CASE_INSENSITIVE);
 
     private final PayslipRepository payslipRepository;
     private final PayslipMapper payslipMapper;
     private final UserRepository userRepository;
     private final S3Service s3Service;
     private final NotificationService notificationService;
+    private final PayslipPdfInfoExtractor payslipPdfInfoExtractor;
+    private final PayslipOcrInfoExtractor payslipOcrInfoExtractor;
 
     @Transactional
     public void sendPayslip(List<MultipartFile> payslipFiles, Long userId) throws IOException {
@@ -60,26 +74,121 @@ public class PayslipService {
                 throw new CustomException(ErrorCode.ONLY_PDF_ALLOWED);
             }
 
-            String fileName =
-                    file.getOriginalFilename(); // 파일명은 "name_yyyyMMdd_급여명세서.ext" (생년월일) 형식으로 고정
-            String[] split = fileName.split("_");
+            String fileNameEmployeeName = parseEmployeeNameFromFileName(originalFileName);
+            PayslipPdfInfoExtractor.PayslipPersonalInfo pdfPersonalInfo =
+                    extractPersonalInfoWithFallback(file, originalFileName);
 
-            String name = split[0].trim();
-            String normalizedName = Normalizer.normalize(name, Normalizer.Form.NFC);
-            String birthDateStr = split[1];
-            LocalDate birthDate =
-                    LocalDate.parse(birthDateStr, DateTimeFormatter.ofPattern("yyyyMMdd"));
+            if (!isSamePersonName(fileNameEmployeeName, pdfPersonalInfo.name())) {
+                throw new CustomException(ErrorCode.PAYSLIP_USER_INFO_MISMATCH);
+            }
 
             User target =
-                    userRepository
-                            .findByNameAndBirthDate(normalizedName, birthDate)
-                            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                    findTargetUserByNameAndBirthDate(
+                            pdfPersonalInfo.name(),
+                            fileNameEmployeeName,
+                            pdfPersonalInfo.birthDate());
 
             String s3Key = s3Service.uploadFile(file);
 
             Payslip savedPayslip = savePayslipInfo(s3Key, originalFileName, target);
             notificationService.sendPayslipAlertToUser(target.getId(), savedPayslip.getId());
         }
+    }
+
+    private PayslipPdfInfoExtractor.PayslipPersonalInfo extractPersonalInfoWithFallback(
+            MultipartFile file, String originalFileName) {
+        PayslipPdfInfoExtractor.PayslipPersonalInfo primaryInfo = null;
+        boolean needsOcrFallback = false;
+
+        try {
+            primaryInfo = payslipPdfInfoExtractor.extract(file);
+            needsOcrFallback = payslipPdfInfoExtractor.isNameLikelyCorrupted(primaryInfo.name());
+        } catch (CustomException e) {
+            if (e.getErrorCode() != ErrorCode.INVALID_PAYSLIP_PDF_CONTENT) {
+                throw e;
+            }
+            needsOcrFallback = true;
+        }
+
+        if (!needsOcrFallback || !payslipOcrInfoExtractor.isOcrEnabled()) {
+            if (primaryInfo == null) {
+                throw new CustomException(ErrorCode.INVALID_PAYSLIP_PDF_CONTENT);
+            }
+            return primaryInfo;
+        }
+
+        try {
+            PayslipPdfInfoExtractor.PayslipPersonalInfo ocrInfo = payslipOcrInfoExtractor.extract(file);
+            if (!payslipPdfInfoExtractor.isNameLikelyCorrupted(ocrInfo.name())) {
+                log.info("급여명세서 OCR fallback 적용 성공 - fileName: {}", originalFileName);
+                return ocrInfo;
+            }
+            return primaryInfo != null ? primaryInfo : ocrInfo;
+        } catch (CustomException e) {
+            if (primaryInfo != null) {
+                return primaryInfo;
+            }
+            throw e;
+        }
+    }
+
+    private String parseEmployeeNameFromFileName(String originalFileName) {
+        if (originalFileName == null || originalFileName.isBlank()) {
+            throw new CustomException(ErrorCode.INVALID_PAYSLIP_FILE_NAME_FORMAT);
+        }
+
+        String baseName = extractBaseFileName(originalFileName);
+        Matcher matcher = PAYSLIP_FILE_NAME_PATTERN.matcher(baseName);
+        if (!matcher.matches()) {
+            throw new CustomException(ErrorCode.INVALID_PAYSLIP_FILE_NAME_FORMAT);
+        }
+
+        String employeeName = matcher.group(2);
+        return normalizeNameForLookup(employeeName);
+    }
+
+    private User findTargetUserByNameAndBirthDate(
+            String pdfName, String fileNameName, LocalDate birthDate) {
+        List<String> lookupCandidates = new ArrayList<>();
+        String normalizedPdfName = normalizeNameForLookup(pdfName);
+        String normalizedFileName = normalizeNameForLookup(fileNameName);
+        lookupCandidates.add(normalizedPdfName);
+        if (!normalizedPdfName.equals(normalizedFileName)) {
+            lookupCandidates.add(normalizedFileName);
+        }
+
+        for (String nameCandidate : lookupCandidates) {
+            Optional<User> foundUser =
+                    userRepository.findByNameAndBirthDate(nameCandidate, birthDate);
+            if (foundUser.isPresent()) {
+                return foundUser.get();
+            }
+        }
+
+        throw new CustomException(ErrorCode.USER_NOT_FOUND);
+    }
+
+    private boolean isSamePersonName(String fileNameName, String pdfName) {
+        String normalizedFileNameName = normalizeNameForComparison(fileNameName);
+        String normalizedPdfName = normalizeNameForComparison(pdfName);
+        return normalizedFileNameName.equals(normalizedPdfName);
+    }
+
+    private String normalizeNameForComparison(String name) {
+        return normalizeNameForLookup(name).replaceAll("\\s+", "").toLowerCase(Locale.ROOT);
+    }
+
+    private String normalizeNameForLookup(String name) {
+        if (name == null) {
+            return "";
+        }
+        return Normalizer.normalize(name, Normalizer.Form.NFC).replaceAll("\\s+", " ").trim();
+    }
+
+    private String extractBaseFileName(String fileName) {
+        String normalizedPath = fileName.replace("\\", "/");
+        String fileOnly = Paths.get(normalizedPath).getFileName().toString();
+        return Normalizer.normalize(fileOnly, Normalizer.Form.NFC);
     }
 
     @Transactional

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/service/PayslipService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/service/PayslipService.java
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -168,14 +167,27 @@ public class PayslipService {
             lookupCandidates.add(normalizedFileName);
         }
 
+        User matchedUser = null;
         for (String nameCandidate : lookupCandidates) {
-            Optional<User> foundUser =
-                    userRepository.findByNameAndBirthDate(nameCandidate, birthDate);
-            if (foundUser.isPresent()) {
-                return foundUser.get();
+            List<User> foundUsers =
+                    userRepository.findAllByNameAndBirthDate(nameCandidate, birthDate);
+
+            if (foundUsers.size() > 1) {
+                throw new CustomException(ErrorCode.AMBIGUOUS_PAYSLIP_RECIPIENT);
+            }
+            if (foundUsers.size() == 1) {
+                User foundUser = foundUsers.get(0);
+                if (matchedUser == null) {
+                    matchedUser = foundUser;
+                } else if (!matchedUser.getId().equals(foundUser.getId())) {
+                    throw new CustomException(ErrorCode.AMBIGUOUS_PAYSLIP_RECIPIENT);
+                }
             }
         }
 
+        if (matchedUser != null) {
+            return matchedUser;
+        }
         throw new CustomException(ErrorCode.USER_NOT_FOUND);
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/controller/UserController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/controller/UserController.java
@@ -13,6 +13,7 @@ import kr.co.awesomelead.groupware_backend.domain.user.dto.response.MyInfoRespon
 import kr.co.awesomelead.groupware_backend.domain.user.dto.response.UpdateMyInfoRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.user.dto.response.UserDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.user.dto.response.UserSummaryResponseDto;
+import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.JobType;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
@@ -141,6 +142,10 @@ public class UserController {
                     Role role,
             @RequestParam(required = false)
                     @io.swagger.v3.oas.annotations.Parameter(
+                            description = "근무사업장 필터 (AWESOME, MARUI)")
+                    Company workLocation,
+            @RequestParam(required = false)
+                    @io.swagger.v3.oas.annotations.Parameter(
                             description = "상태 필터 (AVAILABLE, SUSPENDED)")
                     List<Status> statuses,
             @PageableDefault(size = 20) Pageable pageable) {
@@ -152,6 +157,7 @@ public class UserController {
                                 departmentId,
                                 jobType,
                                 role,
+                                workLocation,
                                 statuses,
                                 pageable)));
     }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/controller/UserController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/controller/UserController.java
@@ -9,11 +9,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 import jakarta.validation.Valid;
 
+import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.user.dto.response.MyInfoResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.user.dto.response.UpdateMyInfoRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.user.dto.response.UserDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.user.dto.response.UserSummaryResponseDto;
-import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.JobType;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/dto/response/UserSummaryResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/dto/response/UserSummaryResponseDto.java
@@ -2,6 +2,7 @@ package kr.co.awesomelead.groupware_backend.domain.user.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.JobType;
@@ -32,6 +33,9 @@ public class UserSummaryResponseDto {
     @Schema(description = "근무 직종", example = "MANAGEMENT")
     private JobType jobType;
 
+    @Schema(description = "근무 사업장", example = "어썸리드")
+    private Company workLocation;
+
     @Schema(description = "입사일", example = "2022-03-01")
     private LocalDate hireDate;
 
@@ -46,6 +50,7 @@ public class UserSummaryResponseDto {
                 .departmentName(
                         user.getDepartment() != null ? user.getDepartment().getName() : null)
                 .jobType(user.getJobType())
+                .workLocation(user.getWorkLocation())
                 .hireDate(user.getHireDate())
                 .resignationDate(user.getResignationDate())
                 .build();

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/UserRepository.java
@@ -46,6 +46,12 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByNameAndBirthDate(
             @Param("name") String name, @Param("birthDate") LocalDate birthDate);
 
+    @Query(
+            "SELECT u FROM User u WHERE (u.nameKor = :name OR u.nameEng = :name) AND u.birthDate ="
+                    + " :birthDate")
+    List<User> findAllByNameAndBirthDate(
+            @Param("name") String name, @Param("birthDate") LocalDate birthDate);
+
     boolean existsByPhoneNumberHash(String phoneNumberHash);
 
     List<User> findAllByRole(Role role);

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/querydsl/UserQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/querydsl/UserQueryRepository.java
@@ -37,6 +37,19 @@ public class UserQueryRepository {
             Role role,
             List<Status> statuses,
             Pageable pageable) {
+        return findAllAvailableWithFilters(
+                keyword, position, departmentId, jobType, role, null, statuses, pageable);
+    }
+
+    public Page<User> findAllAvailableWithFilters(
+            String keyword,
+            Position position,
+            Long departmentId,
+            JobType jobType,
+            Role role,
+            Company workLocation,
+            List<Status> statuses,
+            Pageable pageable) {
 
         List<User> content =
                 queryFactory
@@ -49,7 +62,8 @@ public class UserQueryRepository {
                                 positionFilter(position),
                                 departmentFilter(departmentId),
                                 jobTypeFilter(jobType),
-                                roleFilter(role))
+                                roleFilter(role),
+                                workLocationFilter(workLocation))
                         .orderBy(user.id.desc())
                         .offset(pageable.getOffset())
                         .limit(pageable.getPageSize())
@@ -68,7 +82,8 @@ public class UserQueryRepository {
                                         positionFilter(position),
                                         departmentFilter(departmentId),
                                         jobTypeFilter(jobType),
-                                        roleFilter(role))
+                                        roleFilter(role),
+                                        workLocationFilter(workLocation))
                                 .fetchOne());
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserService.java
@@ -15,6 +15,7 @@ import kr.co.awesomelead.groupware_backend.domain.user.enums.MyInfoUpdateRequest
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
+import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.MyInfoUpdateRequestRepository;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.querydsl.UserQueryRepository;
@@ -198,6 +199,31 @@ public class UserService {
         return userQueryRepository
                 .findAllAvailableWithFilters(
                         keyword, position, departmentId, jobType, role, statuses, unsorted)
+                .map(UserSummaryResponseDto::from);
+    }
+
+    // 전 직원 목록 조회 (근무사업장 필터 포함)
+    @Transactional(readOnly = true)
+    public Page<UserSummaryResponseDto> getEmployeeList(
+            String keyword,
+            Position position,
+            Long departmentId,
+            JobType jobType,
+            Role role,
+            Company workLocation,
+            List<Status> statuses,
+            Pageable pageable) {
+        Pageable unsorted = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
+        return userQueryRepository
+                .findAllAvailableWithFilters(
+                        keyword,
+                        position,
+                        departmentId,
+                        jobType,
+                        role,
+                        workLocation,
+                        statuses,
+                        unsorted)
                 .map(UserSummaryResponseDto::from);
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package kr.co.awesomelead.groupware_backend.domain.user.service;
 
 import kr.co.awesomelead.groupware_backend.domain.aligo.service.PhoneAuthService;
+import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationDomainType;
 import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationMessage;
 import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
@@ -15,7 +16,6 @@ import kr.co.awesomelead.groupware_backend.domain.user.enums.MyInfoUpdateRequest
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
-import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.MyInfoUpdateRequestRepository;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.querydsl.UserQueryRepository;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
@@ -29,10 +29,8 @@ public enum ErrorCode {
     INVALID_BASE_DATE_FORMAT(HttpStatus.BAD_REQUEST, "유효하지 않은 기준일자 형식입니다. (yyyy-MM-dd)"),
     ONLY_PDF_ALLOWED(HttpStatus.BAD_REQUEST, "PDF 파일 형식만 업로드할 수 있습니다."),
     INVALID_PAYSLIP_FILE_NAME_FORMAT(HttpStatus.BAD_REQUEST, "급여명세서 파일명 형식이 올바르지 않습니다."),
-    INVALID_PAYSLIP_PDF_CONTENT(
-            HttpStatus.BAD_REQUEST, "PDF에서 직원명 또는 생년월일을 확인할 수 없습니다."),
-    PAYSLIP_USER_INFO_MISMATCH(
-            HttpStatus.BAD_REQUEST, "파일명의 직원명과 PDF의 직원 정보가 일치하지 않습니다."),
+    INVALID_PAYSLIP_PDF_CONTENT(HttpStatus.BAD_REQUEST, "PDF에서 직원명 또는 생년월일을 확인할 수 없습니다."),
+    PAYSLIP_USER_INFO_MISMATCH(HttpStatus.BAD_REQUEST, "파일명의 직원명과 PDF의 직원 정보가 일치하지 않습니다."),
     IDENTITY_VERIFICATION_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "본인인증이 완료되지 않았습니다."),
     IDENTITY_VERIFICATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 본인인증 정보를 찾을 수 없습니다."),
     NO_REJECTION_REASON_PROVIDED(HttpStatus.BAD_REQUEST, "반려 사유가 제공되지 않았습니다."),

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
@@ -28,6 +28,11 @@ public enum ErrorCode {
     FILE_UPLOAD_ERROR(HttpStatus.BAD_REQUEST, "파일 업로드 중 오류가 발생했습니다."),
     INVALID_BASE_DATE_FORMAT(HttpStatus.BAD_REQUEST, "유효하지 않은 기준일자 형식입니다. (yyyy-MM-dd)"),
     ONLY_PDF_ALLOWED(HttpStatus.BAD_REQUEST, "PDF 파일 형식만 업로드할 수 있습니다."),
+    INVALID_PAYSLIP_FILE_NAME_FORMAT(HttpStatus.BAD_REQUEST, "급여명세서 파일명 형식이 올바르지 않습니다."),
+    INVALID_PAYSLIP_PDF_CONTENT(
+            HttpStatus.BAD_REQUEST, "PDF에서 직원명 또는 생년월일을 확인할 수 없습니다."),
+    PAYSLIP_USER_INFO_MISMATCH(
+            HttpStatus.BAD_REQUEST, "파일명의 직원명과 PDF의 직원 정보가 일치하지 않습니다."),
     IDENTITY_VERIFICATION_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "본인인증이 완료되지 않았습니다."),
     IDENTITY_VERIFICATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 본인인증 정보를 찾을 수 없습니다."),
     NO_REJECTION_REASON_PROVIDED(HttpStatus.BAD_REQUEST, "반려 사유가 제공되지 않았습니다."),

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
@@ -143,6 +143,7 @@ public enum ErrorCode {
     DUPLICATE_LOGIN_ID(HttpStatus.CONFLICT, "이미 사용 중인 아이디입니다."),
     DUPLICATE_PHONE_NUMBER(HttpStatus.CONFLICT, "이미 가입된 전화번호입니다."),
     DUPLICATE_REGISTRATION_NUMBER(HttpStatus.CONFLICT, "이미 가입된 주민등록번호입니다."),
+    AMBIGUOUS_PAYSLIP_RECIPIENT(HttpStatus.CONFLICT, "동명이인으로 급여명세서 수신 대상을 특정할 수 없습니다."),
     DUPLICATE_EDUCATION_CATEGORY_CODE(HttpStatus.CONFLICT, "이미 사용 중인 교육 카테고리 코드입니다."),
     DUPLICATE_APPROVAL_TEMPLATE_CATEGORY_CODE(HttpStatus.CONFLICT, "이미 사용 중인 전자결재 양식구분 코드입니다."),
     DUPLICATE_APPROVAL_TEMPLATE_CODE(HttpStatus.CONFLICT, "이미 사용 중인 전자결재 양식 코드입니다."),

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
@@ -278,6 +278,7 @@ class AdminServiceTest {
                             .id(17L)
                             .nameKor("고영민")
                             .department(department)
+                            .workLocation(Company.AWESOME)
                             .hireDate(LocalDate.of(2025, 9, 22))
                             .resignationDate(LocalDate.of(2026, 3, 31))
                             .build();
@@ -317,6 +318,7 @@ class AdminServiceTest {
             assertThat(result.getContent().get(0).getUserId()).isEqualTo(17L);
             assertThat(result.getContent().get(0).isHasPendingMyInfoRequest()).isEqualTo(true);
             assertThat(result.getContent().get(0).getSignupStatus()).isEqualTo(Status.AVAILABLE);
+            assertThat(result.getContent().get(0).getWorkLocation()).isEqualTo(Company.AWESOME);
             assertThat(result.getContent().get(0).getHireDate())
                     .isEqualTo(LocalDate.of(2025, 9, 22));
             assertThat(result.getContent().get(0).getResignationDate())

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipMapperTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipMapperTest.java
@@ -1,13 +1,17 @@
 package kr.co.awesomelead.groupware_backend.domain.payslip;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.AdminPayslipDetailDto;
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.AdminPayslipSummaryDto;
 import kr.co.awesomelead.groupware_backend.domain.payslip.entity.Payslip;
 import kr.co.awesomelead.groupware_backend.domain.payslip.enums.PayslipStatus;
 import kr.co.awesomelead.groupware_backend.domain.payslip.mapper.PayslipMapper;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
+import kr.co.awesomelead.groupware_backend.global.infra.s3.service.S3Service;
 
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
@@ -35,6 +39,7 @@ class PayslipMapperTest {
         AdminPayslipSummaryDto response = payslipMapper.toAdminPayslipSummaryDto(payslip);
 
         assertThat(response.getEmployeeName()).isEqualTo("리딘뷰");
+        assertThat(response.getEmployPosition()).isEqualTo("사원");
         assertThat(response.getOriginalFileName()).isEqualTo(originalFileName);
         assertThat(response.getPayslipTitle()).isEqualTo("2026년 4월 급여명세서");
     }
@@ -58,5 +63,27 @@ class PayslipMapperTest {
 
         assertThat(response.getOriginalFileName()).isEqualTo(nfdFileName);
         assertThat(response.getPayslipTitle()).isEqualTo("2026년 4월 급여명세서");
+    }
+
+    @Test
+    void toAdminPayslipDetailDto_shouldMapPositionAsKorean() {
+        String originalFileName = "급여명세서(근로기준1)_10002_리딘뷰_202604.pdf";
+        User user = User.builder().nameKor("리딘뷰").position(Position.ASSISTANT_MANAGER).build();
+        Payslip payslip =
+                Payslip.builder()
+                        .id(7L)
+                        .user(user)
+                        .fileKey("payslip-7")
+                        .originalFileName(originalFileName)
+                        .createdAt(LocalDateTime.of(2026, 5, 31, 15, 29, 4))
+                        .status(PayslipStatus.SENT)
+                        .build();
+
+        S3Service s3Service = mock(S3Service.class);
+        when(s3Service.getPresignedViewUrl("payslip-7")).thenReturn("https://example.com/payslip-7");
+
+        AdminPayslipDetailDto response = payslipMapper.toAdminPayslipDetailDto(payslip, s3Service);
+
+        assertThat(response.getEmployPosition()).isEqualTo("대리");
     }
 }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipMapperTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipMapperTest.java
@@ -1,0 +1,62 @@
+package kr.co.awesomelead.groupware_backend.domain.payslip;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.AdminPayslipSummaryDto;
+import kr.co.awesomelead.groupware_backend.domain.payslip.entity.Payslip;
+import kr.co.awesomelead.groupware_backend.domain.payslip.enums.PayslipStatus;
+import kr.co.awesomelead.groupware_backend.domain.payslip.mapper.PayslipMapper;
+import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
+
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import java.time.LocalDateTime;
+import java.text.Normalizer;
+
+class PayslipMapperTest {
+
+    private final PayslipMapper payslipMapper = Mappers.getMapper(PayslipMapper.class);
+
+    @Test
+    void toAdminPayslipSummaryDto_shouldMapNameAndOriginalFileNameWithoutTitleConversion() {
+        String originalFileName = "급여명세서(근로기준1)_10002_리딘뷰_202604.pdf";
+        User user = User.builder().nameKor("리딘뷰").position(Position.STAFF).build();
+        Payslip payslip =
+                Payslip.builder()
+                        .id(5L)
+                        .user(user)
+                        .originalFileName(originalFileName)
+                        .createdAt(LocalDateTime.of(2026, 5, 31, 15, 29, 4))
+                        .status(PayslipStatus.SENT)
+                        .build();
+
+        AdminPayslipSummaryDto response = payslipMapper.toAdminPayslipSummaryDto(payslip);
+
+        assertThat(response.getEmployeeName()).isEqualTo("리딘뷰");
+        assertThat(response.getOriginalFileName()).isEqualTo(originalFileName);
+        assertThat(response.getPayslipTitle()).isEqualTo("2026년 4월 급여명세서");
+    }
+
+    @Test
+    void toAdminPayslipSummaryDto_shouldBuildTitleForNfdFileName() {
+        String nfdFileName =
+                Normalizer.normalize(
+                        "급여명세서(근로기준1)_10002_리딘뷰_202604.pdf", Normalizer.Form.NFD);
+        User user = User.builder().nameKor("리딘뷰").position(Position.STAFF).build();
+        Payslip payslip =
+                Payslip.builder()
+                        .id(6L)
+                        .user(user)
+                        .originalFileName(nfdFileName)
+                        .createdAt(LocalDateTime.of(2026, 5, 31, 15, 29, 4))
+                        .status(PayslipStatus.SENT)
+                        .build();
+
+        AdminPayslipSummaryDto response = payslipMapper.toAdminPayslipSummaryDto(payslip);
+
+        assertThat(response.getOriginalFileName()).isEqualTo(nfdFileName);
+        assertThat(response.getPayslipTitle()).isEqualTo("2026년 4월 급여명세서");
+    }
+}

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipMapperTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipMapperTest.java
@@ -16,8 +16,8 @@ import kr.co.awesomelead.groupware_backend.global.infra.s3.service.S3Service;
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 
-import java.time.LocalDateTime;
 import java.text.Normalizer;
+import java.time.LocalDateTime;
 
 class PayslipMapperTest {
 
@@ -47,8 +47,7 @@ class PayslipMapperTest {
     @Test
     void toAdminPayslipSummaryDto_shouldBuildTitleForNfdFileName() {
         String nfdFileName =
-                Normalizer.normalize(
-                        "급여명세서(근로기준1)_10002_리딘뷰_202604.pdf", Normalizer.Form.NFD);
+                Normalizer.normalize("급여명세서(근로기준1)_10002_리딘뷰_202604.pdf", Normalizer.Form.NFD);
         User user = User.builder().nameKor("리딘뷰").position(Position.STAFF).build();
         Payslip payslip =
                 Payslip.builder()
@@ -80,7 +79,8 @@ class PayslipMapperTest {
                         .build();
 
         S3Service s3Service = mock(S3Service.class);
-        when(s3Service.getPresignedViewUrl("payslip-7")).thenReturn("https://example.com/payslip-7");
+        when(s3Service.getPresignedViewUrl("payslip-7"))
+                .thenReturn("https://example.com/payslip-7");
 
         AdminPayslipDetailDto response = payslipMapper.toAdminPayslipDetailDto(payslip, s3Service);
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipServiceTest.java
@@ -134,8 +134,8 @@ public class PayslipServiceTest {
                         .willReturn(
                                 new PayslipPdfInfoExtractor.PayslipPersonalInfo(
                                         "홍길동", LocalDate.of(1990, 1, 1)));
-                given(userRepository.findByNameAndBirthDate("홍길동", LocalDate.of(1990, 1, 1)))
-                        .willReturn(Optional.of(employee));
+                given(userRepository.findAllByNameAndBirthDate("홍길동", LocalDate.of(1990, 1, 1)))
+                        .willReturn(List.of(employee));
                 given(s3Service.uploadFile(pdfFile)).willReturn("s3-key");
                 Payslip savedPayslip = Payslip.builder().id(99L).user(employee).build();
                 given(payslipRepository.save(any(Payslip.class))).willReturn(savedPayslip);
@@ -179,8 +179,8 @@ public class PayslipServiceTest {
                                 new PayslipPdfInfoExtractor.PayslipPersonalInfo(
                                         "리딘뷰", LocalDate.of(1999, 1, 5)));
                 given(payslipPdfInfoExtractor.isNameLikelyCorrupted("리딘뷰")).willReturn(false);
-                given(userRepository.findByNameAndBirthDate("리딘뷰", LocalDate.of(1999, 1, 5)))
-                        .willReturn(Optional.of(employee));
+                given(userRepository.findAllByNameAndBirthDate("리딘뷰", LocalDate.of(1999, 1, 5)))
+                        .willReturn(List.of(employee));
                 given(s3Service.uploadFile(pdfFile)).willReturn("s3-key");
                 Payslip savedPayslip = Payslip.builder().id(100L).user(employee).build();
                 given(payslipRepository.save(any(Payslip.class))).willReturn(savedPayslip);
@@ -192,6 +192,43 @@ public class PayslipServiceTest {
                 verify(payslipOcrInfoExtractor, times(1)).extract(pdfFile);
                 verify(notificationService, times(1))
                         .sendPayslipAlertToUser(employee.getId(), savedPayslip.getId());
+            }
+        }
+
+        @Nested
+        @DisplayName("이름+생년월일이 같은 사용자가 여러 명이면")
+        class Context_with_ambiguous_recipient {
+
+            @Test
+            @DisplayName("AMBIGUOUS_PAYSLIP_RECIPIENT 예외를 던진다.")
+            void it_throws_ambiguous_recipient_exception() {
+                // given
+                admin.getAuthorities().add(Authority.EDIT_EMPLOYEE_INFO);
+                given(userRepository.findById(1L)).willReturn(Optional.of(admin));
+
+                MockMultipartFile pdfFile =
+                        new MockMultipartFile(
+                                "payslipFiles",
+                                "급여명세서(근로기준1)_10001_홍길동_202605.pdf",
+                                "application/pdf",
+                                "pdf content".getBytes());
+
+                given(payslipPdfInfoExtractor.extract(pdfFile))
+                        .willReturn(
+                                new PayslipPdfInfoExtractor.PayslipPersonalInfo(
+                                        "홍길동", LocalDate.of(1990, 1, 1)));
+                given(payslipPdfInfoExtractor.isNameLikelyCorrupted("홍길동")).willReturn(false);
+
+                User duplicate1 = User.builder().id(2L).build();
+                User duplicate2 = User.builder().id(3L).build();
+                given(userRepository.findAllByNameAndBirthDate("홍길동", LocalDate.of(1990, 1, 1)))
+                        .willReturn(List.of(duplicate1, duplicate2));
+
+                // when & then
+                assertThatThrownBy(() -> payslipService.sendPayslip(List.of(pdfFile), 1L))
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue(
+                                "errorCode", ErrorCode.AMBIGUOUS_PAYSLIP_RECIPIENT);
             }
         }
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipServiceTest.java
@@ -15,6 +15,8 @@ import kr.co.awesomelead.groupware_backend.domain.payslip.entity.Payslip;
 import kr.co.awesomelead.groupware_backend.domain.payslip.enums.PayslipStatus;
 import kr.co.awesomelead.groupware_backend.domain.payslip.mapper.PayslipMapper;
 import kr.co.awesomelead.groupware_backend.domain.payslip.repository.PayslipRepository;
+import kr.co.awesomelead.groupware_backend.domain.payslip.service.PayslipOcrInfoExtractor;
+import kr.co.awesomelead.groupware_backend.domain.payslip.service.PayslipPdfInfoExtractor;
 import kr.co.awesomelead.groupware_backend.domain.payslip.service.PayslipService;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Authority;
@@ -49,6 +51,8 @@ public class PayslipServiceTest {
     @Mock private S3Service s3Service;
     @Mock private PayslipMapper payslipMapper;
     @Mock private NotificationService notificationService;
+    @Mock private PayslipPdfInfoExtractor payslipPdfInfoExtractor;
+    @Mock private PayslipOcrInfoExtractor payslipOcrInfoExtractor;
 
     private User admin;
     private User employee;
@@ -110,7 +114,7 @@ public class PayslipServiceTest {
 
             @Test
             @DisplayName("S3에 업로드하고 정보를 저장한다.")
-            void it_uploads_to_s3_and_saves_info() throws IOException, IOException {
+            void it_uploads_to_s3_and_saves_info() throws IOException {
                 // given
                 admin.getAuthorities().add(Authority.EDIT_EMPLOYEE_INFO);
                 given(userRepository.findById(1L)).willReturn(Optional.of(admin));
@@ -118,10 +122,14 @@ public class PayslipServiceTest {
                 MockMultipartFile pdfFile =
                         new MockMultipartFile(
                                 "payslipFiles",
-                                "홍길동_19900101_급여명세서.pdf",
+                                "급여명세서(근로기준1)_10001_홍길동_202605.pdf",
                                 "application/pdf",
                                 "pdf content".getBytes());
 
+                given(payslipPdfInfoExtractor.extract(pdfFile))
+                        .willReturn(
+                                new PayslipPdfInfoExtractor.PayslipPersonalInfo(
+                                        "홍길동", LocalDate.of(1990, 1, 1)));
                 given(userRepository.findByNameAndBirthDate("홍길동", LocalDate.of(1990, 1, 1)))
                         .willReturn(Optional.of(employee));
                 given(s3Service.uploadFile(pdfFile)).willReturn("s3-key");
@@ -135,6 +143,108 @@ public class PayslipServiceTest {
                 verify(s3Service, times(1)).uploadFile(any());
                 verify(payslipRepository, times(1)).save(any(Payslip.class));
                 verify(notificationService, times(1)).sendPayslipAlertToUser(employee.getId(), 99L);
+            }
+        }
+
+        @Nested
+        @DisplayName("기본 텍스트 추출 이름이 깨졌지만 OCR로 정상 추출되면")
+        class Context_with_corrupted_name_and_ocr_success {
+
+            @Test
+            @DisplayName("OCR 결과로 사용자 매칭 후 발송한다.")
+            void it_uses_ocr_result_for_matching() throws IOException {
+                // given
+                admin.getAuthorities().add(Authority.EDIT_EMPLOYEE_INFO);
+                given(userRepository.findById(1L)).willReturn(Optional.of(admin));
+
+                MockMultipartFile pdfFile =
+                        new MockMultipartFile(
+                                "payslipFiles",
+                                "급여명세서(근로기준1)_10002_리딘뷰_202604.pdf",
+                                "application/pdf",
+                                "pdf content".getBytes());
+
+                given(payslipPdfInfoExtractor.extract(pdfFile))
+                        .willReturn(
+                                new PayslipPdfInfoExtractor.PayslipPersonalInfo(
+                                        "리", LocalDate.of(1999, 1, 5)));
+                given(payslipPdfInfoExtractor.isNameLikelyCorrupted("리")).willReturn(true);
+                given(payslipOcrInfoExtractor.isOcrEnabled()).willReturn(true);
+                given(payslipOcrInfoExtractor.extract(pdfFile))
+                        .willReturn(
+                                new PayslipPdfInfoExtractor.PayslipPersonalInfo(
+                                        "리딘뷰", LocalDate.of(1999, 1, 5)));
+                given(payslipPdfInfoExtractor.isNameLikelyCorrupted("리딘뷰")).willReturn(false);
+                given(userRepository.findByNameAndBirthDate("리딘뷰", LocalDate.of(1999, 1, 5)))
+                        .willReturn(Optional.of(employee));
+                given(s3Service.uploadFile(pdfFile)).willReturn("s3-key");
+                Payslip savedPayslip = Payslip.builder().id(100L).user(employee).build();
+                given(payslipRepository.save(any(Payslip.class))).willReturn(savedPayslip);
+
+                // when
+                payslipService.sendPayslip(List.of(pdfFile), 1L);
+
+                // then
+                verify(payslipOcrInfoExtractor, times(1)).extract(pdfFile);
+                verify(notificationService, times(1))
+                        .sendPayslipAlertToUser(employee.getId(), savedPayslip.getId());
+            }
+        }
+
+        @Nested
+        @DisplayName("파일명 형식이 잘못되면")
+        class Context_with_invalid_file_name_format {
+
+            @Test
+            @DisplayName("INVALID_PAYSLIP_FILE_NAME_FORMAT 예외를 던진다.")
+            void it_throws_invalid_file_name_format_exception() {
+                // given
+                admin.getAuthorities().add(Authority.EDIT_EMPLOYEE_INFO);
+                given(userRepository.findById(1L)).willReturn(Optional.of(admin));
+
+                MockMultipartFile pdfFile =
+                        new MockMultipartFile(
+                                "payslipFiles",
+                                "홍길동_19900101_급여명세서.pdf",
+                                "application/pdf",
+                                "pdf content".getBytes());
+
+                // when & then
+                assertThatThrownBy(() -> payslipService.sendPayslip(List.of(pdfFile), 1L))
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue(
+                                "errorCode", ErrorCode.INVALID_PAYSLIP_FILE_NAME_FORMAT);
+            }
+        }
+
+        @Nested
+        @DisplayName("파일명 이름과 PDF 이름이 다르면")
+        class Context_with_file_name_and_pdf_name_mismatch {
+
+            @Test
+            @DisplayName("PAYSLIP_USER_INFO_MISMATCH 예외를 던진다.")
+            void it_throws_user_info_mismatch_exception() {
+                // given
+                admin.getAuthorities().add(Authority.EDIT_EMPLOYEE_INFO);
+                given(userRepository.findById(1L)).willReturn(Optional.of(admin));
+
+                MockMultipartFile pdfFile =
+                        new MockMultipartFile(
+                                "payslipFiles",
+                                "급여명세서(근로기준1)_10001_홍길동_202605.pdf",
+                                "application/pdf",
+                                "pdf content".getBytes());
+
+                given(payslipPdfInfoExtractor.extract(pdfFile))
+                        .willReturn(
+                                new PayslipPdfInfoExtractor.PayslipPersonalInfo(
+                                        "임꺽정", LocalDate.of(1990, 1, 1)));
+
+                // when & then
+                assertThatThrownBy(() -> payslipService.sendPayslip(List.of(pdfFile), 1L))
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue(
+                                "errorCode", ErrorCode.PAYSLIP_USER_INFO_MISMATCH);
             }
         }
     }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
+import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.AdminPayslipGroupDto;
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.AdminPayslipSummaryDto;
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.EmployeePayslipDetailDto;
 import kr.co.awesomelead.groupware_backend.domain.payslip.entity.Payslip;
@@ -39,6 +40,7 @@ import org.springframework.mock.web.MockMultipartFile;
 
 import java.io.IOException;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -300,6 +302,63 @@ public class PayslipServiceTest {
                 // then
                 assertThat(result.size()).isEqualTo(2);
                 verify(payslipRepository).findAllByStatusOptionalWithUser(null);
+            }
+        }
+
+        @Nested
+        @DisplayName("월별 그룹 조회를 요청하면")
+        class Context_with_grouped_response {
+
+            @Test
+            @DisplayName("급여지급월 기준으로 그룹핑해서 최신 월부터 반환한다.")
+            void it_returns_grouped_result() {
+                // given
+                User adminUser = User.builder().id(1L).role(Role.ADMIN).build();
+                given(userRepository.findById(1L)).willReturn(Optional.of(adminUser));
+
+                List<Payslip> payslips = List.of(new Payslip(), new Payslip(), new Payslip());
+                given(payslipRepository.findAllByStatusOptionalWithUser(null)).willReturn(payslips);
+
+                AdminPayslipSummaryDto mayFirst =
+                        AdminPayslipSummaryDto.builder()
+                                .payslipId(1L)
+                                .originalFileName("급여명세서(근로기준1)_10001_홍길동_202605.pdf")
+                                .createdAt(LocalDateTime.of(2026, 5, 20, 9, 0))
+                                .build();
+                AdminPayslipSummaryDto maySecond =
+                        AdminPayslipSummaryDto.builder()
+                                .payslipId(2L)
+                                .originalFileName("급여명세서(근로기준1)_10002_김영희_202605.pdf")
+                                .createdAt(LocalDateTime.of(2026, 5, 21, 9, 0))
+                                .build();
+                AdminPayslipSummaryDto juneOnly =
+                        AdminPayslipSummaryDto.builder()
+                                .payslipId(3L)
+                                .originalFileName("급여명세서(근로기준1)_10003_박민수_202606.pdf")
+                                .createdAt(LocalDateTime.of(2026, 6, 1, 9, 0))
+                                .build();
+                given(payslipMapper.toAdminPayslipSummaryDtoList(payslips))
+                        .willReturn(List.of(mayFirst, maySecond, juneOnly));
+
+                // when
+                List<AdminPayslipGroupDto> result =
+                        payslipService.getPayslipsForAdminGrouped(1L, null);
+
+                // then
+                assertThat(result.size()).isEqualTo(2);
+
+                AdminPayslipGroupDto firstGroup = result.get(0);
+                assertThat(firstGroup.getYearMonth()).isEqualTo("202606");
+                assertThat(firstGroup.getTitle()).isEqualTo("2026년 6월 급여명세서");
+                assertThat(firstGroup.getTotalCount()).isEqualTo(1);
+                assertThat(firstGroup.getItems().get(0).getPayslipId()).isEqualTo(3L);
+
+                AdminPayslipGroupDto secondGroup = result.get(1);
+                assertThat(secondGroup.getYearMonth()).isEqualTo("202605");
+                assertThat(secondGroup.getTitle()).isEqualTo("2026년 5월 급여명세서");
+                assertThat(secondGroup.getTotalCount()).isEqualTo(2);
+                // createdAt desc로 정렬되어 최신 건이 먼저
+                assertThat(secondGroup.getItems().get(0).getPayslipId()).isEqualTo(2L);
             }
         }
     }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipServiceTest.java
@@ -35,8 +35,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import java.io.IOException;
 import java.text.Normalizer;
@@ -561,7 +561,8 @@ public class PayslipServiceTest {
                                 .originalFileName(nfdFileName)
                                 .createdAt(LocalDateTime.of(2026, 4, 30, 9, 0))
                                 .build();
-                given(payslipMapper.toAdminPayslipSummaryDtoList(payslips)).willReturn(List.of(summary));
+                given(payslipMapper.toAdminPayslipSummaryDtoList(payslips))
+                        .willReturn(List.of(summary));
 
                 // when
                 List<AdminPayslipGroupDto> result =
@@ -635,8 +636,7 @@ public class PayslipServiceTest {
                         .willReturn(false);
 
                 // when & then
-                assertThatThrownBy(
-                                () -> payslipService.getPayslip(1L, 100L, "wrong-password"))
+                assertThatThrownBy(() -> payslipService.getPayslip(1L, 100L, "wrong-password"))
                         .isInstanceOf(CustomException.class)
                         .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PASSWORD_MISMATCH);
             }
@@ -661,7 +661,8 @@ public class PayslipServiceTest {
                         .willReturn(EmployeePayslipDetailDto.builder().payslipId(100L).build());
 
                 // when
-                EmployeePayslipDetailDto result = payslipService.getPayslip(1L, 100L, "password123!");
+                EmployeePayslipDetailDto result =
+                        payslipService.getPayslip(1L, 100L, "password123!");
 
                 // then
                 assertThat(result.getPayslipId()).isEqualTo(100L);

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipServiceTest.java
@@ -386,6 +386,55 @@ public class PayslipServiceTest {
     }
 
     @Nested
+    @DisplayName("deletePayslip 메서드는")
+    class Describe_deletePayslip {
+
+        @Test
+        @DisplayName("관리자 권한이 없으면 NO_AUTHORITY_FOR_PAYSLIP 예외를 던진다.")
+        void it_throws_no_authority_exception() {
+            // given
+            given(userRepository.findById(1L)).willReturn(Optional.of(admin));
+
+            // when & then
+            assertThatThrownBy(() -> payslipService.deletePayslip(10L, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NO_AUTHORITY_FOR_PAYSLIP);
+        }
+
+        @Test
+        @DisplayName("삭제 대상 명세서가 없으면 PAYSLIP_NOT_FOUND 예외를 던진다.")
+        void it_throws_payslip_not_found_exception() {
+            // given
+            admin.getAuthorities().add(Authority.EDIT_EMPLOYEE_INFO);
+            given(userRepository.findById(1L)).willReturn(Optional.of(admin));
+            given(payslipRepository.findById(10L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> payslipService.deletePayslip(10L, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PAYSLIP_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("유효한 삭제 요청이면 명세서와 S3 파일을 삭제한다.")
+        void it_deletes_payslip_and_s3_file() {
+            // given
+            admin.getAuthorities().add(Authority.EDIT_EMPLOYEE_INFO);
+            given(userRepository.findById(1L)).willReturn(Optional.of(admin));
+
+            Payslip payslip = Payslip.builder().id(10L).fileKey("delete-key").build();
+            given(payslipRepository.findById(10L)).willReturn(Optional.of(payslip));
+
+            // when
+            payslipService.deletePayslip(10L, 1L);
+
+            // then
+            verify(payslipRepository).delete(payslip);
+            verify(s3Service).deleteFile("delete-key");
+        }
+    }
+
+    @Nested
     @DisplayName("getPayslipsForAdmin 메서드는 (관리자용 목록 조회)")
     class Describe_getPayslipsForAdmin {
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipServiceTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.mock.web.MockMultipartFile;
 
 import java.io.IOException;
@@ -53,6 +54,7 @@ public class PayslipServiceTest {
     @Mock private NotificationService notificationService;
     @Mock private PayslipPdfInfoExtractor payslipPdfInfoExtractor;
     @Mock private PayslipOcrInfoExtractor payslipOcrInfoExtractor;
+    @Mock private BCryptPasswordEncoder bCryptPasswordEncoder;
 
     private User admin;
     private User employee;
@@ -317,7 +319,7 @@ public class PayslipServiceTest {
                 given(payslipRepository.findById(anyLong())).willReturn(Optional.empty());
 
                 // when & then
-                assertThatThrownBy(() -> payslipService.getPayslip(1L, 999L))
+                assertThatThrownBy(() -> payslipService.getPayslip(1L, 999L, "password"))
                         .isInstanceOf(CustomException.class)
                         .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PAYSLIP_NOT_FOUND);
             }
@@ -338,10 +340,34 @@ public class PayslipServiceTest {
                 Long intruderId = 1L; // 침입자 ID
 
                 // when & then
-                assertThatThrownBy(() -> payslipService.getPayslip(intruderId, 100L))
+                assertThatThrownBy(() -> payslipService.getPayslip(intruderId, 100L, "password"))
                         .isInstanceOf(CustomException.class)
                         .hasFieldOrPropertyWithValue(
                                 "errorCode", ErrorCode.NO_AUTHORITY_FOR_VIEW_PAYSLIP);
+            }
+        }
+
+        @Nested
+        @DisplayName("비밀번호가 일치하지 않으면")
+        class Context_with_wrong_password {
+
+            @Test
+            @DisplayName("PASSWORD_MISMATCH 예외를 던진다.")
+            void it_throws_password_mismatch_exception() {
+                // given
+                User owner = User.builder().id(1L).password("encoded-password").build();
+                Payslip myPayslip =
+                        Payslip.builder().id(100L).user(owner).status(PayslipStatus.SENT).build();
+
+                given(payslipRepository.findById(100L)).willReturn(Optional.of(myPayslip));
+                given(bCryptPasswordEncoder.matches("wrong-password", "encoded-password"))
+                        .willReturn(false);
+
+                // when & then
+                assertThatThrownBy(
+                                () -> payslipService.getPayslip(1L, 100L, "wrong-password"))
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PASSWORD_MISMATCH);
             }
         }
 
@@ -353,16 +379,18 @@ public class PayslipServiceTest {
             @DisplayName("상세 정보 DTO를 반환한다.")
             void it_returns_detail_dto() {
                 // given
-                User owner = User.builder().id(1L).build();
+                User owner = User.builder().id(1L).password("encoded-password").build();
                 Payslip myPayslip =
                         Payslip.builder().id(100L).user(owner).status(PayslipStatus.SENT).build();
 
                 given(payslipRepository.findById(100L)).willReturn(Optional.of(myPayslip));
+                given(bCryptPasswordEncoder.matches("password123!", "encoded-password"))
+                        .willReturn(true);
                 given(payslipMapper.toEmployeePayslipDetailDto(myPayslip, s3Service))
                         .willReturn(EmployeePayslipDetailDto.builder().payslipId(100L).build());
 
                 // when
-                EmployeePayslipDetailDto result = payslipService.getPayslip(1L, 100L);
+                EmployeePayslipDetailDto result = payslipService.getPayslip(1L, 100L, "password123!");
 
                 // then
                 assertThat(result.getPayslipId()).isEqualTo(100L);

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipServiceTest.java
@@ -292,6 +292,100 @@ public class PayslipServiceTest {
     }
 
     @Nested
+    @DisplayName("updatePayslip 메서드는")
+    class Describe_updatePayslip {
+
+        @Test
+        @DisplayName("관리자 권한이 없으면 NO_AUTHORITY_FOR_PAYSLIP 예외를 던진다.")
+        void it_throws_no_authority_exception() {
+            // given
+            given(userRepository.findById(1L)).willReturn(Optional.of(admin));
+            MockMultipartFile pdfFile =
+                    new MockMultipartFile(
+                            "payslipFile",
+                            "급여명세서(근로기준1)_10001_홍길동_202605.pdf",
+                            "application/pdf",
+                            "pdf content".getBytes());
+
+            // when & then
+            assertThatThrownBy(() -> payslipService.updatePayslip(10L, pdfFile, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NO_AUTHORITY_FOR_PAYSLIP);
+        }
+
+        @Test
+        @DisplayName("수정 대상 명세서가 없으면 PAYSLIP_NOT_FOUND 예외를 던진다.")
+        void it_throws_payslip_not_found_exception() {
+            // given
+            admin.getAuthorities().add(Authority.EDIT_EMPLOYEE_INFO);
+            given(userRepository.findById(1L)).willReturn(Optional.of(admin));
+            given(payslipRepository.findById(10L)).willReturn(Optional.empty());
+
+            MockMultipartFile pdfFile =
+                    new MockMultipartFile(
+                            "payslipFile",
+                            "급여명세서(근로기준1)_10001_홍길동_202605.pdf",
+                            "application/pdf",
+                            "pdf content".getBytes());
+
+            // when & then
+            assertThatThrownBy(() -> payslipService.updatePayslip(10L, pdfFile, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PAYSLIP_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("유효한 수정 요청이면 파일/수신자/상태를 교체하고 알림을 보낸다.")
+        void it_updates_payslip_and_sends_notification() throws IOException {
+            // given
+            admin.getAuthorities().add(Authority.EDIT_EMPLOYEE_INFO);
+            given(userRepository.findById(1L)).willReturn(Optional.of(admin));
+
+            User previousOwner = User.builder().id(50L).build();
+            Payslip payslip =
+                    Payslip.builder()
+                            .id(10L)
+                            .user(previousOwner)
+                            .fileKey("old-key")
+                            .originalFileName("급여명세서(근로기준1)_10050_기존직원_202605.pdf")
+                            .status(PayslipStatus.READ)
+                            .readAt(LocalDateTime.of(2026, 5, 30, 10, 0))
+                            .build();
+            given(payslipRepository.findById(10L)).willReturn(Optional.of(payslip));
+
+            MockMultipartFile pdfFile =
+                    new MockMultipartFile(
+                            "payslipFile",
+                            "급여명세서(근로기준1)_10001_홍길동_202605.pdf",
+                            "application/pdf",
+                            "pdf content".getBytes());
+
+            given(payslipPdfInfoExtractor.extract(pdfFile))
+                    .willReturn(
+                            new PayslipPdfInfoExtractor.PayslipPersonalInfo(
+                                    "홍길동", LocalDate.of(1990, 1, 1)));
+            given(payslipPdfInfoExtractor.isNameLikelyCorrupted("홍길동")).willReturn(false);
+            given(userRepository.findAllByNameAndBirthDate("홍길동", LocalDate.of(1990, 1, 1)))
+                    .willReturn(List.of(employee));
+            given(s3Service.uploadFile(pdfFile)).willReturn("new-key");
+
+            // when
+            payslipService.updatePayslip(10L, pdfFile, 1L);
+
+            // then
+            assertThat(payslip.getFileKey()).isEqualTo("new-key");
+            assertThat(payslip.getOriginalFileName())
+                    .isEqualTo("급여명세서(근로기준1)_10001_홍길동_202605.pdf");
+            assertThat(payslip.getUser().getId()).isEqualTo(employee.getId());
+            assertThat(payslip.getStatus()).isEqualTo(PayslipStatus.SENT);
+            assertThat(payslip.getReadAt()).isNull();
+
+            verify(notificationService).sendPayslipAlertToUser(employee.getId(), 10L);
+            verify(s3Service).deleteFile("old-key");
+        }
+    }
+
+    @Nested
     @DisplayName("getPayslipsForAdmin 메서드는 (관리자용 목록 조회)")
     class Describe_getPayslipsForAdmin {
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipServiceTest.java
@@ -39,6 +39,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.mock.web.MockMultipartFile;
 
 import java.io.IOException;
+import java.text.Normalizer;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -396,6 +397,37 @@ public class PayslipServiceTest {
                 assertThat(secondGroup.getTotalCount()).isEqualTo(2);
                 // createdAt desc로 정렬되어 최신 건이 먼저
                 assertThat(secondGroup.getItems().get(0).getPayslipId()).isEqualTo(2L);
+            }
+
+            @Test
+            @DisplayName("NFD(분해형 한글) 파일명도 정상적으로 월별 그룹핑한다.")
+            void it_groups_nfd_file_name_by_year_month() {
+                // given
+                User adminUser = User.builder().id(1L).role(Role.ADMIN).build();
+                given(userRepository.findById(1L)).willReturn(Optional.of(adminUser));
+
+                List<Payslip> payslips = List.of(new Payslip());
+                given(payslipRepository.findAllByStatusOptionalWithUser(null)).willReturn(payslips);
+
+                String nfdFileName =
+                        Normalizer.normalize(
+                                "급여명세서(근로기준1)_10002_리딘뷰_202604.pdf", Normalizer.Form.NFD);
+                AdminPayslipSummaryDto summary =
+                        AdminPayslipSummaryDto.builder()
+                                .payslipId(10L)
+                                .originalFileName(nfdFileName)
+                                .createdAt(LocalDateTime.of(2026, 4, 30, 9, 0))
+                                .build();
+                given(payslipMapper.toAdminPayslipSummaryDtoList(payslips)).willReturn(List.of(summary));
+
+                // when
+                List<AdminPayslipGroupDto> result =
+                        payslipService.getPayslipsForAdminGrouped(1L, null);
+
+                // then
+                assertThat(result.size()).isEqualTo(1);
+                assertThat(result.get(0).getYearMonth()).isEqualTo("202604");
+                assertThat(result.get(0).getTitle()).isEqualTo("2026년 4월 급여명세서");
             }
         }
     }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserServiceTest.java
@@ -455,6 +455,7 @@ class UserServiceTest {
                     .isEqualTo(Position.ASSISTANT_MANAGER);
             assertThat(result.getContent().get(0).getDepartmentName())
                     .isEqualTo(DepartmentName.CHUNGNAM_HQ);
+            assertThat(result.getContent().get(0).getWorkLocation()).isEqualTo(Company.AWESOME);
             assertThat(result.getContent().get(1).getUserId()).isEqualTo(2L);
             assertThat(result.getContent().get(1).getName()).isEqualTo("이영희");
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserServiceTest.java
@@ -575,14 +575,7 @@ class UserServiceTest {
 
             given(
                             userQueryRepository.findAllAvailableWithFilters(
-                                    null,
-                                    null,
-                                    null,
-                                    null,
-                                    null,
-                                    Company.AWESOME,
-                                    null,
-                                    unsorted))
+                                    null, null, null, null, null, Company.AWESOME, null, unsorted))
                     .willReturn(userPage);
 
             // when

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserServiceTest.java
@@ -565,6 +565,41 @@ class UserServiceTest {
         }
 
         @Test
+        @DisplayName("성공: 근무사업장 필터를 전달하면 필터 쿼리에 반영된다")
+        void getEmployeeList_withWorkLocationFilter() {
+            // given
+            Pageable pageable = PageRequest.of(0, 20);
+            Pageable unsorted = PageRequest.of(0, 20);
+            User user = createTestUser();
+            Page<User> userPage = new PageImpl<>(List.of(user), pageable, 1);
+
+            given(
+                            userQueryRepository.findAllAvailableWithFilters(
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    Company.AWESOME,
+                                    null,
+                                    unsorted))
+                    .willReturn(userPage);
+
+            // when
+            Page<UserSummaryResponseDto> result =
+                    userService.getEmployeeList(
+                            null, null, null, null, null, Company.AWESOME, null, pageable);
+
+            // then
+            assertThat(result.getTotalElements()).isEqualTo(1);
+            assertThat(result.getContent().get(0).getWorkLocation()).isEqualTo(Company.AWESOME);
+
+            verify(userQueryRepository)
+                    .findAllAvailableWithFilters(
+                            null, null, null, null, null, Company.AWESOME, null, unsorted);
+        }
+
+        @Test
         @DisplayName("성공: statuses가 null이면 Repository에 null을 전달한다")
         void getEmployeeList_statuses가_null이면_repository에_null을_전달한다() {
             // given


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #412 

## 📝작업 내용
- 급여명세서 도메인
  - 파일명 규칙 검증 + PDF 이름/생년월일 매칭 강화
  - 텍스트 깨짐 대응을 위한 OCR fallback 적용
  - 동명이인(이름+생년월일) 충돌 시 409 에러 처리
  - 직원 상세 조회 시 로그인 비밀번호 검증 후 presigned URL 발급
  - payslipTitle(YYYYMM 기반) 목록/상세 응답 추가
  - 관리자 목록을 월별 그룹 구조로 제공하고 `/api/payslips/admin`으로 경로 일원화
  - 관리자 목록/상세 `employPosition` 한국어 응답 처리
  - 관리자 보낸 명세서 수정 API 추가 (`PUT /api/payslips/admin/{payslipId}`)
  - 관리자 보낸 명세서 삭제 API 추가 (`DELETE /api/payslips/admin/{payslipId}`)

- 사용자/관리자 목록 도메인
  - `GET /api/admin/users` 응답에 `workLocation` 추가
  - `GET /api/users/list` 응답에 `workLocation` 추가
  - `GET /api/users/list`에 `workLocation` 필터 추가 (`AWESOME`, `MARUI`)

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X