### PR TITLE
feat(414): 서버 도커 이미지에 Tesseract OCR 런타임 의존성 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 FROM eclipse-temurin:17-jdk
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       tesseract-ocr \
+       tesseract-ocr-kor \
+       tesseract-ocr-eng \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY build/libs/*SNAPSHOT.jar /app.jar
 
 EXPOSE 8080


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #414 

## 📝작업 내용
- `Dockerfile`에 OCR 런타임 의존성 설치 단계 추가
  - `tesseract-ocr`
  - `tesseract-ocr-kor`
  - `tesseract-ocr-eng`
- apt 캐시 정리(`rm -rf /var/lib/apt/lists/*`)로 이미지 레이어 최적화
- 목적: 급여명세서 OCR fallback이 컨테이너 환경에서도 정상 동작하도록 보장

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [ ] 테스트를 수행함

## 💬리뷰 요구사항(선택)
- 배포 후 아래 명령으로 컨테이너 내부 검증 부탁드립니다.
  - `docker exec -it groupware-backend tesseract --version`
  - `docker exec -it groupware-backend tesseract --list-langs | grep -E '^kor$|^eng$'`