### PR TITLE
feat(417): 관리자 연차 발송 관리 API 추가

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/controller/AnnualLeaveController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/controller/AnnualLeaveController.java
@@ -92,8 +92,7 @@ public class AnnualLeaveController {
     @Operation(summary = "보낸 연차 삭제 (관리자)", description = "관리자가 특정 연차 발송 이력을 삭제합니다.")
     @DeleteMapping("/admin/{dispatchId}")
     public ResponseEntity<ApiResponse<Void>> deleteAnnualLeaveDispatch(
-            @PathVariable Long dispatchId,
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @PathVariable Long dispatchId, @AuthenticationPrincipal CustomUserDetails userDetails) {
         annualLeaveService.deleteAnnualLeaveDispatchForAdmin(userDetails.getId(), dispatchId);
         return ResponseEntity.ok(ApiResponse.onNoContent("연차 발송 이력이 성공적으로 삭제되었습니다."));
     }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/controller/AnnualLeaveController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/controller/AnnualLeaveController.java
@@ -15,9 +15,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -72,5 +74,27 @@ public class AnnualLeaveController {
                 annualLeaveService.getAnnualLeaveDispatchDetailForAdmin(
                         userDetails.getId(), dispatchId);
         return ResponseEntity.ok(ApiResponse.onSuccess(responseDto));
+    }
+
+    @Operation(summary = "보낸 연차 수정 (관리자)", description = "관리자가 특정 연차 발송 이력을 새 파일로 수정합니다.")
+    @PutMapping(value = "/admin/{dispatchId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<ExcelUploadResponseDto>> updateAnnualLeaveDispatch(
+            @PathVariable Long dispatchId,
+            @RequestPart("file") MultipartFile file,
+            @RequestParam("sheetName") String sheetName,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        ExcelUploadResponseDto responseDto =
+                annualLeaveService.updateAnnualLeaveDispatchForAdmin(
+                        userDetails.getId(), dispatchId, file, sheetName);
+        return ResponseEntity.ok(ApiResponse.onSuccess(responseDto));
+    }
+
+    @Operation(summary = "보낸 연차 삭제 (관리자)", description = "관리자가 특정 연차 발송 이력을 삭제합니다.")
+    @DeleteMapping("/admin/{dispatchId}")
+    public ResponseEntity<ApiResponse<Void>> deleteAnnualLeaveDispatch(
+            @PathVariable Long dispatchId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        annualLeaveService.deleteAnnualLeaveDispatchForAdmin(userDetails.getId(), dispatchId);
+        return ResponseEntity.ok(ApiResponse.onNoContent("연차 발송 이력이 성공적으로 삭제되었습니다."));
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/controller/AnnualLeaveController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/controller/AnnualLeaveController.java
@@ -2,6 +2,7 @@ package kr.co.awesomelead.groupware_backend.domain.annualleave.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 
+import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AdminAnnualLeaveDispatchDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AdminAnnualLeaveDispatchGroupResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AnnualLeaveResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.ExcelUploadResponseDto;
@@ -15,6 +16,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -60,6 +62,18 @@ public class AnnualLeaveController {
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         List<AdminAnnualLeaveDispatchGroupResponseDto> responseDto =
                 annualLeaveService.getAnnualLeavesForAdmin(userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(responseDto));
+    }
+
+    @Operation(summary = "보낸 연차 상세 조회 (관리자)", description = "관리자가 특정 연차 발송 이력을 상세 조회합니다.")
+    @GetMapping("/admin/{dispatchId}")
+    public ResponseEntity<ApiResponse<AdminAnnualLeaveDispatchDetailResponseDto>>
+            getAnnualLeaveDispatchDetailForAdmin(
+            @PathVariable Long dispatchId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        AdminAnnualLeaveDispatchDetailResponseDto responseDto =
+                annualLeaveService.getAnnualLeaveDispatchDetailForAdmin(
+                        userDetails.getId(), dispatchId);
         return ResponseEntity.ok(ApiResponse.onSuccess(responseDto));
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/controller/AnnualLeaveController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/controller/AnnualLeaveController.java
@@ -16,8 +16,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -53,13 +53,10 @@ public class AnnualLeaveController {
         return ResponseEntity.ok(ApiResponse.onSuccess(responseDto));
     }
 
-    @Operation(
-            summary = "보낸 연차 목록 조회 (관리자)",
-            description = "관리자가 보낸 연차 이력을 시트명 기준 그룹으로 조회합니다.")
+    @Operation(summary = "보낸 연차 목록 조회 (관리자)", description = "관리자가 보낸 연차 이력을 시트명 기준 그룹으로 조회합니다.")
     @GetMapping("/admin")
     public ResponseEntity<ApiResponse<List<AdminAnnualLeaveDispatchGroupResponseDto>>>
-            getAnnualLeavesForAdmin(
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
+            getAnnualLeavesForAdmin(@AuthenticationPrincipal CustomUserDetails userDetails) {
         List<AdminAnnualLeaveDispatchGroupResponseDto> responseDto =
                 annualLeaveService.getAnnualLeavesForAdmin(userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(responseDto));
@@ -69,8 +66,8 @@ public class AnnualLeaveController {
     @GetMapping("/admin/{dispatchId}")
     public ResponseEntity<ApiResponse<AdminAnnualLeaveDispatchDetailResponseDto>>
             getAnnualLeaveDispatchDetailForAdmin(
-            @PathVariable Long dispatchId,
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
+                    @PathVariable Long dispatchId,
+                    @AuthenticationPrincipal CustomUserDetails userDetails) {
         AdminAnnualLeaveDispatchDetailResponseDto responseDto =
                 annualLeaveService.getAnnualLeaveDispatchDetailForAdmin(
                         userDetails.getId(), dispatchId);

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/controller/AnnualLeaveController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/controller/AnnualLeaveController.java
@@ -2,6 +2,7 @@ package kr.co.awesomelead.groupware_backend.domain.annualleave.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 
+import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AdminAnnualLeaveDispatchGroupResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AnnualLeaveResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.ExcelUploadResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.service.AnnualLeaveService;
@@ -20,6 +21,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/annualleaves")
@@ -45,6 +48,18 @@ public class AnnualLeaveController {
     public ResponseEntity<ApiResponse<AnnualLeaveResponseDto>> getAnnualLeave(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         AnnualLeaveResponseDto responseDto = annualLeaveService.getAnnualLeave(userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(responseDto));
+    }
+
+    @Operation(
+            summary = "보낸 연차 목록 조회 (관리자)",
+            description = "관리자가 보낸 연차 이력을 시트명 기준 그룹으로 조회합니다.")
+    @GetMapping("/admin")
+    public ResponseEntity<ApiResponse<List<AdminAnnualLeaveDispatchGroupResponseDto>>>
+            getAnnualLeavesForAdmin(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<AdminAnnualLeaveDispatchGroupResponseDto> responseDto =
+                annualLeaveService.getAnnualLeavesForAdmin(userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess(responseDto));
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/dto/response/AdminAnnualLeaveDispatchDetailResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/dto/response/AdminAnnualLeaveDispatchDetailResponseDto.java
@@ -1,0 +1,33 @@
+package kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "관리자용 연차 발송 상세 응답")
+public class AdminAnnualLeaveDispatchDetailResponseDto {
+
+    @Schema(description = "발송 이력 ID", example = "10")
+    private Long dispatchId;
+
+    @Schema(description = "보낸 파일명", example = "2026_연차현황.xlsx")
+    private String originalFileName;
+
+    @Schema(description = "시트명", example = "2026-06")
+    private String sheetName;
+
+    @Schema(description = "업로드 시각", example = "2026-05-31T15:29:04")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "엑셀 파일 열람 URL(Presigned)", example = "https://...presigned-url")
+    private String fileUrl;
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/dto/response/AdminAnnualLeaveDispatchGroupResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/dto/response/AdminAnnualLeaveDispatchGroupResponseDto.java
@@ -1,0 +1,30 @@
+package kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "관리자용 연차 발송 목록 그룹 응답")
+public class AdminAnnualLeaveDispatchGroupResponseDto {
+
+    @Schema(description = "시트명", example = "2026-06")
+    private String sheetName;
+
+    @Schema(description = "그룹 제목(시트명)", example = "2026-06")
+    private String title;
+
+    @Schema(description = "해당 시트 발송 건수", example = "3")
+    private int totalCount;
+
+    @Schema(description = "해당 시트의 발송 목록")
+    private List<AdminAnnualLeaveDispatchItemResponseDto> items;
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/dto/response/AdminAnnualLeaveDispatchItemResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/dto/response/AdminAnnualLeaveDispatchItemResponseDto.java
@@ -14,6 +14,9 @@ import lombok.NoArgsConstructor;
 @Schema(description = "관리자용 연차 발송 목록 아이템")
 public class AdminAnnualLeaveDispatchItemResponseDto {
 
+    @Schema(description = "발송 이력 ID", example = "10")
+    private Long dispatchId;
+
     @Schema(description = "보낸 파일명", example = "2026년_연차현황.xlsx")
     private String originalFileName;
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/dto/response/AdminAnnualLeaveDispatchItemResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/dto/response/AdminAnnualLeaveDispatchItemResponseDto.java
@@ -1,0 +1,25 @@
+package kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "관리자용 연차 발송 목록 아이템")
+public class AdminAnnualLeaveDispatchItemResponseDto {
+
+    @Schema(description = "보낸 파일명", example = "2026년_연차현황.xlsx")
+    private String originalFileName;
+
+    @Schema(description = "시트명", example = "2026-06")
+    private String sheetName;
+
+    @Schema(description = "엑셀 파일 열람 URL(Presigned)", example = "https://...presigned-url")
+    private String fileUrl;
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/entity/AnnualLeaveDispatchHistory.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/entity/AnnualLeaveDispatchHistory.java
@@ -1,0 +1,55 @@
+package kr.co.awesomelead.groupware_backend.domain.annualleave.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class AnnualLeaveDispatchHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "uploaded_by_user_id", nullable = false)
+    private User uploadedBy;
+
+    @Column(nullable = false, length = 255)
+    private String originalFileName;
+
+    @Column(nullable = false, length = 120)
+    private String sheetName;
+
+    @Column(length = 500)
+    private String fileKey;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/repository/AnnualLeaveDispatchHistoryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/repository/AnnualLeaveDispatchHistoryRepository.java
@@ -1,0 +1,15 @@
+package kr.co.awesomelead.groupware_backend.domain.annualleave.repository;
+
+import kr.co.awesomelead.groupware_backend.domain.annualleave.entity.AnnualLeaveDispatchHistory;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface AnnualLeaveDispatchHistoryRepository
+        extends JpaRepository<AnnualLeaveDispatchHistory, Long> {
+
+    @Query("SELECT h FROM AnnualLeaveDispatchHistory h ORDER BY h.createdAt DESC, h.id DESC")
+    List<AnnualLeaveDispatchHistory> findAllOrderByCreatedAtDesc();
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
@@ -1,10 +1,14 @@
 package kr.co.awesomelead.groupware_backend.domain.annualleave.service;
 
+import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AdminAnnualLeaveDispatchGroupResponseDto;
+import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AdminAnnualLeaveDispatchItemResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AnnualLeaveResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.ExcelUploadResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.ExcelUploadResponseDto.FailureDetail;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.entity.AnnualLeave;
+import kr.co.awesomelead.groupware_backend.domain.annualleave.entity.AnnualLeaveDispatchHistory;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.mapper.AnnualLeaveMapper;
+import kr.co.awesomelead.groupware_backend.domain.annualleave.repository.AnnualLeaveDispatchHistoryRepository;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.repository.AnnualLeaveRepository;
 import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
@@ -12,6 +16,7 @@ import kr.co.awesomelead.groupware_backend.domain.user.enums.Authority;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
 import kr.co.awesomelead.groupware_backend.global.error.CustomException;
 import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
+import kr.co.awesomelead.groupware_backend.global.infra.s3.service.S3Service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,7 +37,11 @@ import java.io.InputStream;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -40,21 +49,17 @@ import java.util.List;
 public class AnnualLeaveService {
 
     private final AnnualLeaveRepository annualLeaveRepository;
+    private final AnnualLeaveDispatchHistoryRepository annualLeaveDispatchHistoryRepository;
     private final AnnualLeaveMapper annualLeaveMapper;
     private final UserRepository userRepository;
     private final NotificationService notificationService;
+    private final S3Service s3Service;
 
     @Transactional
     public ExcelUploadResponseDto uploadAnnualLeaveFile(
             MultipartFile file, String sheetName, Long userId) {
-        // 유저의 연차발송 권한 확인
-        User currentUser =
-                userRepository
-                        .findById(userId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        if (!currentUser.hasAuthority(Authority.EDIT_EMPLOYEE_INFO)) {
-            throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_ANNUAL_LEAVE);
-        }
+        User currentUser = validateAnnualLeaveEditAuthority(userId);
+        String normalizedSheetName = normalizeSheetName(sheetName);
 
         List<FailureDetail> failures = new ArrayList<>();
         int successCount = 0;
@@ -63,7 +68,8 @@ public class AnnualLeaveService {
         try (InputStream is = file.getInputStream();
                 Workbook workbook = WorkbookFactory.create(is)) {
 
-            Sheet sheet = workbook.getSheet(sheetName); // 하나의 엑셀파일에서 월별로 시트를 구분하는 것으로 확인
+            Sheet sheet =
+                    workbook.getSheet(normalizedSheetName); // 하나의 엑셀파일에서 월별로 시트를 구분하는 것으로 확인
 
             // 기준일 파싱 (5행 J열(Index 9)에서 기준일 추출)
             LocalDate baseUpdateDate = parseBaseDate(sheet);
@@ -94,12 +100,16 @@ public class AnnualLeaveService {
             throw new CustomException(ErrorCode.FILE_UPLOAD_ERROR);
         }
 
-        return ExcelUploadResponseDto.builder()
+        ExcelUploadResponseDto response =
+                ExcelUploadResponseDto.builder()
                 .totalCount(totalProcessed)
                 .successCount(successCount)
                 .failureCount(failures.size())
                 .failures(failures)
                 .build();
+        String fileKey = uploadAnnualLeaveSourceFile(file);
+        saveDispatchHistory(currentUser, file.getOriginalFilename(), normalizedSheetName, fileKey);
+        return response;
     }
 
     private void processAnnualLeaveRow(Row row, LocalDate updateDate) {
@@ -203,5 +213,92 @@ public class AnnualLeaveService {
                         .findById(userId)
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         return annualLeaveMapper.toAnnualLeaveResponseDto(user.getAnnualLeave());
+    }
+
+    @Transactional(readOnly = true)
+    public List<AdminAnnualLeaveDispatchGroupResponseDto> getAnnualLeavesForAdmin(Long userId) {
+        validateAnnualLeaveEditAuthority(userId);
+
+        List<AnnualLeaveDispatchHistory> histories =
+                annualLeaveDispatchHistoryRepository.findAllOrderByCreatedAtDesc();
+        Map<String, List<AnnualLeaveDispatchHistory>> groupedBySheetName =
+                histories.stream()
+                        .collect(
+                                Collectors.groupingBy(
+                                        history -> normalizeSheetName(history.getSheetName()),
+                                        LinkedHashMap::new,
+                                        Collectors.toList()));
+
+        return groupedBySheetName.entrySet().stream()
+                .map(
+                        entry -> {
+                            String sheetName = entry.getKey();
+                            List<AdminAnnualLeaveDispatchItemResponseDto> items =
+                                    entry.getValue().stream()
+                                            .map(this::toDispatchItemDto)
+                                            .toList();
+
+                            return AdminAnnualLeaveDispatchGroupResponseDto.builder()
+                                    .sheetName(sheetName)
+                                    .title(sheetName)
+                                    .totalCount(items.size())
+                                    .items(items)
+                                    .build();
+                        })
+                .toList();
+    }
+
+    private AdminAnnualLeaveDispatchItemResponseDto toDispatchItemDto(
+            AnnualLeaveDispatchHistory history) {
+        return AdminAnnualLeaveDispatchItemResponseDto.builder()
+                .originalFileName(history.getOriginalFileName())
+                .sheetName(normalizeSheetName(history.getSheetName()))
+                .fileUrl(s3Service.getPresignedViewUrl(history.getFileKey()))
+                .build();
+    }
+
+    private User validateAnnualLeaveEditAuthority(Long userId) {
+        User currentUser =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        if (!currentUser.hasAuthority(Authority.EDIT_EMPLOYEE_INFO)) {
+            throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_ANNUAL_LEAVE);
+        }
+        return currentUser;
+    }
+
+    private void saveDispatchHistory(
+            User uploader, String originalFileName, String sheetName, String fileKey) {
+        AnnualLeaveDispatchHistory history =
+                AnnualLeaveDispatchHistory.builder()
+                        .uploadedBy(uploader)
+                        .originalFileName(normalizeOriginalFileName(originalFileName))
+                        .sheetName(normalizeSheetName(sheetName))
+                        .fileKey(fileKey)
+                        .build();
+        annualLeaveDispatchHistoryRepository.save(history);
+    }
+
+    private String uploadAnnualLeaveSourceFile(MultipartFile file) {
+        try {
+            return s3Service.uploadFile(file);
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.FILE_UPLOAD_ERROR);
+        }
+    }
+
+    private String normalizeOriginalFileName(String originalFileName) {
+        if (originalFileName == null || originalFileName.isBlank()) {
+            return "unknown.xlsx";
+        }
+        return originalFileName.trim();
+    }
+
+    private String normalizeSheetName(String sheetName) {
+        if (sheetName == null || sheetName.isBlank()) {
+            return "미분류 시트";
+        }
+        return Objects.requireNonNull(sheetName).trim();
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
@@ -251,6 +251,7 @@ public class AnnualLeaveService {
     private AdminAnnualLeaveDispatchItemResponseDto toDispatchItemDto(
             AnnualLeaveDispatchHistory history) {
         return AdminAnnualLeaveDispatchItemResponseDto.builder()
+                .dispatchId(history.getId())
                 .originalFileName(history.getOriginalFileName())
                 .sheetName(normalizeSheetName(history.getSheetName()))
                 .fileUrl(s3Service.getPresignedViewUrl(history.getFileKey()))

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
@@ -1,5 +1,6 @@
 package kr.co.awesomelead.groupware_backend.domain.annualleave.service;
 
+import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AdminAnnualLeaveDispatchDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AdminAnnualLeaveDispatchGroupResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AdminAnnualLeaveDispatchItemResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AnnualLeaveResponseDto;
@@ -254,6 +255,29 @@ public class AnnualLeaveService {
                 .dispatchId(history.getId())
                 .originalFileName(history.getOriginalFileName())
                 .sheetName(normalizeSheetName(history.getSheetName()))
+                .fileUrl(s3Service.getPresignedViewUrl(history.getFileKey()))
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public AdminAnnualLeaveDispatchDetailResponseDto getAnnualLeaveDispatchDetailForAdmin(
+            Long userId, Long dispatchId) {
+        validateAnnualLeaveEditAuthority(userId);
+
+        AnnualLeaveDispatchHistory history =
+                annualLeaveDispatchHistoryRepository
+                        .findById(dispatchId)
+                        .orElseThrow(
+                                () ->
+                                        new CustomException(
+                                                ErrorCode
+                                                        .ANNUAL_LEAVE_DISPATCH_HISTORY_NOT_FOUND));
+
+        return AdminAnnualLeaveDispatchDetailResponseDto.builder()
+                .dispatchId(history.getId())
+                .originalFileName(history.getOriginalFileName())
+                .sheetName(normalizeSheetName(history.getSheetName()))
+                .createdAt(history.getCreatedAt())
                 .fileUrl(s3Service.getPresignedViewUrl(history.getFileKey()))
                 .build();
     }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
@@ -61,7 +61,77 @@ public class AnnualLeaveService {
             MultipartFile file, String sheetName, Long userId) {
         User currentUser = validateAnnualLeaveEditAuthority(userId);
         String normalizedSheetName = normalizeSheetName(sheetName);
+        ExcelUploadResponseDto response = processAnnualLeaveFile(file, normalizedSheetName);
+        String fileKey = uploadAnnualLeaveSourceFile(file);
+        saveDispatchHistory(currentUser, file.getOriginalFilename(), normalizedSheetName, fileKey);
+        return response;
+    }
 
+    @Transactional
+    public ExcelUploadResponseDto updateAnnualLeaveDispatchForAdmin(
+            Long userId, Long dispatchId, MultipartFile file, String sheetName) {
+        User currentUser = validateAnnualLeaveEditAuthority(userId);
+        AnnualLeaveDispatchHistory history =
+                annualLeaveDispatchHistoryRepository
+                        .findById(dispatchId)
+                        .orElseThrow(
+                                () ->
+                                        new CustomException(
+                                                ErrorCode
+                                                        .ANNUAL_LEAVE_DISPATCH_HISTORY_NOT_FOUND));
+        String normalizedSheetName = normalizeSheetName(sheetName);
+        ExcelUploadResponseDto response = processAnnualLeaveFile(file, normalizedSheetName);
+
+        String oldFileKey = history.getFileKey();
+        String newFileKey = uploadAnnualLeaveSourceFile(file);
+
+        history.setUploadedBy(currentUser);
+        history.setOriginalFileName(normalizeOriginalFileName(file.getOriginalFilename()));
+        history.setSheetName(normalizeSheetName(sheetName));
+        history.setFileKey(newFileKey);
+
+        if (oldFileKey != null && !oldFileKey.isBlank() && !oldFileKey.equals(newFileKey)) {
+            try {
+                s3Service.deleteFile(oldFileKey);
+            } catch (RuntimeException e) {
+                log.warn(
+                        "연차 발송 기존 파일 삭제 실패 - dispatchId: {}, fileKey: {}",
+                        dispatchId,
+                        oldFileKey,
+                        e);
+            }
+        }
+
+        return response;
+    }
+
+    @Transactional
+    public void deleteAnnualLeaveDispatchForAdmin(Long userId, Long dispatchId) {
+        validateAnnualLeaveEditAuthority(userId);
+
+        AnnualLeaveDispatchHistory history =
+                annualLeaveDispatchHistoryRepository
+                        .findById(dispatchId)
+                        .orElseThrow(
+                                () ->
+                                        new CustomException(
+                                                ErrorCode
+                                                        .ANNUAL_LEAVE_DISPATCH_HISTORY_NOT_FOUND));
+
+        String fileKey = history.getFileKey();
+        annualLeaveDispatchHistoryRepository.delete(history);
+
+        if (fileKey != null && !fileKey.isBlank()) {
+            try {
+                s3Service.deleteFile(fileKey);
+            } catch (RuntimeException e) {
+                log.warn("연차 발송 파일 삭제 실패 - dispatchId: {}, fileKey: {}", dispatchId, fileKey, e);
+            }
+        }
+    }
+
+    private ExcelUploadResponseDto processAnnualLeaveFile(
+            MultipartFile file, String normalizedSheetName) {
         List<FailureDetail> failures = new ArrayList<>();
         int successCount = 0;
         int totalProcessed = 0;
@@ -102,13 +172,11 @@ public class AnnualLeaveService {
 
         ExcelUploadResponseDto response =
                 ExcelUploadResponseDto.builder()
-                        .totalCount(totalProcessed)
-                        .successCount(successCount)
-                        .failureCount(failures.size())
-                        .failures(failures)
-                        .build();
-        String fileKey = uploadAnnualLeaveSourceFile(file);
-        saveDispatchHistory(currentUser, file.getOriginalFilename(), normalizedSheetName, fileKey);
+                .totalCount(totalProcessed)
+                .successCount(successCount)
+                .failureCount(failures.size())
+                .failures(failures)
+                .build();
         return response;
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
@@ -69,8 +69,7 @@ public class AnnualLeaveService {
         try (InputStream is = file.getInputStream();
                 Workbook workbook = WorkbookFactory.create(is)) {
 
-            Sheet sheet =
-                    workbook.getSheet(normalizedSheetName); // 하나의 엑셀파일에서 월별로 시트를 구분하는 것으로 확인
+            Sheet sheet = workbook.getSheet(normalizedSheetName); // 하나의 엑셀파일에서 월별로 시트를 구분하는 것으로 확인
 
             // 기준일 파싱 (5행 J열(Index 9)에서 기준일 추출)
             LocalDate baseUpdateDate = parseBaseDate(sheet);
@@ -103,11 +102,11 @@ public class AnnualLeaveService {
 
         ExcelUploadResponseDto response =
                 ExcelUploadResponseDto.builder()
-                .totalCount(totalProcessed)
-                .successCount(successCount)
-                .failureCount(failures.size())
-                .failures(failures)
-                .build();
+                        .totalCount(totalProcessed)
+                        .successCount(successCount)
+                        .failureCount(failures.size())
+                        .failures(failures)
+                        .build();
         String fileKey = uploadAnnualLeaveSourceFile(file);
         saveDispatchHistory(currentUser, file.getOriginalFilename(), normalizedSheetName, fileKey);
         return response;
@@ -235,9 +234,7 @@ public class AnnualLeaveService {
                         entry -> {
                             String sheetName = entry.getKey();
                             List<AdminAnnualLeaveDispatchItemResponseDto> items =
-                                    entry.getValue().stream()
-                                            .map(this::toDispatchItemDto)
-                                            .toList();
+                                    entry.getValue().stream().map(this::toDispatchItemDto).toList();
 
                             return AdminAnnualLeaveDispatchGroupResponseDto.builder()
                                     .sheetName(sheetName)
@@ -270,8 +267,7 @@ public class AnnualLeaveService {
                         .orElseThrow(
                                 () ->
                                         new CustomException(
-                                                ErrorCode
-                                                        .ANNUAL_LEAVE_DISPATCH_HISTORY_NOT_FOUND));
+                                                ErrorCode.ANNUAL_LEAVE_DISPATCH_HISTORY_NOT_FOUND));
 
         return AdminAnnualLeaveDispatchDetailResponseDto.builder()
                 .dispatchId(history.getId())

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
@@ -77,8 +77,7 @@ public class AnnualLeaveService {
                         .orElseThrow(
                                 () ->
                                         new CustomException(
-                                                ErrorCode
-                                                        .ANNUAL_LEAVE_DISPATCH_HISTORY_NOT_FOUND));
+                                                ErrorCode.ANNUAL_LEAVE_DISPATCH_HISTORY_NOT_FOUND));
         String normalizedSheetName = normalizeSheetName(sheetName);
         ExcelUploadResponseDto response = processAnnualLeaveFile(file, normalizedSheetName);
 
@@ -115,8 +114,7 @@ public class AnnualLeaveService {
                         .orElseThrow(
                                 () ->
                                         new CustomException(
-                                                ErrorCode
-                                                        .ANNUAL_LEAVE_DISPATCH_HISTORY_NOT_FOUND));
+                                                ErrorCode.ANNUAL_LEAVE_DISPATCH_HISTORY_NOT_FOUND));
 
         String fileKey = history.getFileKey();
         annualLeaveDispatchHistoryRepository.delete(history);
@@ -172,11 +170,11 @@ public class AnnualLeaveService {
 
         ExcelUploadResponseDto response =
                 ExcelUploadResponseDto.builder()
-                .totalCount(totalProcessed)
-                .successCount(successCount)
-                .failureCount(failures.size())
-                .failures(failures)
-                .build();
+                        .totalCount(totalProcessed)
+                        .successCount(successCount)
+                        .failureCount(failures.size())
+                        .failures(failures)
+                        .build();
         return response;
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
@@ -124,6 +124,7 @@ public enum ErrorCode {
     REQUEST_HISTORY_NOT_CANCELABLE(HttpStatus.BAD_REQUEST, "대기 상태 요청만 취소할 수 있습니다."),
     REQUEST_HISTORY_NOT_DELETABLE(HttpStatus.BAD_REQUEST, "PENDING 상태 요청만 삭제할 수 있습니다."),
     PAYSLIP_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 급여명세서를 찾을 수 없습니다."),
+    ANNUAL_LEAVE_DISPATCH_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 연차 발송 이력을 찾을 수 없습니다."),
     EDUCATION_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 교육 카테고리를 찾을 수 없습니다."),
     RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 방문기록을 찾을 수 없습니다."),
     FCM_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 FCM 토큰을 찾을 수 없습니다."),

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
@@ -345,6 +345,158 @@ public class AnnualLeaveServiceTest {
     }
 
     @Nested
+    @DisplayName("updateAnnualLeaveDispatchForAdmin 메서드는")
+    class Describe_updateAnnualLeaveDispatchForAdmin {
+
+        @Test
+        @DisplayName("연차 발송 권한이 없는 유저가 요청하면 NO_AUTHORITY_FOR_ANNUAL_LEAVE 예외를 던진다")
+        void it_throws_when_user_has_no_authority() throws IOException {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(createMockUser(null)));
+            MultipartFile mockFile = createMockExcelFile();
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    annualLeaveService.updateAnnualLeaveDispatchForAdmin(
+                                            userId, 10L, mockFile, "8월"))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining("연차 발송 권한이 없습니다.");
+        }
+
+        @Test
+        @DisplayName("해당 발송 이력이 없으면 ANNUAL_LEAVE_DISPATCH_HISTORY_NOT_FOUND 예외를 던진다")
+        void it_throws_when_history_not_found() throws IOException {
+            // given
+            Long adminId = 1L;
+            User admin = createMockUser(Authority.EDIT_EMPLOYEE_INFO);
+            given(userRepository.findById(adminId)).willReturn(Optional.of(admin));
+            given(annualLeaveDispatchHistoryRepository.findById(999L)).willReturn(Optional.empty());
+            MultipartFile mockFile = createMockExcelFile();
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    annualLeaveService.updateAnnualLeaveDispatchForAdmin(
+                                            adminId, 999L, mockFile, "8월"))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining("해당 연차 발송 이력을 찾을 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("권한이 있는 관리자가 요청하면 발송 이력을 수정하고 기존 파일을 삭제한다")
+        void it_updates_dispatch_history() throws IOException {
+            // given
+            Long adminId = 1L;
+            Long dispatchId = 10L;
+            User admin = createMockUser(Authority.EDIT_EMPLOYEE_INFO);
+            given(userRepository.findById(adminId)).willReturn(Optional.of(admin));
+
+            AnnualLeaveDispatchHistory history =
+                    AnnualLeaveDispatchHistory.builder()
+                            .id(dispatchId)
+                            .uploadedBy(admin)
+                            .originalFileName("old.xlsx")
+                            .sheetName("7월")
+                            .fileKey("annual-leave/old.xlsx")
+                            .build();
+            given(annualLeaveDispatchHistoryRepository.findById(dispatchId))
+                    .willReturn(Optional.of(history));
+
+            MultipartFile mockFile = createMockExcelFile();
+            User targetUser =
+                    User.builder()
+                            .nameKor("테스트 유저")
+                            .hireDate(LocalDate.of(2025, 12, 31))
+                            .build();
+            given(userRepository.findByNameAndJoinDate(anyString(), any()))
+                    .willReturn(Optional.of(targetUser));
+            given(annualLeaveRepository.findByUser(targetUser)).willReturn(Optional.empty());
+            given(s3Service.uploadFile(mockFile)).willReturn("annual-leave/new.xlsx");
+
+            // when
+            ExcelUploadResponseDto result =
+                    annualLeaveService.updateAnnualLeaveDispatchForAdmin(
+                            adminId, dispatchId, mockFile, "8월");
+
+            // then
+            assertThat(result.getSuccessCount()).isGreaterThan(0);
+            assertThat(history.getOriginalFileName()).isEqualTo("annual_leave_test.xlsx");
+            assertThat(history.getSheetName()).isEqualTo("8월");
+            assertThat(history.getFileKey()).isEqualTo("annual-leave/new.xlsx");
+            verify(s3Service).deleteFile("annual-leave/old.xlsx");
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteAnnualLeaveDispatchForAdmin 메서드는")
+    class Describe_deleteAnnualLeaveDispatchForAdmin {
+
+        @Test
+        @DisplayName("연차 발송 권한이 없는 유저가 요청하면 NO_AUTHORITY_FOR_ANNUAL_LEAVE 예외를 던진다")
+        void it_throws_when_user_has_no_authority() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(createMockUser(null)));
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    annualLeaveService.deleteAnnualLeaveDispatchForAdmin(
+                                            userId, 10L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining("연차 발송 권한이 없습니다.");
+        }
+
+        @Test
+        @DisplayName("해당 발송 이력이 없으면 ANNUAL_LEAVE_DISPATCH_HISTORY_NOT_FOUND 예외를 던진다")
+        void it_throws_when_history_not_found() {
+            // given
+            Long adminId = 1L;
+            User admin = createMockUser(Authority.EDIT_EMPLOYEE_INFO);
+            given(userRepository.findById(adminId)).willReturn(Optional.of(admin));
+            given(annualLeaveDispatchHistoryRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    annualLeaveService.deleteAnnualLeaveDispatchForAdmin(
+                                            adminId, 999L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining("해당 연차 발송 이력을 찾을 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("권한이 있는 관리자가 요청하면 발송 이력과 연결 파일을 삭제한다")
+        void it_deletes_dispatch_history() {
+            // given
+            Long adminId = 1L;
+            Long dispatchId = 10L;
+            User admin = createMockUser(Authority.EDIT_EMPLOYEE_INFO);
+            given(userRepository.findById(adminId)).willReturn(Optional.of(admin));
+
+            AnnualLeaveDispatchHistory history =
+                    AnnualLeaveDispatchHistory.builder()
+                            .id(dispatchId)
+                            .uploadedBy(admin)
+                            .originalFileName("2026_연차현황.xlsx")
+                            .sheetName("8월")
+                            .fileKey("annual-leave/2026-08.xlsx")
+                            .build();
+            given(annualLeaveDispatchHistoryRepository.findById(dispatchId))
+                    .willReturn(Optional.of(history));
+
+            // when
+            annualLeaveService.deleteAnnualLeaveDispatchForAdmin(adminId, dispatchId);
+
+            // then
+            verify(annualLeaveDispatchHistoryRepository).delete(history);
+            verify(s3Service).deleteFile("annual-leave/2026-08.xlsx");
+        }
+    }
+
+    @Nested
     @DisplayName("getAnnualLeaveDispatchDetailForAdmin 메서드는")
     class Describe_getAnnualLeaveDispatchDetailForAdmin {
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
@@ -413,7 +413,8 @@ public class AnnualLeaveServiceTest {
             assertThat(result.getDispatchId()).isEqualTo(10L);
             assertThat(result.getOriginalFileName()).isEqualTo("2026_연차현황.xlsx");
             assertThat(result.getSheetName()).isEqualTo("2026-06");
-            assertThat(result.getFileUrl()).isEqualTo("https://example.com/annual-leave-2026-06-first");
+            assertThat(result.getFileUrl())
+                    .isEqualTo("https://example.com/annual-leave-2026-06-first");
         }
     }
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
@@ -327,6 +327,7 @@ public class AnnualLeaveServiceTest {
             assertThat(result.get(0).getSheetName()).isEqualTo("2026-06");
             assertThat(result.get(0).getTitle()).isEqualTo("2026-06");
             assertThat(result.get(0).getTotalCount()).isEqualTo(2);
+            assertThat(result.get(0).getItems().get(0).getDispatchId()).isEqualTo(10L);
             assertThat(result.get(0).getItems().get(0).getOriginalFileName())
                     .isEqualTo("2026_연차현황.xlsx");
             assertThat(result.get(0).getItems().get(1).getOriginalFileName())

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
@@ -8,17 +8,22 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 
+import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AdminAnnualLeaveDispatchGroupResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AnnualLeaveResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.ExcelUploadResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.entity.AnnualLeave;
+import kr.co.awesomelead.groupware_backend.domain.annualleave.entity.AnnualLeaveDispatchHistory;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.mapper.AnnualLeaveMapper;
+import kr.co.awesomelead.groupware_backend.domain.annualleave.repository.AnnualLeaveDispatchHistoryRepository;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.repository.AnnualLeaveRepository;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.service.AnnualLeaveService;
 import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Authority;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
 import kr.co.awesomelead.groupware_backend.global.error.CustomException;
+import kr.co.awesomelead.groupware_backend.global.infra.s3.service.S3Service;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -33,18 +38,21 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
 public class AnnualLeaveServiceTest {
 
     @Mock private AnnualLeaveRepository annualLeaveRepository;
+    @Mock private AnnualLeaveDispatchHistoryRepository annualLeaveDispatchHistoryRepository;
 
     @Mock private UserRepository userRepository;
 
     @Mock private AnnualLeaveMapper annualLeaveMapper;
 
     @Mock private NotificationService notificationService;
+    @Mock private S3Service s3Service;
 
     @InjectMocks private AnnualLeaveService annualLeaveService;
 
@@ -98,6 +106,7 @@ public class AnnualLeaveServiceTest {
                 given(userRepository.findByNameAndJoinDate(anyString(), any()))
                         .willReturn(Optional.of(targetUser));
                 given(annualLeaveRepository.findByUser(targetUser)).willReturn(Optional.empty());
+                given(s3Service.uploadFile(mockFile)).willReturn("annual-leave/history-1.xlsx");
 
                 // when
                 ExcelUploadResponseDto response =
@@ -109,6 +118,7 @@ public class AnnualLeaveServiceTest {
                 verify(annualLeaveRepository, atLeastOnce()).save(any());
                 verify(notificationService, atLeastOnce())
                         .sendAnnualLeaveAlertToUser(any(), anyString());
+                verify(annualLeaveDispatchHistoryRepository, atLeastOnce()).save(any());
             }
         }
 
@@ -247,6 +257,88 @@ public class AnnualLeaveServiceTest {
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining("사용자를 찾을 수 없습니다.");
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("getAnnualLeavesForAdmin 메서드는")
+    class Describe_getAnnualLeavesForAdmin {
+
+        @Test
+        @DisplayName("연차 발송 권한이 없는 유저가 요청하면 NO_AUTHORITY_FOR_ANNUAL_LEAVE 예외를 던진다")
+        void it_throws_when_user_has_no_authority() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(createMockUser(null)));
+
+            // when & then
+            assertThatThrownBy(() -> annualLeaveService.getAnnualLeavesForAdmin(userId))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining("연차 발송 권한이 없습니다.");
+        }
+
+        @Test
+        @DisplayName("권한이 있는 관리자가 요청하면 시트명 그룹으로 발송 목록을 반환한다")
+        void it_returns_dispatched_annual_leave_list() {
+            // given
+            Long adminId = 1L;
+            User admin = createMockUser(Authority.EDIT_EMPLOYEE_INFO);
+            given(userRepository.findById(adminId)).willReturn(Optional.of(admin));
+
+            AnnualLeaveDispatchHistory first =
+                    AnnualLeaveDispatchHistory.builder()
+                            .id(10L)
+                            .uploadedBy(admin)
+                            .originalFileName("2026_연차현황.xlsx")
+                            .sheetName("2026-06")
+                            .fileKey("annual-leave/2026-06-first.xlsx")
+                            .build();
+            AnnualLeaveDispatchHistory second =
+                    AnnualLeaveDispatchHistory.builder()
+                            .id(11L)
+                            .uploadedBy(admin)
+                            .originalFileName("2026_연차현황_수정본.xlsx")
+                            .sheetName("2026-06")
+                            .fileKey("annual-leave/2026-06-second.xlsx")
+                            .build();
+            AnnualLeaveDispatchHistory third =
+                    AnnualLeaveDispatchHistory.builder()
+                            .id(12L)
+                            .uploadedBy(admin)
+                            .originalFileName("2026_연차현황_7월.xlsx")
+                            .sheetName("2026-07")
+                            .fileKey("annual-leave/2026-07-first.xlsx")
+                            .build();
+            given(annualLeaveDispatchHistoryRepository.findAllOrderByCreatedAtDesc())
+                    .willReturn(List.of(first, second, third));
+            given(s3Service.getPresignedViewUrl("annual-leave/2026-06-first.xlsx"))
+                    .willReturn("https://example.com/annual-leave-2026-06-first");
+            given(s3Service.getPresignedViewUrl("annual-leave/2026-06-second.xlsx"))
+                    .willReturn("https://example.com/annual-leave-2026-06-second");
+            given(s3Service.getPresignedViewUrl("annual-leave/2026-07-first.xlsx"))
+                    .willReturn("https://example.com/annual-leave-2026-07-first");
+
+            // when
+            List<AdminAnnualLeaveDispatchGroupResponseDto> result =
+                    annualLeaveService.getAnnualLeavesForAdmin(adminId);
+
+            // then
+            assertThat(result.size()).isEqualTo(2);
+            assertThat(result.get(0).getSheetName()).isEqualTo("2026-06");
+            assertThat(result.get(0).getTitle()).isEqualTo("2026-06");
+            assertThat(result.get(0).getTotalCount()).isEqualTo(2);
+            assertThat(result.get(0).getItems().get(0).getOriginalFileName())
+                    .isEqualTo("2026_연차현황.xlsx");
+            assertThat(result.get(0).getItems().get(1).getOriginalFileName())
+                    .isEqualTo("2026_연차현황_수정본.xlsx");
+            assertThat(result.get(0).getItems().get(0).getFileUrl())
+                    .isEqualTo("https://example.com/annual-leave-2026-06-first");
+
+            assertThat(result.get(1).getSheetName()).isEqualTo("2026-07");
+            assertThat(result.get(1).getTitle()).isEqualTo("2026-07");
+            assertThat(result.get(1).getTotalCount()).isEqualTo(1);
+            assertThat(result.get(1).getItems().get(0).getFileUrl())
+                    .isEqualTo("https://example.com/annual-leave-2026-07-first");
         }
     }
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 
+import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AdminAnnualLeaveDispatchDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AdminAnnualLeaveDispatchGroupResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AnnualLeaveResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.ExcelUploadResponseDto;
@@ -20,7 +21,6 @@ import kr.co.awesomelead.groupware_backend.domain.annualleave.service.AnnualLeav
 import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Authority;
-import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
 import kr.co.awesomelead.groupware_backend.global.error.CustomException;
 import kr.co.awesomelead.groupware_backend.global.infra.s3.service.S3Service;
@@ -38,6 +38,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -340,6 +341,79 @@ public class AnnualLeaveServiceTest {
             assertThat(result.get(1).getTotalCount()).isEqualTo(1);
             assertThat(result.get(1).getItems().get(0).getFileUrl())
                     .isEqualTo("https://example.com/annual-leave-2026-07-first");
+        }
+    }
+
+    @Nested
+    @DisplayName("getAnnualLeaveDispatchDetailForAdmin 메서드는")
+    class Describe_getAnnualLeaveDispatchDetailForAdmin {
+
+        @Test
+        @DisplayName("연차 발송 권한이 없는 유저가 요청하면 NO_AUTHORITY_FOR_ANNUAL_LEAVE 예외를 던진다")
+        void it_throws_when_user_has_no_authority() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(createMockUser(null)));
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    annualLeaveService.getAnnualLeaveDispatchDetailForAdmin(
+                                            userId, 10L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining("연차 발송 권한이 없습니다.");
+        }
+
+        @Test
+        @DisplayName("해당 발송 이력이 없으면 ANNUAL_LEAVE_DISPATCH_HISTORY_NOT_FOUND 예외를 던진다")
+        void it_throws_when_history_not_found() {
+            // given
+            Long adminId = 1L;
+            User admin = createMockUser(Authority.EDIT_EMPLOYEE_INFO);
+            given(userRepository.findById(adminId)).willReturn(Optional.of(admin));
+            given(annualLeaveDispatchHistoryRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(
+                            () ->
+                                    annualLeaveService.getAnnualLeaveDispatchDetailForAdmin(
+                                            adminId, 999L))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining("해당 연차 발송 이력을 찾을 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("권한이 있는 관리자가 요청하면 발송 상세와 파일 URL을 반환한다")
+        void it_returns_dispatch_detail() {
+            // given
+            Long adminId = 1L;
+            User admin = createMockUser(Authority.EDIT_EMPLOYEE_INFO);
+            given(userRepository.findById(adminId)).willReturn(Optional.of(admin));
+
+            AnnualLeaveDispatchHistory history =
+                    AnnualLeaveDispatchHistory.builder()
+                            .id(10L)
+                            .uploadedBy(admin)
+                            .originalFileName("2026_연차현황.xlsx")
+                            .sheetName("2026-06")
+                            .fileKey("annual-leave/2026-06-first.xlsx")
+                            .createdAt(LocalDateTime.of(2026, 5, 31, 15, 29, 4))
+                            .build();
+
+            given(annualLeaveDispatchHistoryRepository.findById(10L))
+                    .willReturn(Optional.of(history));
+            given(s3Service.getPresignedViewUrl("annual-leave/2026-06-first.xlsx"))
+                    .willReturn("https://example.com/annual-leave-2026-06-first");
+
+            // when
+            AdminAnnualLeaveDispatchDetailResponseDto result =
+                    annualLeaveService.getAnnualLeaveDispatchDetailForAdmin(adminId, 10L);
+
+            // then
+            assertThat(result.getDispatchId()).isEqualTo(10L);
+            assertThat(result.getOriginalFileName()).isEqualTo("2026_연차현황.xlsx");
+            assertThat(result.getSheetName()).isEqualTo("2026-06");
+            assertThat(result.getFileUrl()).isEqualTo("https://example.com/annual-leave-2026-06-first");
         }
     }
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
@@ -406,10 +406,7 @@ public class AnnualLeaveServiceTest {
 
             MultipartFile mockFile = createMockExcelFile();
             User targetUser =
-                    User.builder()
-                            .nameKor("테스트 유저")
-                            .hireDate(LocalDate.of(2025, 12, 31))
-                            .build();
+                    User.builder().nameKor("테스트 유저").hireDate(LocalDate.of(2025, 12, 31)).build();
             given(userRepository.findByNameAndJoinDate(anyString(), any()))
                     .willReturn(Optional.of(targetUser));
             given(annualLeaveRepository.findByUser(targetUser)).willReturn(Optional.empty());
@@ -442,9 +439,7 @@ public class AnnualLeaveServiceTest {
 
             // when & then
             assertThatThrownBy(
-                            () ->
-                                    annualLeaveService.deleteAnnualLeaveDispatchForAdmin(
-                                            userId, 10L))
+                            () -> annualLeaveService.deleteAnnualLeaveDispatchForAdmin(userId, 10L))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining("연차 발송 권한이 없습니다.");
         }


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #417 

## 📝작업 내용
- 관리자 보낸 연차 목록 조회 API 추가
  - `GET /api/annualleaves/admin`
- 보낸 연차 목록 아이템에 `dispatchId` 필드 추가
- 관리자 보낸 연차 상세 조회 API 추가
  - `GET /api/annualleaves/admin/{dispatchId}`
- 관리자 보낸 연차 수정 API 추가
  - `PUT /api/annualleaves/admin/{dispatchId}`
- 관리자 보낸 연차 삭제 API 추가
  - `DELETE /api/annualleaves/admin/{dispatchId}`

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [ ] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X