### PR TITLE
fix(420): 교육 게시물 에디터 본문 지원 및 파일 삭제 API 추가

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
@@ -66,6 +66,7 @@ public class EduReportController {
                                         - `requestDto`(JSON 파트)는 필수입니다.
                                         - `files`(파일 파트)는 선택입니다.
                                         - 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 있어야 생성할 수 있습니다.
+                                        - 본문은 `content`(plain) 또는 `contentDelta`/`contentHtml`(에디터 원본/렌더링용)으로 전달할 수 있습니다.
                                         """,
             requestBody =
                     @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -996,6 +997,7 @@ public class EduReportController {
                                         - `OPEN` 상태에서만 수정 가능합니다.
                                         - 출석 완료자가 1명이라도 있으면 수정할 수 없습니다.
                                         - `requestDto`(JSON 파트)는 필수이며, `files`(파일 파트)는 선택입니다.
+                                        - 본문은 `content`(plain) 또는 `contentDelta`/`contentHtml`(에디터 원본/렌더링용)으로 수정할 수 있습니다.
                                         - `requestDto.deleteAttachmentIds`로 기존 첨부파일 삭제가 가능합니다.
                                         """,
             requestBody =

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
@@ -172,6 +172,7 @@ public class EduReportController {
                                         - `requestDto`(JSON 파트)는 필수입니다.
                                         - `files`(파일 파트)는 선택입니다.
                                         - PSM 관리 권한(`MANAGE_PSM`)이 있어야 생성할 수 있습니다.
+                                        - 본문은 `content`(plain) 또는 `contentDelta`/`contentHtml`(에디터 원본/렌더링용)으로 전달할 수 있습니다.
                                         - `companyScope`는 회사 목록 배열입니다.
                                         - `[AWESOME]`처럼 1개를 보내면 해당 회사 게시물로 생성됩니다.
                                         - `[AWESOME, MARUI]`, `null`, `[]`는 모든 회사 공통 게시물로 생성됩니다.
@@ -917,6 +918,7 @@ public class EduReportController {
                                         - `OPEN` 상태에서만 수정 가능합니다.
                                         - 출석 완료자가 1명이라도 있으면 수정할 수 없습니다.
                                         - `requestDto`(JSON 파트)는 필수이며, `files`(파일 파트)는 선택입니다.
+                                        - 본문은 `content`(plain) 또는 `contentDelta`/`contentHtml`(에디터 원본/렌더링용)으로 수정할 수 있습니다.
                                         - `requestDto.deleteAttachmentIds`로 기존 첨부파일 삭제가 가능합니다.
                                         """,
             requestBody =

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
@@ -281,6 +281,7 @@ public class EduReportController {
                                         - `requestDto`(JSON 파트)는 필수입니다.
                                         - `files`(파일 파트)는 선택입니다.
                                         - 안전 보건 관리 권한(`MANAGE_SAFETY`)이 있어야 생성할 수 있습니다.
+                                        - 본문은 `content`(plain) 또는 `contentDelta`/`contentHtml`(에디터 원본/렌더링용)으로 전달할 수 있습니다.
                                         - `companyScope`는 회사 목록 배열입니다.
                                         - `[AWESOME]`처럼 1개를 보내면 해당 회사 게시물로 생성됩니다.
                                         - `[AWESOME, MARUI]`, `null`, `[]`는 모든 회사 공통 게시물로 생성됩니다.
@@ -1072,6 +1073,7 @@ public class EduReportController {
                                         - `OPEN` 상태에서만 수정 가능합니다.
                                         - 출석 완료자가 1명이라도 있으면 수정할 수 없습니다.
                                         - `requestDto`(JSON 파트)는 필수이며, `files`(파일 파트)는 선택입니다.
+                                        - 본문은 `content`(plain) 또는 `contentDelta`/`contentHtml`(에디터 원본/렌더링용)으로 수정할 수 있습니다.
                                         - `requestDto.deleteAttachmentIds`로 기존 첨부파일 삭제가 가능합니다.
                                         """,
             requestBody =

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/DepartmentEduReportCreateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/DepartmentEduReportCreateRequestDto.java
@@ -30,9 +30,7 @@ public class DepartmentEduReportCreateRequestDto {
             example = "{\"ops\":[{\"insert\":\"부서 교육 본문입니다.\\n\"}]}")
     private String contentDelta;
 
-    @Schema(
-            description = "HTML 본문(렌더링/미리보기용)",
-            example = "<p>부서 운영 규정 및 공지사항 교육</p>")
+    @Schema(description = "HTML 본문(렌더링/미리보기용)", example = "<p>부서 운영 규정 및 공지사항 교육</p>")
     private String contentHtml;
 
     @Schema(description = "상단 고정 여부", example = "false", defaultValue = "false")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/DepartmentEduReportCreateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/DepartmentEduReportCreateRequestDto.java
@@ -20,9 +20,20 @@ public class DepartmentEduReportCreateRequestDto {
     @NotBlank(message = "제목은 필수입니다.")
     private String title;
 
-    @Schema(description = "교육 내용", example = "부서 운영 규정 및 공지사항 교육")
-    @NotBlank(message = "내용은 필수입니다.")
+    @Schema(
+            description = "레거시 평문 본문(하위 호환용). 신규 개발은 contentDelta + contentHtml 사용 권장",
+            example = "부서 운영 규정 및 공지사항 교육")
     private String content;
+
+    @Schema(
+            description = "Quill Delta JSON 문자열(에디터 원본)",
+            example = "{\"ops\":[{\"insert\":\"부서 교육 본문입니다.\\n\"}]}")
+    private String contentDelta;
+
+    @Schema(
+            description = "HTML 본문(렌더링/미리보기용)",
+            example = "<p>부서 운영 규정 및 공지사항 교육</p>")
+    private String contentHtml;
 
     @Schema(description = "상단 고정 여부", example = "false", defaultValue = "false")
     private boolean pinned;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/EduReportRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/EduReportRequestDto.java
@@ -33,6 +33,19 @@ public class EduReportRequestDto {
     @NotBlank(message = "내용은 필수입니다.")
     private String content;
 
+    @Schema(
+            description = "Quill Delta JSON 문자열(에디터 원본, 선택)",
+            example = "{\"ops\":[{\"insert\":\"PSM 교육 본문입니다.\\n\"}]}")
+    private String contentDelta;
+
+    @Schema(
+            description = "HTML 본문(선택)",
+            example = "<p>PSM 교육 본문입니다.</p>")
+    private String contentHtml;
+
+    @Schema(description = "본문 검색용 평문(서버에서 생성, 내부 전달용)")
+    private String contentText;
+
     @Schema(description = "상단 고정 여부", example = "false", defaultValue = "false")
     private boolean pinned;
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/EduReportRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/EduReportRequestDto.java
@@ -38,9 +38,7 @@ public class EduReportRequestDto {
             example = "{\"ops\":[{\"insert\":\"PSM 교육 본문입니다.\\n\"}]}")
     private String contentDelta;
 
-    @Schema(
-            description = "HTML 본문(선택)",
-            example = "<p>PSM 교육 본문입니다.</p>")
+    @Schema(description = "HTML 본문(선택)", example = "<p>PSM 교육 본문입니다.</p>")
     private String contentHtml;
 
     @Schema(description = "본문 검색용 평문(서버에서 생성, 내부 전달용)")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/EduReportUpdateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/EduReportUpdateRequestDto.java
@@ -24,9 +24,20 @@ public class EduReportUpdateRequestDto {
     @NotBlank(message = "제목은 필수입니다.")
     private String title;
 
-    @Schema(description = "교육 내용", example = "개인정보 보호 및 사내 보안 규정 안내 (수정)")
-    @NotBlank(message = "내용은 필수입니다.")
+    @Schema(
+            description = "레거시 평문 본문(하위 호환용). PSM은 contentDelta/contentHtml과 함께 사용할 수 있습니다.",
+            example = "개인정보 보호 및 사내 보안 규정 안내 (수정)")
     private String content;
+
+    @Schema(
+            description = "Quill Delta JSON 문자열(에디터 원본, 선택)",
+            example = "{\"ops\":[{\"insert\":\"PSM 수정 본문입니다.\\n\"}]}")
+    private String contentDelta;
+
+    @Schema(
+            description = "HTML 본문(선택)",
+            example = "<p>PSM 수정 본문입니다.</p>")
+    private String contentHtml;
 
     @Schema(description = "상단 고정 여부", example = "false", defaultValue = "false")
     private boolean pinned;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/EduReportUpdateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/EduReportUpdateRequestDto.java
@@ -34,9 +34,7 @@ public class EduReportUpdateRequestDto {
             example = "{\"ops\":[{\"insert\":\"PSM 수정 본문입니다.\\n\"}]}")
     private String contentDelta;
 
-    @Schema(
-            description = "HTML 본문(선택)",
-            example = "<p>PSM 수정 본문입니다.</p>")
+    @Schema(description = "HTML 본문(선택)", example = "<p>PSM 수정 본문입니다.</p>")
     private String contentHtml;
 
     @Schema(description = "상단 고정 여부", example = "false", defaultValue = "false")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/PsmEduReportCreateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/PsmEduReportCreateRequestDto.java
@@ -26,9 +26,20 @@ public class PsmEduReportCreateRequestDto {
     @NotBlank(message = "제목은 필수입니다.")
     private String title;
 
-    @Schema(description = "교육 내용", example = "변경관리 절차 및 주의사항 안내")
-    @NotBlank(message = "내용은 필수입니다.")
+    @Schema(
+            description = "레거시 평문 본문(하위 호환용). 신규 개발은 contentDelta + contentHtml 사용 권장",
+            example = "변경관리 절차 및 주의사항 안내")
     private String content;
+
+    @Schema(
+            description = "Quill Delta JSON 문자열(에디터 원본)",
+            example = "{\"ops\":[{\"insert\":\"PSM 교육 내용입니다.\\n\"}]}")
+    private String contentDelta;
+
+    @Schema(
+            description = "HTML 본문(렌더링/미리보기용)",
+            example = "<p>변경관리 절차 및 주의사항 안내</p>")
+    private String contentHtml;
 
     @Schema(description = "상단 고정 여부", example = "false", defaultValue = "false")
     private boolean pinned;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/PsmEduReportCreateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/PsmEduReportCreateRequestDto.java
@@ -36,9 +36,7 @@ public class PsmEduReportCreateRequestDto {
             example = "{\"ops\":[{\"insert\":\"PSM 교육 내용입니다.\\n\"}]}")
     private String contentDelta;
 
-    @Schema(
-            description = "HTML 본문(렌더링/미리보기용)",
-            example = "<p>변경관리 절차 및 주의사항 안내</p>")
+    @Schema(description = "HTML 본문(렌더링/미리보기용)", example = "<p>변경관리 절차 및 주의사항 안내</p>")
     private String contentHtml;
 
     @Schema(description = "상단 고정 여부", example = "false", defaultValue = "false")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/SafetyEduReportCreateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/SafetyEduReportCreateRequestDto.java
@@ -36,9 +36,7 @@ public class SafetyEduReportCreateRequestDto {
             example = "{\"ops\":[{\"insert\":\"안전보건 교육 본문입니다.\\n\"}]}")
     private String contentDelta;
 
-    @Schema(
-            description = "HTML 본문(렌더링/미리보기용)",
-            example = "<p>사업장 안전수칙 및 보호구 착용 기준 안내</p>")
+    @Schema(description = "HTML 본문(렌더링/미리보기용)", example = "<p>사업장 안전수칙 및 보호구 착용 기준 안내</p>")
     private String contentHtml;
 
     @Schema(description = "상단 고정 여부", example = "false", defaultValue = "false")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/SafetyEduReportCreateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/SafetyEduReportCreateRequestDto.java
@@ -26,9 +26,20 @@ public class SafetyEduReportCreateRequestDto {
     @NotBlank(message = "제목은 필수입니다.")
     private String title;
 
-    @Schema(description = "교육 내용", example = "사업장 안전수칙 및 보호구 착용 기준 안내")
-    @NotBlank(message = "내용은 필수입니다.")
+    @Schema(
+            description = "레거시 평문 본문(하위 호환용). 신규 개발은 contentDelta + contentHtml 사용 권장",
+            example = "사업장 안전수칙 및 보호구 착용 기준 안내")
     private String content;
+
+    @Schema(
+            description = "Quill Delta JSON 문자열(에디터 원본)",
+            example = "{\"ops\":[{\"insert\":\"안전보건 교육 본문입니다.\\n\"}]}")
+    private String contentDelta;
+
+    @Schema(
+            description = "HTML 본문(렌더링/미리보기용)",
+            example = "<p>사업장 안전수칙 및 보호구 착용 기준 안내</p>")
+    private String contentHtml;
 
     @Schema(description = "상단 고정 여부", example = "false", defaultValue = "false")
     private boolean pinned;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportDetailDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportDetailDto.java
@@ -63,9 +63,7 @@ public class EduReportDetailDto {
             example = "{\"ops\":[{\"insert\":\"교육 본문입니다.\\n\"}]}")
     private String contentDelta;
 
-    @Schema(
-            description = "HTML 본문(PSM/안전보건 에디터 렌더링용, 없으면 null)",
-            example = "<p>교육 본문입니다.</p>")
+    @Schema(description = "HTML 본문(PSM/안전보건 에디터 렌더링용, 없으면 null)", example = "<p>교육 본문입니다.</p>")
     private String contentHtml;
 
     @Schema(description = "출석 여부", example = "true")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportDetailDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/EduReportDetailDto.java
@@ -58,6 +58,16 @@ public class EduReportDetailDto {
     @Schema(description = "교육 내용", example = "이번 교육에서는 안전 수칙에 대해 다룹니다.")
     private String content;
 
+    @Schema(
+            description = "Quill Delta JSON 문자열(PSM/안전보건 에디터 원본, 없으면 null)",
+            example = "{\"ops\":[{\"insert\":\"교육 본문입니다.\\n\"}]}")
+    private String contentDelta;
+
+    @Schema(
+            description = "HTML 본문(PSM/안전보건 에디터 렌더링용, 없으면 null)",
+            example = "<p>교육 본문입니다.</p>")
+    private String contentHtml;
+
     @Schema(description = "출석 여부", example = "true")
     private boolean attendance;
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/entity/EduReport.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/entity/EduReport.java
@@ -62,6 +62,18 @@ public class EduReport {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
+    @Lob
+    @Column(name = "content_delta", columnDefinition = "TEXT")
+    private String contentDelta;
+
+    @Lob
+    @Column(name = "content_html", columnDefinition = "TEXT")
+    private String contentHtml;
+
+    @Lob
+    @Column(name = "content_text", columnDefinition = "TEXT")
+    private String contentText;
+
     @Builder.Default
     @OneToMany(mappedBy = "eduReport", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<EduAttachment> attachments = new ArrayList<>();
@@ -114,5 +126,13 @@ public class EduReport {
     public void addAttachment(EduAttachment attachment) {
         this.attachments.add(attachment);
         attachment.setEduReport(this);
+    }
+
+    public void updateEditorContent(
+            String content, String contentDelta, String contentHtml, String contentText) {
+        this.content = content;
+        this.contentDelta = contentDelta;
+        this.contentHtml = contentHtml;
+        this.contentText = contentText;
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -81,8 +81,8 @@ public class EduReportService {
     public Long createPsmEduReport(
             PsmEduReportCreateRequestDto requestDto, List<MultipartFile> files, Long id)
             throws IOException {
-        PsmContentFields contentFields =
-                resolvePsmCreateContentFields(
+        EditorContentFields contentFields =
+                resolveEditorCreateContentFields(
                         requestDto.getContent(),
                         requestDto.getContentDelta(),
                         requestDto.getContentHtml());
@@ -217,11 +217,20 @@ public class EduReportService {
     public Long createDepartmentEduReport(
             DepartmentEduReportCreateRequestDto requestDto, List<MultipartFile> files, Long id)
             throws IOException {
+        EditorContentFields contentFields =
+                resolveEditorCreateContentFields(
+                        requestDto.getContent(),
+                        requestDto.getContentDelta(),
+                        requestDto.getContentHtml());
+
         EduReportRequestDto baseRequest =
                 EduReportRequestDto.builder()
                         .eduType(EduType.DEPARTMENT)
                         .title(requestDto.getTitle())
-                        .content(requestDto.getContent())
+                        .content(contentFields.content())
+                        .contentDelta(contentFields.contentDelta())
+                        .contentHtml(contentFields.contentHtml())
+                        .contentText(contentFields.contentText())
                         .pinned(requestDto.isPinned())
                         .signatureRequired(requestDto.isSignatureRequired())
                         .departmentId(requestDto.getDepartmentId())
@@ -891,9 +900,9 @@ public class EduReportService {
             report.setPinned(requestDto.isPinned());
             report.setSignatureRequired(requestDto.isSignatureRequired());
 
-            if (report.getEduType() == EduType.PSM) {
-                PsmContentFields contentFields =
-                        resolvePsmUpdateContentFields(
+            if (report.getEduType() == EduType.PSM || report.getEduType() == EduType.DEPARTMENT) {
+                EditorContentFields contentFields =
+                        resolveEditorUpdateContentFields(
                                 report,
                                 requestDto.getContent(),
                                 requestDto.getContentDelta(),
@@ -1137,7 +1146,7 @@ public class EduReportService {
         return category;
     }
 
-    private PsmContentFields resolvePsmCreateContentFields(
+    private EditorContentFields resolveEditorCreateContentFields(
             String requestContent, String requestContentDelta, String requestContentHtml) {
         String content = requestContent;
         if (!StringUtils.hasText(content)) {
@@ -1155,14 +1164,14 @@ public class EduReportService {
             throw new CustomException(ErrorCode.INVALID_ARGUMENT);
         }
 
-        return new PsmContentFields(
+        return new EditorContentFields(
                 normalizeNullableContent(content),
                 normalizeNullableContent(requestContentDelta),
                 normalizeNullableContent(requestContentHtml),
                 contentText);
     }
 
-    private PsmContentFields resolvePsmUpdateContentFields(
+    private EditorContentFields resolveEditorUpdateContentFields(
             EduReport report,
             String requestContent,
             String requestContentDelta,
@@ -1194,7 +1203,7 @@ public class EduReportService {
             throw new CustomException(ErrorCode.INVALID_ARGUMENT);
         }
 
-        return new PsmContentFields(
+        return new EditorContentFields(
                 normalizeNullableContent(resolvedContent),
                 normalizeNullableContent(resolvedContentDelta),
                 normalizeNullableContent(resolvedContentHtml),
@@ -1482,6 +1491,6 @@ public class EduReportService {
         return (int) value;
     }
 
-    private record PsmContentFields(
+    private record EditorContentFields(
             String content, String contentDelta, String contentHtml, String contentText) {}
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -1,5 +1,8 @@
 package kr.co.awesomelead.groupware_backend.domain.education.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import kr.co.awesomelead.groupware_backend.domain.department.entity.Department;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
@@ -41,6 +44,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -54,6 +58,7 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 public class EduReportService {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final EduReportRepository eduReportRepository;
     private final EduReportQueryRepository eduReportQueryRepository;
@@ -76,11 +81,20 @@ public class EduReportService {
     public Long createPsmEduReport(
             PsmEduReportCreateRequestDto requestDto, List<MultipartFile> files, Long id)
             throws IOException {
+        PsmContentFields contentFields =
+                resolvePsmCreateContentFields(
+                        requestDto.getContent(),
+                        requestDto.getContentDelta(),
+                        requestDto.getContentHtml());
+
         EduReportRequestDto baseRequest =
                 EduReportRequestDto.builder()
                         .eduType(EduType.PSM)
                         .title(requestDto.getTitle())
-                        .content(requestDto.getContent())
+                        .content(contentFields.content())
+                        .contentDelta(contentFields.contentDelta())
+                        .contentHtml(contentFields.contentHtml())
+                        .contentText(contentFields.contentText())
                         .pinned(requestDto.isPinned())
                         .signatureRequired(false)
                         .categoryId(requestDto.getCategoryId())
@@ -874,9 +888,30 @@ public class EduReportService {
         List<String> uploadedAttachmentKeys = new ArrayList<>();
         try {
             report.setTitle(requestDto.getTitle().trim());
-            report.setContent(requestDto.getContent().trim());
             report.setPinned(requestDto.isPinned());
             report.setSignatureRequired(requestDto.isSignatureRequired());
+
+            if (report.getEduType() == EduType.PSM) {
+                PsmContentFields contentFields =
+                        resolvePsmUpdateContentFields(
+                                report,
+                                requestDto.getContent(),
+                                requestDto.getContentDelta(),
+                                requestDto.getContentHtml());
+                report.updateEditorContent(
+                        contentFields.content(),
+                        contentFields.contentDelta(),
+                        contentFields.contentHtml(),
+                        contentFields.contentText());
+            } else {
+                if (!StringUtils.hasText(requestDto.getContent())) {
+                    throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+                }
+                report.setContent(requestDto.getContent().trim());
+                report.setContentDelta(null);
+                report.setContentHtml(null);
+                report.setContentText(null);
+            }
 
             if (report.getEduType() == EduType.DEPARTMENT) {
                 if (requestDto.getDepartmentId() == null) {
@@ -1102,6 +1137,164 @@ public class EduReportService {
         return category;
     }
 
+    private PsmContentFields resolvePsmCreateContentFields(
+            String requestContent, String requestContentDelta, String requestContentHtml) {
+        String content = requestContent;
+        if (!StringUtils.hasText(content)) {
+            if (StringUtils.hasText(requestContentDelta)) {
+                content = extractPlainTextFromDelta(requestContentDelta);
+            } else if (StringUtils.hasText(requestContentHtml)) {
+                content = extractPlainTextFromHtml(requestContentHtml);
+            }
+        }
+
+        String contentText =
+                resolveSearchableText(requestContentDelta, requestContentHtml, content, null);
+
+        if (!StringUtils.hasText(content) && !StringUtils.hasText(contentText)) {
+            throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+        }
+
+        return new PsmContentFields(
+                normalizeNullableContent(content),
+                normalizeNullableContent(requestContentDelta),
+                normalizeNullableContent(requestContentHtml),
+                contentText);
+    }
+
+    private PsmContentFields resolvePsmUpdateContentFields(
+            EduReport report,
+            String requestContent,
+            String requestContentDelta,
+            String requestContentHtml) {
+        String resolvedContentDelta =
+                requestContentDelta != null ? requestContentDelta : report.getContentDelta();
+        String resolvedContentHtml =
+                requestContentHtml != null ? requestContentHtml : report.getContentHtml();
+
+        String resolvedContent;
+        if (requestContent != null) {
+            resolvedContent = requestContent;
+        } else if (requestContentDelta != null) {
+            resolvedContent = extractPlainTextFromDelta(requestContentDelta);
+        } else if (requestContentHtml != null) {
+            resolvedContent = extractPlainTextFromHtml(requestContentHtml);
+        } else {
+            resolvedContent = report.getContent();
+        }
+
+        String resolvedContentText =
+                resolveSearchableText(
+                        resolvedContentDelta,
+                        resolvedContentHtml,
+                        resolvedContent,
+                        report.getContentText());
+
+        if (!StringUtils.hasText(resolvedContent) && !StringUtils.hasText(resolvedContentText)) {
+            throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+        }
+
+        return new PsmContentFields(
+                normalizeNullableContent(resolvedContent),
+                normalizeNullableContent(resolvedContentDelta),
+                normalizeNullableContent(resolvedContentHtml),
+                resolvedContentText);
+    }
+
+    private String resolveSearchableText(
+            String contentDelta, String contentHtml, String content, String fallbackContentText) {
+        String deltaText = extractPlainTextFromDelta(contentDelta);
+        if (StringUtils.hasText(deltaText)) {
+            return deltaText;
+        }
+
+        String htmlText = extractPlainTextFromHtml(contentHtml);
+        if (StringUtils.hasText(htmlText)) {
+            return htmlText;
+        }
+
+        String contentText = extractPlainTextFromHtml(content);
+        if (StringUtils.hasText(contentText)) {
+            return contentText;
+        }
+
+        if (StringUtils.hasText(content)) {
+            return content.trim();
+        }
+
+        if (StringUtils.hasText(fallbackContentText)) {
+            return fallbackContentText;
+        }
+        return "";
+    }
+
+    private String extractPlainTextFromDelta(String contentDelta) {
+        if (!StringUtils.hasText(contentDelta)) {
+            return "";
+        }
+
+        try {
+            JsonNode root = OBJECT_MAPPER.readTree(contentDelta);
+            JsonNode ops = root.path("ops");
+            if (!ops.isArray()) {
+                return "";
+            }
+
+            StringBuilder plain = new StringBuilder();
+            for (JsonNode op : ops) {
+                JsonNode insert = op.get("insert");
+                if (insert == null) {
+                    continue;
+                }
+                if (insert.isTextual()) {
+                    plain.append(insert.asText());
+                } else if (insert.isObject() && insert.has("image")) {
+                    plain.append(' ');
+                }
+            }
+            return normalizeWhitespace(plain.toString());
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    private String extractPlainTextFromHtml(String html) {
+        if (!StringUtils.hasText(html)) {
+            return "";
+        }
+        String text =
+                html.replaceAll("(?is)<script[^>]*>.*?</script>", " ")
+                        .replaceAll("(?is)<style[^>]*>.*?</style>", " ")
+                        .replaceAll("(?is)<br\\s*/?>", "\n")
+                        .replaceAll("(?is)</p>", "\n")
+                        .replaceAll("(?is)</tr>", "\n")
+                        .replaceAll("(?is)<[^>]+>", " ")
+                        .replace("&nbsp;", " ")
+                        .replace("&amp;", "&")
+                        .replace("&lt;", "<")
+                        .replace("&gt;", ">");
+        return normalizeWhitespace(text);
+    }
+
+    private String normalizeWhitespace(String text) {
+        if (!StringUtils.hasText(text)) {
+            return "";
+        }
+        return text.replace('\u00A0', ' ')
+                .replaceAll("[\\t\\x0B\\f\\r ]+", " ")
+                .replaceAll(" *\\n *", "\n")
+                .replaceAll("\\n{3,}", "\n\n")
+                .trim();
+    }
+
+    private String normalizeNullableContent(String content) {
+        if (content == null) {
+            return null;
+        }
+        String normalized = content.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+
     @Transactional(readOnly = true)
     public List<EduReportSignatureStatusDto> getSignatureStatuses(
             Long educationId, String name, Long userId) {
@@ -1288,4 +1481,7 @@ public class EduReportService {
         }
         return (int) value;
     }
+
+    private record PsmContentFields(
+            String content, String contentDelta, String contentHtml, String contentText) {}
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -107,11 +107,20 @@ public class EduReportService {
     public Long createSafetyEduReport(
             SafetyEduReportCreateRequestDto requestDto, List<MultipartFile> files, Long id)
             throws IOException {
+        EditorContentFields contentFields =
+                resolveEditorCreateContentFields(
+                        requestDto.getContent(),
+                        requestDto.getContentDelta(),
+                        requestDto.getContentHtml());
+
         EduReportRequestDto baseRequest =
                 EduReportRequestDto.builder()
                         .eduType(EduType.SAFETY)
                         .title(requestDto.getTitle())
-                        .content(requestDto.getContent())
+                        .content(contentFields.content())
+                        .contentDelta(contentFields.contentDelta())
+                        .contentHtml(contentFields.contentHtml())
+                        .contentText(contentFields.contentText())
                         .pinned(requestDto.isPinned())
                         .signatureRequired(false)
                         .categoryId(requestDto.getCategoryId())
@@ -900,7 +909,9 @@ public class EduReportService {
             report.setPinned(requestDto.isPinned());
             report.setSignatureRequired(requestDto.isSignatureRequired());
 
-            if (report.getEduType() == EduType.PSM || report.getEduType() == EduType.DEPARTMENT) {
+            if (report.getEduType() == EduType.PSM
+                    || report.getEduType() == EduType.DEPARTMENT
+                    || report.getEduType() == EduType.SAFETY) {
                 EditorContentFields contentFields =
                         resolveEditorUpdateContentFields(
                                 report,

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/infra/s3/controller/S3Controller.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/infra/s3/controller/S3Controller.java
@@ -15,8 +15,8 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -42,8 +42,7 @@ public class S3Controller {
 
     @Operation(summary = "파일 단일 삭제", description = "파일 키(fileKey)를 입력하여 S3 파일을 삭제합니다.")
     @DeleteMapping("/delete")
-    public ResponseEntity<ApiResponse<Void>> deleteFile(
-            @RequestParam("fileKey") String fileKey) {
+    public ResponseEntity<ApiResponse<Void>> deleteFile(@RequestParam("fileKey") String fileKey) {
         if (!StringUtils.hasText(fileKey)) {
             throw new CustomException(ErrorCode.INVALID_ARGUMENT);
         }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/infra/s3/controller/S3Controller.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/infra/s3/controller/S3Controller.java
@@ -3,15 +3,20 @@ package kr.co.awesomelead.groupware_backend.global.infra.s3.controller;
 import io.swagger.v3.oas.annotations.Operation;
 
 import kr.co.awesomelead.groupware_backend.global.common.response.ApiResponse;
+import kr.co.awesomelead.groupware_backend.global.error.CustomException;
+import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
 import kr.co.awesomelead.groupware_backend.global.infra.s3.service.S3Service;
 
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -33,5 +38,17 @@ public class S3Controller {
         String fileUrl = s3Service.uploadFile(file);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(fileUrl));
+    }
+
+    @Operation(summary = "파일 단일 삭제", description = "파일 키(fileKey)를 입력하여 S3 파일을 삭제합니다.")
+    @DeleteMapping("/delete")
+    public ResponseEntity<ApiResponse<Void>> deleteFile(
+            @RequestParam("fileKey") String fileKey) {
+        if (!StringUtils.hasText(fileKey)) {
+            throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+        }
+
+        s3Service.deleteFile(fileKey.trim());
+        return ResponseEntity.ok(ApiResponse.onNoContent("파일이 성공적으로 삭제되었습니다."));
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #420 

## 📝작업 내용
- PSM/부서교육/안전보건 게시물에 공지사항과 동일한 에디터 본문 구조 적용
  - `contentDelta`, `contentHtml` 저장/수정 지원
  - `contentText` 생성 및 저장(검색/요약용)
  - 기존 `content` 기반 하위호환 유지
- 파일 단일 삭제 API 추가
  - `DELETE /api/files/delete?fileKey=...`

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X