### PR TITLE
fix(426): 연차 발송 삭제 재계산 및 목록 제목 개선

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/controller/AnnualLeaveController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/controller/AnnualLeaveController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -87,6 +88,14 @@ public class AnnualLeaveController {
                 annualLeaveService.updateAnnualLeaveDispatchForAdmin(
                         userDetails.getId(), dispatchId, file, sheetName);
         return ResponseEntity.ok(ApiResponse.onSuccess(responseDto));
+    }
+
+    @Operation(summary = "연차 정보 재계산 (관리자)", description = "남아 있는 연차 발송 이력의 원본 파일 기준으로 사용자 연차 정보를 다시 계산합니다.")
+    @PostMapping("/admin/rebuild")
+    public ResponseEntity<ApiResponse<Void>> rebuildAnnualLeavesForAdmin(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        annualLeaveService.rebuildAnnualLeavesForAdmin(userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onNoContent("연차 정보가 성공적으로 재계산되었습니다."));
     }
 
     @Operation(summary = "보낸 연차 삭제 (관리자)", description = "관리자가 특정 연차 발송 이력을 삭제합니다.")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/controller/AnnualLeaveController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/controller/AnnualLeaveController.java
@@ -90,7 +90,9 @@ public class AnnualLeaveController {
         return ResponseEntity.ok(ApiResponse.onSuccess(responseDto));
     }
 
-    @Operation(summary = "연차 정보 재계산 (관리자)", description = "남아 있는 연차 발송 이력의 원본 파일 기준으로 사용자 연차 정보를 다시 계산합니다.")
+    @Operation(
+            summary = "연차 정보 재계산 (관리자)",
+            description = "남아 있는 연차 발송 이력의 원본 파일 기준으로 사용자 연차 정보를 다시 계산합니다.")
     @PostMapping("/admin/rebuild")
     public ResponseEntity<ApiResponse<Void>> rebuildAnnualLeavesForAdmin(
             @AuthenticationPrincipal CustomUserDetails userDetails) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/controller/AnnualLeaveController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/controller/AnnualLeaveController.java
@@ -55,7 +55,7 @@ public class AnnualLeaveController {
         return ResponseEntity.ok(ApiResponse.onSuccess(responseDto));
     }
 
-    @Operation(summary = "보낸 연차 목록 조회 (관리자)", description = "관리자가 보낸 연차 이력을 시트명 기준 그룹으로 조회합니다.")
+    @Operation(summary = "보낸 연차 목록 조회 (관리자)", description = "관리자가 보낸 연차 이력을 연도 기준 그룹으로 조회합니다.")
     @GetMapping("/admin")
     public ResponseEntity<ApiResponse<List<AdminAnnualLeaveDispatchGroupResponseDto>>>
             getAnnualLeavesForAdmin(@AuthenticationPrincipal CustomUserDetails userDetails) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/dto/response/AdminAnnualLeaveDispatchGroupResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/dto/response/AdminAnnualLeaveDispatchGroupResponseDto.java
@@ -16,15 +16,15 @@ import java.util.List;
 @Schema(description = "관리자용 연차 발송 목록 그룹 응답")
 public class AdminAnnualLeaveDispatchGroupResponseDto {
 
-    @Schema(description = "시트명", example = "2026-06")
+    @Schema(description = "그룹 기준 연도", example = "2026년")
     private String sheetName;
 
-    @Schema(description = "그룹 제목(시트명)", example = "2026-06")
+    @Schema(description = "그룹 제목(연도)", example = "2026년")
     private String title;
 
-    @Schema(description = "해당 시트 발송 건수", example = "3")
+    @Schema(description = "해당 연도 발송 건수", example = "3")
     private int totalCount;
 
-    @Schema(description = "해당 시트의 발송 목록")
+    @Schema(description = "해당 연도의 발송 목록")
     private List<AdminAnnualLeaveDispatchItemResponseDto> items;
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/dto/response/AdminAnnualLeaveDispatchItemResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/dto/response/AdminAnnualLeaveDispatchItemResponseDto.java
@@ -17,6 +17,9 @@ public class AdminAnnualLeaveDispatchItemResponseDto {
     @Schema(description = "발송 이력 ID", example = "10")
     private Long dispatchId;
 
+    @Schema(description = "아이템 제목(월)", example = "7월")
+    private String title;
+
     @Schema(description = "보낸 파일명", example = "2026년_연차현황.xlsx")
     private String originalFileName;
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
@@ -33,12 +33,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -153,6 +155,7 @@ public class AnnualLeaveService {
 
         String fileKey = history.getFileKey();
         annualLeaveDispatchHistoryRepository.delete(history);
+        rebuildAnnualLeavesFromDispatchHistories(dispatchId);
 
         if (fileKey != null && !fileKey.isBlank()) {
             try {
@@ -163,16 +166,30 @@ public class AnnualLeaveService {
         }
     }
 
+    @Transactional
+    public void rebuildAnnualLeavesForAdmin(Long userId) {
+        validateAnnualLeaveEditAuthority(userId);
+        rebuildAnnualLeavesFromDispatchHistories(null);
+    }
+
     private record ProcessResult(ExcelUploadResponseDto response, LocalDate baseDate) {}
 
     private ProcessResult processAnnualLeaveFile(MultipartFile file, String normalizedSheetName) {
+        try (InputStream is = file.getInputStream()) {
+            return processAnnualLeaveFile(is, normalizedSheetName, true);
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.FILE_UPLOAD_ERROR);
+        }
+    }
+
+    private ProcessResult processAnnualLeaveFile(
+            InputStream is, String normalizedSheetName, boolean sendNotification) {
         List<FailureDetail> failures = new ArrayList<>();
         int successCount = 0;
         int totalProcessed = 0;
         LocalDate baseUpdateDate = null;
 
-        try (InputStream is = file.getInputStream();
-                Workbook workbook = WorkbookFactory.create(is)) {
+        try (Workbook workbook = WorkbookFactory.create(is)) {
 
             Sheet sheet = workbook.getSheet(normalizedSheetName);
             if (sheet == null) {
@@ -191,7 +208,7 @@ public class AnnualLeaveService {
 
                 totalProcessed++; // 파싱 작업 수 증가
                 try {
-                    processAnnualLeaveRow(row, baseUpdateDate);
+                    processAnnualLeaveRow(row, baseUpdateDate, sendNotification);
                     successCount++; // 성공 작업 수 증가
                 } catch (Exception e) {
                     log.warn("엑셀 업로드 실패 - 행 {}: {}", i + 1, e.getMessage());
@@ -218,7 +235,7 @@ public class AnnualLeaveService {
         return new ProcessResult(response, baseUpdateDate);
     }
 
-    private void processAnnualLeaveRow(Row row, LocalDate updateDate) {
+    private void processAnnualLeaveRow(Row row, LocalDate updateDate, boolean sendNotification) {
         // 엑셀 컬럼 정의 기반 데이터 추출
         String name = getCellValueAsString(row.getCell(3)).trim();
         LocalDate joinDate = getCellValueAsLocalDate(row.getCell(4));
@@ -263,9 +280,12 @@ public class AnnualLeaveService {
 
         annualLeaveRepository.save(annualLeave);
 
-        // 연차 알림 전송 (LocalDate를 "yyyy년 MM월 dd일" 형식으로 변환하여 템플릿과 매칭)
-        String formattedDate = updateDate.format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일"));
-        notificationService.sendAnnualLeaveAlertToUser(targetUser.getId(), formattedDate);
+        if (sendNotification) {
+            // 연차 알림 전송 (LocalDate를 "yyyy년 MM월 dd일" 형식으로 변환하여 템플릿과 매칭)
+            String formattedDate =
+                    updateDate.format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일"));
+            notificationService.sendAnnualLeaveAlertToUser(targetUser.getId(), formattedDate);
+        }
     }
 
     // 연차 데이터 공지 기준일 파싱
@@ -403,6 +423,45 @@ public class AnnualLeaveService {
     }
 
     private record DispatchPeriod(Integer year, Integer month) {}
+
+    private void rebuildAnnualLeavesFromDispatchHistories(Long excludedDispatchId) {
+        annualLeaveRepository.deleteAllInBatch();
+
+        List<AnnualLeaveDispatchHistory> remainingHistories =
+                annualLeaveDispatchHistoryRepository.findAll().stream()
+                        .filter(
+                                history ->
+                                        excludedDispatchId == null
+                                                || !Objects.equals(
+                                                        history.getId(), excludedDispatchId))
+                        .sorted(dispatchHistoryReplayOrder())
+                        .toList();
+
+        for (AnnualLeaveDispatchHistory history : remainingHistories) {
+            if (history.getFileKey() == null || history.getFileKey().isBlank()) {
+                log.warn("연차 재계산 스킵 - dispatchId: {}, fileKey 없음", history.getId());
+                continue;
+            }
+
+            byte[] fileBytes = s3Service.downloadFile(history.getFileKey());
+            processAnnualLeaveFile(
+                    new ByteArrayInputStream(fileBytes),
+                    normalizeSheetName(history.getSheetName()),
+                    false);
+        }
+    }
+
+    private Comparator<AnnualLeaveDispatchHistory> dispatchHistoryReplayOrder() {
+        return Comparator.comparing(
+                        AnnualLeaveDispatchHistory::getBaseDate,
+                        Comparator.nullsLast(Comparator.naturalOrder()))
+                .thenComparing(
+                        AnnualLeaveDispatchHistory::getCreatedAt,
+                        Comparator.nullsLast(Comparator.naturalOrder()))
+                .thenComparing(
+                        AnnualLeaveDispatchHistory::getId,
+                        Comparator.nullsLast(Comparator.naturalOrder()));
+    }
 
     public AdminAnnualLeaveDispatchDetailResponseDto getAnnualLeaveDispatchDetailForAdmin(
             Long userId, Long dispatchId) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
@@ -282,8 +282,7 @@ public class AnnualLeaveService {
 
         if (sendNotification) {
             // 연차 알림 전송 (LocalDate를 "yyyy년 MM월 dd일" 형식으로 변환하여 템플릿과 매칭)
-            String formattedDate =
-                    updateDate.format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일"));
+            String formattedDate = updateDate.format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일"));
             notificationService.sendAnnualLeaveAlertToUser(targetUser.getId(), formattedDate);
         }
     }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
@@ -334,24 +334,24 @@ public class AnnualLeaveService {
 
         List<AnnualLeaveDispatchHistory> histories =
                 annualLeaveDispatchHistoryRepository.findAllOrderByCreatedAtDesc();
-        Map<String, List<AnnualLeaveDispatchHistory>> groupedBySheetName =
+        Map<String, List<AnnualLeaveDispatchHistory>> groupedByYear =
                 histories.stream()
                         .collect(
                                 Collectors.groupingBy(
-                                        history -> normalizeSheetName(history.getSheetName()),
+                                        this::resolveDispatchYearTitle,
                                         LinkedHashMap::new,
                                         Collectors.toList()));
 
-        return groupedBySheetName.entrySet().stream()
+        return groupedByYear.entrySet().stream()
                 .map(
                         entry -> {
-                            String sheetName = entry.getKey();
+                            String yearTitle = entry.getKey();
                             List<AdminAnnualLeaveDispatchItemResponseDto> items =
                                     entry.getValue().stream().map(this::toDispatchItemDto).toList();
 
                             return AdminAnnualLeaveDispatchGroupResponseDto.builder()
-                                    .sheetName(sheetName)
-                                    .title(sheetName)
+                                    .sheetName(yearTitle)
+                                    .title(yearTitle)
                                     .totalCount(items.size())
                                     .items(items)
                                     .build();
@@ -363,11 +363,46 @@ public class AnnualLeaveService {
             AnnualLeaveDispatchHistory history) {
         return AdminAnnualLeaveDispatchItemResponseDto.builder()
                 .dispatchId(history.getId())
+                .title(resolveDispatchMonthTitle(history))
                 .originalFileName(history.getOriginalFileName())
                 .sheetName(normalizeSheetName(history.getSheetName()))
                 .fileUrl(s3Service.getPresignedViewUrl(history.getFileKey()))
                 .build();
     }
+
+    private String resolveDispatchYearTitle(AnnualLeaveDispatchHistory history) {
+        DispatchPeriod period = resolveDispatchPeriod(history);
+        if (period.year() == null) {
+            return "연도 미상";
+        }
+        return period.year() + "년";
+    }
+
+    private String resolveDispatchMonthTitle(AnnualLeaveDispatchHistory history) {
+        DispatchPeriod period = resolveDispatchPeriod(history);
+        if (period.month() == null) {
+            return normalizeSheetName(history.getSheetName());
+        }
+        return period.month() + "월";
+    }
+
+    private DispatchPeriod resolveDispatchPeriod(AnnualLeaveDispatchHistory history) {
+        LocalDate baseDate = history.getBaseDate();
+        if (baseDate != null) {
+            return new DispatchPeriod(baseDate.getYear(), baseDate.getMonthValue());
+        }
+
+        YearMonth sheetYearMonth =
+                parseStrictYearMonthFromSheetName(normalizeSheetName(history.getSheetName()));
+        if (sheetYearMonth != null) {
+            return new DispatchPeriod(sheetYearMonth.getYear(), sheetYearMonth.getMonthValue());
+        }
+
+        Integer month = parseMonthFromSheetName(normalizeSheetName(history.getSheetName()));
+        return new DispatchPeriod(null, month);
+    }
+
+    private record DispatchPeriod(Integer year, Integer month) {}
 
     public AdminAnnualLeaveDispatchDetailResponseDto getAnnualLeaveDispatchDetailForAdmin(
             Long userId, Long dispatchId) {
@@ -423,20 +458,46 @@ public class AnnualLeaveService {
             return null;
         }
         // "2026-06" 형식
-        try {
-            return YearMonth.parse(sheetName, DateTimeFormatter.ofPattern("yyyy-MM"));
-        } catch (Exception ignored) {
+        YearMonth strictYearMonth = parseStrictYearMonthFromSheetName(sheetName);
+        if (strictYearMonth != null) {
+            return strictYearMonth;
         }
         // "8월", "08월", "8" 형식 — 연도는 현재 연도로 추정
         try {
-            String numericStr = sheetName.replaceAll("[^0-9]", "");
-            if (!numericStr.isEmpty()) {
-                int month = Integer.parseInt(numericStr);
-                if (month >= 1 && month <= 12) {
-                    return YearMonth.of(java.time.LocalDate.now().getYear(), month);
-                }
+            Integer month = parseMonthFromSheetName(sheetName);
+            if (month != null) {
+                return YearMonth.of(java.time.LocalDate.now().getYear(), month);
             }
         } catch (Exception ignored) {
+        }
+        return null;
+    }
+
+    private YearMonth parseStrictYearMonthFromSheetName(String sheetName) {
+        if (sheetName == null || sheetName.isBlank()) {
+            return null;
+        }
+        try {
+            return YearMonth.parse(sheetName, DateTimeFormatter.ofPattern("yyyy-MM"));
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private Integer parseMonthFromSheetName(String sheetName) {
+        if (sheetName == null || sheetName.isBlank()) {
+            return null;
+        }
+        String numericStr = sheetName.replaceAll("[^0-9]", "");
+        if (numericStr.isEmpty()) {
+            return null;
+        }
+        try {
+            int month = Integer.parseInt(numericStr);
+            if (month >= 1 && month <= 12) {
+                return month;
+            }
+        } catch (NumberFormatException ignored) {
         }
         return null;
     }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
@@ -532,10 +532,7 @@ public class AnnualLeaveServiceTest {
                     .willReturn(remainingFile.getBytes());
 
             User targetUser =
-                    User.builder()
-                            .nameKor("테스트 유저")
-                            .hireDate(LocalDate.of(2025, 12, 31))
-                            .build();
+                    User.builder().nameKor("테스트 유저").hireDate(LocalDate.of(2025, 12, 31)).build();
             given(userRepository.findByNameAndJoinDate(anyString(), any()))
                     .willReturn(Optional.of(targetUser));
             given(annualLeaveRepository.findByUser(targetUser)).willReturn(Optional.empty());
@@ -669,10 +666,7 @@ public class AnnualLeaveServiceTest {
                     .willReturn(remainingFile.getBytes());
 
             User targetUser =
-                    User.builder()
-                            .nameKor("테스트 유저")
-                            .hireDate(LocalDate.of(2025, 12, 31))
-                            .build();
+                    User.builder().nameKor("테스트 유저").hireDate(LocalDate.of(2025, 12, 31)).build();
             given(userRepository.findByNameAndJoinDate(anyString(), any()))
                     .willReturn(Optional.of(targetUser));
             given(annualLeaveRepository.findByUser(targetUser)).willReturn(Optional.empty());

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
@@ -279,7 +279,7 @@ public class AnnualLeaveServiceTest {
         }
 
         @Test
-        @DisplayName("권한이 있는 관리자가 요청하면 시트명 그룹으로 발송 목록을 반환한다")
+        @DisplayName("권한이 있는 관리자가 요청하면 연도 그룹과 월 제목으로 발송 목록을 반환한다")
         void it_returns_dispatched_annual_leave_list() {
             // given
             Long adminId = 1L;
@@ -293,6 +293,7 @@ public class AnnualLeaveServiceTest {
                             .originalFileName("2026_연차현황.xlsx")
                             .sheetName("2026-06")
                             .fileKey("annual-leave/2026-06-first.xlsx")
+                            .baseDate(LocalDate.of(2026, 6, 1))
                             .build();
             AnnualLeaveDispatchHistory second =
                     AnnualLeaveDispatchHistory.builder()
@@ -301,6 +302,7 @@ public class AnnualLeaveServiceTest {
                             .originalFileName("2026_연차현황_수정본.xlsx")
                             .sheetName("2026-06")
                             .fileKey("annual-leave/2026-06-second.xlsx")
+                            .baseDate(LocalDate.of(2026, 6, 1))
                             .build();
             AnnualLeaveDispatchHistory third =
                     AnnualLeaveDispatchHistory.builder()
@@ -309,6 +311,7 @@ public class AnnualLeaveServiceTest {
                             .originalFileName("2026_연차현황_7월.xlsx")
                             .sheetName("2026-07")
                             .fileKey("annual-leave/2026-07-first.xlsx")
+                            .baseDate(LocalDate.of(2026, 7, 1))
                             .build();
             given(annualLeaveDispatchHistoryRepository.findAllOrderByCreatedAtDesc())
                     .willReturn(List.of(first, second, third));
@@ -324,22 +327,22 @@ public class AnnualLeaveServiceTest {
                     annualLeaveService.getAnnualLeavesForAdmin(adminId);
 
             // then
-            assertThat(result.size()).isEqualTo(2);
-            assertThat(result.get(0).getSheetName()).isEqualTo("2026-06");
-            assertThat(result.get(0).getTitle()).isEqualTo("2026-06");
-            assertThat(result.get(0).getTotalCount()).isEqualTo(2);
+            assertThat(result.size()).isEqualTo(1);
+            assertThat(result.get(0).getSheetName()).isEqualTo("2026년");
+            assertThat(result.get(0).getTitle()).isEqualTo("2026년");
+            assertThat(result.get(0).getTotalCount()).isEqualTo(3);
             assertThat(result.get(0).getItems().get(0).getDispatchId()).isEqualTo(10L);
+            assertThat(result.get(0).getItems().get(0).getTitle()).isEqualTo("6월");
             assertThat(result.get(0).getItems().get(0).getOriginalFileName())
                     .isEqualTo("2026_연차현황.xlsx");
+            assertThat(result.get(0).getItems().get(0).getSheetName()).isEqualTo("2026-06");
+            assertThat(result.get(0).getItems().get(1).getTitle()).isEqualTo("6월");
             assertThat(result.get(0).getItems().get(1).getOriginalFileName())
                     .isEqualTo("2026_연차현황_수정본.xlsx");
             assertThat(result.get(0).getItems().get(0).getFileUrl())
                     .isEqualTo("https://example.com/annual-leave-2026-06-first");
-
-            assertThat(result.get(1).getSheetName()).isEqualTo("2026-07");
-            assertThat(result.get(1).getTitle()).isEqualTo("2026-07");
-            assertThat(result.get(1).getTotalCount()).isEqualTo(1);
-            assertThat(result.get(1).getItems().get(0).getFileUrl())
+            assertThat(result.get(0).getItems().get(2).getTitle()).isEqualTo("7월");
+            assertThat(result.get(0).getItems().get(2).getFileUrl())
                     .isEqualTo("https://example.com/annual-leave-2026-07-first");
         }
     }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
@@ -484,13 +484,73 @@ public class AnnualLeaveServiceTest {
                             .build();
             given(annualLeaveDispatchHistoryRepository.findById(dispatchId))
                     .willReturn(Optional.of(history));
+            given(annualLeaveDispatchHistoryRepository.findAll()).willReturn(List.of());
 
             // when
             annualLeaveService.deleteAnnualLeaveDispatchForAdmin(adminId, dispatchId);
 
             // then
             verify(annualLeaveDispatchHistoryRepository).delete(history);
+            verify(annualLeaveRepository).deleteAllInBatch();
             verify(s3Service).deleteFile("annual-leave/2026-08.xlsx");
+        }
+
+        @Test
+        @DisplayName("삭제 후 남은 발송 이력의 원본 파일 기준으로 연차 정보를 다시 계산한다")
+        void it_rebuilds_annual_leaves_from_remaining_dispatch_histories() throws IOException {
+            // given
+            Long adminId = 1L;
+            Long dispatchId = 10L;
+            User admin = createMockUser(Authority.EDIT_EMPLOYEE_INFO);
+            given(userRepository.findById(adminId)).willReturn(Optional.of(admin));
+
+            AnnualLeaveDispatchHistory deletedHistory =
+                    AnnualLeaveDispatchHistory.builder()
+                            .id(dispatchId)
+                            .uploadedBy(admin)
+                            .originalFileName("2026_연차현황_9월.xlsx")
+                            .sheetName("9월")
+                            .fileKey("annual-leave/2026-09.xlsx")
+                            .baseDate(LocalDate.of(2026, 9, 1))
+                            .build();
+            AnnualLeaveDispatchHistory remainingHistory =
+                    AnnualLeaveDispatchHistory.builder()
+                            .id(9L)
+                            .uploadedBy(admin)
+                            .originalFileName("2026_연차현황_8월.xlsx")
+                            .sheetName("8월")
+                            .fileKey("annual-leave/2026-08.xlsx")
+                            .baseDate(LocalDate.of(2026, 8, 1))
+                            .build();
+            given(annualLeaveDispatchHistoryRepository.findById(dispatchId))
+                    .willReturn(Optional.of(deletedHistory));
+            given(annualLeaveDispatchHistoryRepository.findAll())
+                    .willReturn(List.of(deletedHistory, remainingHistory));
+
+            MultipartFile remainingFile = createMockExcelFile();
+            given(s3Service.downloadFile("annual-leave/2026-08.xlsx"))
+                    .willReturn(remainingFile.getBytes());
+
+            User targetUser =
+                    User.builder()
+                            .nameKor("테스트 유저")
+                            .hireDate(LocalDate.of(2025, 12, 31))
+                            .build();
+            given(userRepository.findByNameAndJoinDate(anyString(), any()))
+                    .willReturn(Optional.of(targetUser));
+            given(annualLeaveRepository.findByUser(targetUser)).willReturn(Optional.empty());
+
+            // when
+            annualLeaveService.deleteAnnualLeaveDispatchForAdmin(adminId, dispatchId);
+
+            // then
+            verify(annualLeaveDispatchHistoryRepository).delete(deletedHistory);
+            verify(annualLeaveRepository).deleteAllInBatch();
+            verify(s3Service).downloadFile("annual-leave/2026-08.xlsx");
+            verify(annualLeaveRepository, atLeastOnce()).save(any(AnnualLeave.class));
+            org.mockito.Mockito.verify(notificationService, org.mockito.Mockito.never())
+                    .sendAnnualLeaveAlertToUser(any(), anyString());
+            verify(s3Service).deleteFile("annual-leave/2026-09.xlsx");
         }
     }
 
@@ -565,6 +625,67 @@ public class AnnualLeaveServiceTest {
             assertThat(result.getSheetName()).isEqualTo("2026-06");
             assertThat(result.getFileUrl())
                     .isEqualTo("https://example.com/annual-leave-2026-06-first");
+        }
+    }
+
+    @Nested
+    @DisplayName("rebuildAnnualLeavesForAdmin 메서드는")
+    class Describe_rebuildAnnualLeavesForAdmin {
+
+        @Test
+        @DisplayName("연차 발송 권한이 없는 유저가 요청하면 NO_AUTHORITY_FOR_ANNUAL_LEAVE 예외를 던진다")
+        void it_throws_when_user_has_no_authority() {
+            // given
+            Long userId = 1L;
+            given(userRepository.findById(userId)).willReturn(Optional.of(createMockUser(null)));
+
+            // when & then
+            assertThatThrownBy(() -> annualLeaveService.rebuildAnnualLeavesForAdmin(userId))
+                    .isInstanceOf(CustomException.class)
+                    .hasMessageContaining("연차 발송 권한이 없습니다.");
+        }
+
+        @Test
+        @DisplayName("권한이 있는 관리자가 요청하면 남은 발송 이력 기준으로 연차 정보를 다시 계산한다")
+        void it_rebuilds_annual_leaves() throws IOException {
+            // given
+            Long adminId = 1L;
+            User admin = createMockUser(Authority.EDIT_EMPLOYEE_INFO);
+            given(userRepository.findById(adminId)).willReturn(Optional.of(admin));
+
+            AnnualLeaveDispatchHistory history =
+                    AnnualLeaveDispatchHistory.builder()
+                            .id(9L)
+                            .uploadedBy(admin)
+                            .originalFileName("2026_연차현황_8월.xlsx")
+                            .sheetName("8월")
+                            .fileKey("annual-leave/2026-08.xlsx")
+                            .baseDate(LocalDate.of(2026, 8, 1))
+                            .build();
+            given(annualLeaveDispatchHistoryRepository.findAll()).willReturn(List.of(history));
+
+            MultipartFile remainingFile = createMockExcelFile();
+            given(s3Service.downloadFile("annual-leave/2026-08.xlsx"))
+                    .willReturn(remainingFile.getBytes());
+
+            User targetUser =
+                    User.builder()
+                            .nameKor("테스트 유저")
+                            .hireDate(LocalDate.of(2025, 12, 31))
+                            .build();
+            given(userRepository.findByNameAndJoinDate(anyString(), any()))
+                    .willReturn(Optional.of(targetUser));
+            given(annualLeaveRepository.findByUser(targetUser)).willReturn(Optional.empty());
+
+            // when
+            annualLeaveService.rebuildAnnualLeavesForAdmin(adminId);
+
+            // then
+            verify(annualLeaveRepository).deleteAllInBatch();
+            verify(s3Service).downloadFile("annual-leave/2026-08.xlsx");
+            verify(annualLeaveRepository, atLeastOnce()).save(any(AnnualLeave.class));
+            org.mockito.Mockito.verify(notificationService, org.mockito.Mockito.never())
+                    .sendAnnualLeaveAlertToUser(any(), anyString());
         }
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #426 

## 📝작업 내용
- 관리자 보낸 연차 목록 조회 응답에서 그룹 `title`을 연도 기준으로 내려주도록 수정했습니다.
- 각 발송 목록 item에 월 기준 `title`을 추가했습니다.
- 연차 발송 이력 삭제 시 `annual_leave` 현재값을 초기화한 뒤, 남아 있는 발송 이력의 원본 엑셀을 오래된 순서대로 다시 적용하도록 수정했습니다.
- 재계산 과정에서는 기존 사용자에게 연차 알림이 재발송되지 않도록 처리했습니다.
- 이미 삭제 후 데이터가 꼬인 상태를 복구할 수 있도록 관리자용 재계산 API를 추가했습니다.
  - `POST /api/annualleaves/admin/rebuild`

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X