### PR TITLE
fix(430): 급여명세서 title에서 '급여명세서' suffix 제거 및 예외 처리 강화

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/AdminPayslipDetailDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/AdminPayslipDetailDto.java
@@ -35,7 +35,7 @@ public class AdminPayslipDetailDto {
     @Schema(description = "원본 파일명", example = "급여명세서(근로기준1)_10001_홍길동_202605.pdf")
     private String originalFileName;
 
-    @Schema(description = "급여명세서 제목", example = "2026년 5월 급여명세서")
+    @Schema(description = "급여명세서 제목", example = "2026년 5월")
     private String payslipTitle;
 
     @Schema(description = "생성 일시", example = "2025-12-31T10:15:30")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/AdminPayslipGroupDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/AdminPayslipGroupDto.java
@@ -19,7 +19,7 @@ public class AdminPayslipGroupDto {
     @Schema(description = "급여지급월(YYYYMM)", example = "202606")
     private String yearMonth;
 
-    @Schema(description = "월별 그룹 제목", example = "2026년 6월 급여명세서")
+    @Schema(description = "월별 그룹 제목", example = "2026년 6월")
     private String title;
 
     @Schema(description = "해당 월 명세서 건수", example = "18")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/AdminPayslipSummaryDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/AdminPayslipSummaryDto.java
@@ -30,7 +30,7 @@ public class AdminPayslipSummaryDto {
     @Schema(description = "원본 파일명", example = "급여명세서(근로기준1)_10001_홍길동_202605.pdf")
     private String originalFileName;
 
-    @Schema(description = "급여명세서 제목", example = "2026년 5월 급여명세서")
+    @Schema(description = "급여명세서 제목", example = "2026년 5월")
     private String payslipTitle;
 
     @Schema(description = "생성 일시", example = "2025-12-31T10:15:30")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/EmployeePayslipDetailDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/EmployeePayslipDetailDto.java
@@ -27,7 +27,7 @@ public class EmployeePayslipDetailDto {
     @Schema(description = "원본 파일명", example = "급여명세서(근로기준1)_10001_홍길동_202605.pdf")
     private String originalFileName;
 
-    @Schema(description = "급여명세서 제목", example = "2026년 5월 급여명세서")
+    @Schema(description = "급여명세서 제목", example = "2026년 5월")
     private String payslipTitle;
 
     @Schema(description = "생성 일시", example = "2025-12-31T10:15:30")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/EmployeePayslipSummaryDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/dto/response/EmployeePayslipSummaryDto.java
@@ -22,7 +22,7 @@ public class EmployeePayslipSummaryDto {
     @Schema(description = "원본 파일명", example = "급여명세서(근로기준1)_10001_홍길동_202605.pdf")
     private String originalFileName;
 
-    @Schema(description = "급여명세서 제목", example = "2026년 5월 급여명세서")
+    @Schema(description = "급여명세서 제목", example = "2026년 5월")
     private String payslipTitle;
 
     @Schema(description = "생성 일시", example = "2025-12-31T10:15:30")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/mapper/PayslipMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/mapper/PayslipMapper.java
@@ -6,10 +6,9 @@ import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.EmployeeP
 import kr.co.awesomelead.groupware_backend.domain.payslip.dto.response.EmployeePayslipSummaryDto;
 import kr.co.awesomelead.groupware_backend.domain.payslip.entity.Payslip;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
-import kr.co.awesomelead.groupware_backend.global.infra.s3.service.S3Service;
-
 import kr.co.awesomelead.groupware_backend.global.error.CustomException;
 import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
+import kr.co.awesomelead.groupware_backend.global.infra.s3.service.S3Service;
 
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/mapper/PayslipMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/mapper/PayslipMapper.java
@@ -8,6 +8,9 @@ import kr.co.awesomelead.groupware_backend.domain.payslip.entity.Payslip;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
 import kr.co.awesomelead.groupware_backend.global.infra.s3.service.S3Service;
 
+import kr.co.awesomelead.groupware_backend.global.error.CustomException;
+import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
+
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -57,7 +60,7 @@ public interface PayslipMapper {
 
     default String buildPayslipTitle(Payslip payslip) {
         if (payslip == null) {
-            return "급여명세서";
+            throw new CustomException(ErrorCode.PAYSLIP_NOT_FOUND);
         }
         return buildPayslipTitleFromOriginalFileName(payslip.getOriginalFileName());
     }
@@ -75,7 +78,7 @@ public interface PayslipMapper {
 
     private static String buildPayslipTitleFromOriginalFileName(String originalFileName) {
         if (originalFileName == null || originalFileName.isBlank()) {
-            return "급여명세서";
+            throw new CustomException(ErrorCode.INVALID_PAYSLIP_FILE_NAME_FORMAT);
         }
 
         String normalizedPath = originalFileName.replace("\\", "/");
@@ -84,7 +87,7 @@ public interface PayslipMapper {
 
         Matcher matcher = PAYSLIP_MONTH_PATTERN.matcher(baseFileName);
         if (!matcher.matches()) {
-            return "급여명세서";
+            throw new CustomException(ErrorCode.INVALID_PAYSLIP_FILE_NAME_FORMAT);
         }
 
         String yearMonth = matcher.group(1);
@@ -92,9 +95,9 @@ public interface PayslipMapper {
         int month = Integer.parseInt(yearMonth.substring(4, 6));
 
         if (month < 1 || month > 12) {
-            return "급여명세서";
+            throw new CustomException(ErrorCode.INVALID_PAYSLIP_FILE_NAME_FORMAT);
         }
 
-        return year + "년 " + month + "월 급여명세서";
+        return year + "년 " + month + "월";
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/service/PayslipService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/service/PayslipService.java
@@ -426,16 +426,16 @@ public class PayslipService {
 
     private String buildGroupTitle(String yearMonth) {
         if (UNKNOWN_YEAR_MONTH.equals(yearMonth) || yearMonth == null || yearMonth.length() != 6) {
-            return "미분류 급여명세서";
+            throw new CustomException(ErrorCode.INVALID_PAYSLIP_FILE_NAME_FORMAT);
         }
 
         int year = Integer.parseInt(yearMonth.substring(0, 4));
         int month = Integer.parseInt(yearMonth.substring(4, 6));
         if (month < 1 || month > 12) {
-            return "미분류 급여명세서";
+            throw new CustomException(ErrorCode.INVALID_PAYSLIP_FILE_NAME_FORMAT);
         }
 
-        return year + "년 " + month + "월 급여명세서";
+        return year + "년 " + month + "월";
     }
 
     private int compareYearMonthDesc(String first, String second) {

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipMapperTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipMapperTest.java
@@ -1,6 +1,7 @@
 package kr.co.awesomelead.groupware_backend.domain.payslip;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -11,6 +12,8 @@ import kr.co.awesomelead.groupware_backend.domain.payslip.enums.PayslipStatus;
 import kr.co.awesomelead.groupware_backend.domain.payslip.mapper.PayslipMapper;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
+import kr.co.awesomelead.groupware_backend.global.error.CustomException;
+import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
 import kr.co.awesomelead.groupware_backend.global.infra.s3.service.S3Service;
 
 import org.junit.jupiter.api.Test;
@@ -41,7 +44,7 @@ class PayslipMapperTest {
         assertThat(response.getEmployeeName()).isEqualTo("리딘뷰");
         assertThat(response.getEmployPosition()).isEqualTo("사원");
         assertThat(response.getOriginalFileName()).isEqualTo(originalFileName);
-        assertThat(response.getPayslipTitle()).isEqualTo("2026년 4월 급여명세서");
+        assertThat(response.getPayslipTitle()).isEqualTo("2026년 4월");
     }
 
     @Test
@@ -61,7 +64,7 @@ class PayslipMapperTest {
         AdminPayslipSummaryDto response = payslipMapper.toAdminPayslipSummaryDto(payslip);
 
         assertThat(response.getOriginalFileName()).isEqualTo(nfdFileName);
-        assertThat(response.getPayslipTitle()).isEqualTo("2026년 4월 급여명세서");
+        assertThat(response.getPayslipTitle()).isEqualTo("2026년 4월");
     }
 
     @Test
@@ -85,5 +88,30 @@ class PayslipMapperTest {
         AdminPayslipDetailDto response = payslipMapper.toAdminPayslipDetailDto(payslip, s3Service);
 
         assertThat(response.getEmployPosition()).isEqualTo("대리");
+    }
+
+    @Test
+    void buildPayslipTitle_throwsWhenPayslipIsNull() {
+        assertThatThrownBy(() -> payslipMapper.buildPayslipTitle(null))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PAYSLIP_NOT_FOUND);
+    }
+
+    @Test
+    void buildPayslipTitle_throwsWhenOriginalFileNameIsNull() {
+        Payslip payslip = Payslip.builder().id(1L).originalFileName(null).build();
+
+        assertThatThrownBy(() -> payslipMapper.toAdminPayslipSummaryDto(payslip))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_PAYSLIP_FILE_NAME_FORMAT);
+    }
+
+    @Test
+    void buildPayslipTitle_throwsWhenOriginalFileNameIsInvalidFormat() {
+        Payslip payslip = Payslip.builder().id(1L).originalFileName("잘못된_파일명.pdf").build();
+
+        assertThatThrownBy(() -> payslipMapper.toAdminPayslipSummaryDto(payslip))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_PAYSLIP_FILE_NAME_FORMAT);
     }
 }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipMapperTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipMapperTest.java
@@ -103,7 +103,8 @@ class PayslipMapperTest {
 
         assertThatThrownBy(() -> payslipMapper.toAdminPayslipSummaryDto(payslip))
                 .isInstanceOf(CustomException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_PAYSLIP_FILE_NAME_FORMAT);
+                .hasFieldOrPropertyWithValue(
+                        "errorCode", ErrorCode.INVALID_PAYSLIP_FILE_NAME_FORMAT);
     }
 
     @Test
@@ -112,6 +113,7 @@ class PayslipMapperTest {
 
         assertThatThrownBy(() -> payslipMapper.toAdminPayslipSummaryDto(payslip))
                 .isInstanceOf(CustomException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_PAYSLIP_FILE_NAME_FORMAT);
+                .hasFieldOrPropertyWithValue(
+                        "errorCode", ErrorCode.INVALID_PAYSLIP_FILE_NAME_FORMAT);
     }
 }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipServiceTest.java
@@ -530,13 +530,13 @@ public class PayslipServiceTest {
 
                 AdminPayslipGroupDto firstGroup = result.get(0);
                 assertThat(firstGroup.getYearMonth()).isEqualTo("202606");
-                assertThat(firstGroup.getTitle()).isEqualTo("2026년 6월 급여명세서");
+                assertThat(firstGroup.getTitle()).isEqualTo("2026년 6월");
                 assertThat(firstGroup.getTotalCount()).isEqualTo(1);
                 assertThat(firstGroup.getItems().get(0).getPayslipId()).isEqualTo(3L);
 
                 AdminPayslipGroupDto secondGroup = result.get(1);
                 assertThat(secondGroup.getYearMonth()).isEqualTo("202605");
-                assertThat(secondGroup.getTitle()).isEqualTo("2026년 5월 급여명세서");
+                assertThat(secondGroup.getTitle()).isEqualTo("2026년 5월");
                 assertThat(secondGroup.getTotalCount()).isEqualTo(2);
                 // createdAt desc로 정렬되어 최신 건이 먼저
                 assertThat(secondGroup.getItems().get(0).getPayslipId()).isEqualTo(2L);
@@ -571,7 +571,33 @@ public class PayslipServiceTest {
                 // then
                 assertThat(result.size()).isEqualTo(1);
                 assertThat(result.get(0).getYearMonth()).isEqualTo("202604");
-                assertThat(result.get(0).getTitle()).isEqualTo("2026년 4월 급여명세서");
+                assertThat(result.get(0).getTitle()).isEqualTo("2026년 4월");
+            }
+
+            @Test
+            @DisplayName("originalFileName이 null인 DTO가 있으면 INVALID_PAYSLIP_FILE_NAME_FORMAT 예외를 던진다.")
+            void getPayslipsForAdminGrouped_throwsWhenOriginalFileNameIsNull() {
+                // given
+                User adminUser = User.builder().id(1L).role(Role.ADMIN).build();
+                given(userRepository.findById(1L)).willReturn(Optional.of(adminUser));
+
+                List<Payslip> payslips = List.of(new Payslip());
+                given(payslipRepository.findAllByStatusOptionalWithUser(null)).willReturn(payslips);
+
+                AdminPayslipSummaryDto nullFileName =
+                        AdminPayslipSummaryDto.builder()
+                                .payslipId(1L)
+                                .originalFileName(null)
+                                .createdAt(LocalDateTime.of(2026, 5, 20, 9, 0))
+                                .build();
+                given(payslipMapper.toAdminPayslipSummaryDtoList(payslips))
+                        .willReturn(List.of(nullFileName));
+
+                // when & then
+                assertThatThrownBy(() -> payslipService.getPayslipsForAdminGrouped(1L, null))
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue(
+                                "errorCode", ErrorCode.INVALID_PAYSLIP_FILE_NAME_FORMAT);
             }
         }
     }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipServiceTest.java
@@ -575,7 +575,8 @@ public class PayslipServiceTest {
             }
 
             @Test
-            @DisplayName("originalFileName이 null인 DTO가 있으면 INVALID_PAYSLIP_FILE_NAME_FORMAT 예외를 던진다.")
+            @DisplayName(
+                    "originalFileName이 null인 DTO가 있으면 INVALID_PAYSLIP_FILE_NAME_FORMAT 예외를 던진다.")
             void getPayslipsForAdminGrouped_throwsWhenOriginalFileNameIsNull() {
                 // given
                 User adminUser = User.builder().id(1L).role(Role.ADMIN).build();


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #430

## 📝작업 내용

- DTO `@Schema` 예시 값을 `"YYYY년 MM월"` 포맷으로 통일 (5개 파일)
- `PayslipService.buildGroupTitle`: 파일명 형식 위반 시 `"미분류 급여명세서"` fallback 반환 제거 → `INVALID_PAYSLIP_FILE_NAME_FORMAT` 예외 발생
- `PayslipMapper.buildPayslipTitle`: null payslip 시 `"급여명세서"` fallback 제거 → `PAYSLIP_NOT_FOUND` 예외 발생
- `PayslipMapper.buildPayslipTitleFromOriginalFileName`: null/blank/패턴불일치/월범위 초과 시 fallback 제거 → `INVALID_PAYSLIP_FILE_NAME_FORMAT` 예외 발생
- 정상 반환값을 `"N년 M월 급여명세서"` → `"N년 M월"` 으로 변경

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)

- X