### PR TITLE
feat(433): 연차 관리를 Company별 구분으로 고도화

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/controller/AnnualLeaveController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/controller/AnnualLeaveController.java
@@ -62,7 +62,8 @@ public class AnnualLeaveController {
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         ExcelUploadResponseDto responseDto =
-                annualLeaveService.uploadAnnualLeaveFile(file, sheetName, userDetails.getId(), company);
+                annualLeaveService.uploadAnnualLeaveFile(
+                        file, sheetName, userDetails.getId(), company);
         return ResponseEntity.ok(ApiResponse.onSuccess(responseDto));
     }
 
@@ -99,7 +100,8 @@ public class AnnualLeaveController {
                                         schema =
                                                 @Schema(
                                                         implementation =
-                                                                AdminAnnualLeaveDispatchGroupResponseDto.class)))
+                                                                AdminAnnualLeaveDispatchGroupResponseDto
+                                                                        .class)))
             })
     @GetMapping("/admin")
     public ResponseEntity<ApiResponse<List<AdminAnnualLeaveDispatchGroupResponseDto>>>
@@ -123,7 +125,8 @@ public class AnnualLeaveController {
                                         schema =
                                                 @Schema(
                                                         implementation =
-                                                                AdminAnnualLeaveDispatchDetailResponseDto.class)))
+                                                                AdminAnnualLeaveDispatchDetailResponseDto
+                                                                        .class)))
             })
     @GetMapping("/admin/{dispatchId}")
     public ResponseEntity<ApiResponse<AdminAnnualLeaveDispatchDetailResponseDto>>

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/controller/AnnualLeaveController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/controller/AnnualLeaveController.java
@@ -1,12 +1,16 @@
 package kr.co.awesomelead.groupware_backend.domain.annualleave.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AdminAnnualLeaveDispatchDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AdminAnnualLeaveDispatchGroupResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AnnualLeaveResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.ExcelUploadResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.service.AnnualLeaveService;
+import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.user.dto.CustomUserDetails;
 import kr.co.awesomelead.groupware_backend.global.common.response.ApiResponse;
 
@@ -37,18 +41,45 @@ public class AnnualLeaveController {
     private final AnnualLeaveService annualLeaveService;
 
     @Operation(summary = "연차 발송", description = "엑셀 파일과 시트명을 입력하여 연차를 일괄적으로 발송합니다.")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "업로드 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema =
+                                                @Schema(
+                                                        implementation =
+                                                                ExcelUploadResponseDto.class)))
+            })
     @PatchMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<ExcelUploadResponseDto>> uploadAnnualLeaveFile(
             @RequestPart("file") MultipartFile file,
             @RequestParam("sheetName") String sheetName,
+            @RequestParam("company") Company company,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         ExcelUploadResponseDto responseDto =
-                annualLeaveService.uploadAnnualLeaveFile(file, sheetName, userDetails.getId());
+                annualLeaveService.uploadAnnualLeaveFile(file, sheetName, userDetails.getId(), company);
         return ResponseEntity.ok(ApiResponse.onSuccess(responseDto));
     }
 
     @Operation(summary = "연차 조회", description = "연차 정보를 조회합니다.")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "조회 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema =
+                                                @Schema(
+                                                        implementation =
+                                                                AnnualLeaveResponseDto.class)))
+            })
     @GetMapping
     public ResponseEntity<ApiResponse<AnnualLeaveResponseDto>> getAnnualLeave(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -57,15 +88,43 @@ public class AnnualLeaveController {
     }
 
     @Operation(summary = "보낸 연차 목록 조회 (관리자)", description = "관리자가 보낸 연차 이력을 연도 기준 그룹으로 조회합니다.")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "조회 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema =
+                                                @Schema(
+                                                        implementation =
+                                                                AdminAnnualLeaveDispatchGroupResponseDto.class)))
+            })
     @GetMapping("/admin")
     public ResponseEntity<ApiResponse<List<AdminAnnualLeaveDispatchGroupResponseDto>>>
-            getAnnualLeavesForAdmin(@AuthenticationPrincipal CustomUserDetails userDetails) {
+            getAnnualLeavesForAdmin(
+                    @RequestParam(value = "company", required = false) Company company,
+                    @AuthenticationPrincipal CustomUserDetails userDetails) {
         List<AdminAnnualLeaveDispatchGroupResponseDto> responseDto =
-                annualLeaveService.getAnnualLeavesForAdmin(userDetails.getId());
+                annualLeaveService.getAnnualLeavesForAdmin(userDetails.getId(), company);
         return ResponseEntity.ok(ApiResponse.onSuccess(responseDto));
     }
 
     @Operation(summary = "보낸 연차 상세 조회 (관리자)", description = "관리자가 특정 연차 발송 이력을 상세 조회합니다.")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "조회 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema =
+                                                @Schema(
+                                                        implementation =
+                                                                AdminAnnualLeaveDispatchDetailResponseDto.class)))
+            })
     @GetMapping("/admin/{dispatchId}")
     public ResponseEntity<ApiResponse<AdminAnnualLeaveDispatchDetailResponseDto>>
             getAnnualLeaveDispatchDetailForAdmin(
@@ -78,21 +137,41 @@ public class AnnualLeaveController {
     }
 
     @Operation(summary = "보낸 연차 수정 (관리자)", description = "관리자가 특정 연차 발송 이력을 새 파일로 수정합니다.")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "수정 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema =
+                                                @Schema(
+                                                        implementation =
+                                                                ExcelUploadResponseDto.class)))
+            })
     @PutMapping(value = "/admin/{dispatchId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<ExcelUploadResponseDto>> updateAnnualLeaveDispatch(
             @PathVariable Long dispatchId,
             @RequestPart("file") MultipartFile file,
             @RequestParam("sheetName") String sheetName,
+            @RequestParam("company") Company company,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         ExcelUploadResponseDto responseDto =
                 annualLeaveService.updateAnnualLeaveDispatchForAdmin(
-                        userDetails.getId(), dispatchId, file, sheetName);
+                        userDetails.getId(), dispatchId, file, sheetName, company);
         return ResponseEntity.ok(ApiResponse.onSuccess(responseDto));
     }
 
     @Operation(
             summary = "연차 정보 재계산 (관리자)",
             description = "남아 있는 연차 발송 이력의 원본 파일 기준으로 사용자 연차 정보를 다시 계산합니다.")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "처리 성공")
+            })
     @PostMapping("/admin/rebuild")
     public ResponseEntity<ApiResponse<Void>> rebuildAnnualLeavesForAdmin(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -101,6 +180,12 @@ public class AnnualLeaveController {
     }
 
     @Operation(summary = "보낸 연차 삭제 (관리자)", description = "관리자가 특정 연차 발송 이력을 삭제합니다.")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "처리 성공")
+            })
     @DeleteMapping("/admin/{dispatchId}")
     public ResponseEntity<ApiResponse<Void>> deleteAnnualLeaveDispatch(
             @PathVariable Long dispatchId, @AuthenticationPrincipal CustomUserDetails userDetails) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/dto/response/AdminAnnualLeaveDispatchDetailResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/dto/response/AdminAnnualLeaveDispatchDetailResponseDto.java
@@ -2,17 +2,15 @@ package kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import lombok.AllArgsConstructor;
+import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
+
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
 @Schema(description = "관리자용 연차 발송 상세 응답")
 public class AdminAnnualLeaveDispatchDetailResponseDto {
 
@@ -30,4 +28,10 @@ public class AdminAnnualLeaveDispatchDetailResponseDto {
 
     @Schema(description = "엑셀 파일 열람 URL(Presigned)", example = "https://...presigned-url")
     private String fileUrl;
+
+    @Schema(description = "아이템 제목(월)", example = "7월")
+    private String title;
+
+    @Schema(description = "소속 회사", example = "AWESOME")
+    private Company company;
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/dto/response/AdminAnnualLeaveDispatchGroupResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/dto/response/AdminAnnualLeaveDispatchGroupResponseDto.java
@@ -2,17 +2,13 @@ package kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
 @Schema(description = "관리자용 연차 발송 목록 그룹 응답")
 public class AdminAnnualLeaveDispatchGroupResponseDto {
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/dto/response/AdminAnnualLeaveDispatchItemResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/dto/response/AdminAnnualLeaveDispatchItemResponseDto.java
@@ -2,15 +2,13 @@ package kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import lombok.AllArgsConstructor;
+import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
+
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
 @Schema(description = "관리자용 연차 발송 목록 아이템")
 public class AdminAnnualLeaveDispatchItemResponseDto {
 
@@ -28,4 +26,7 @@ public class AdminAnnualLeaveDispatchItemResponseDto {
 
     @Schema(description = "엑셀 파일 열람 URL(Presigned)", example = "https://...presigned-url")
     private String fileUrl;
+
+    @Schema(description = "소속 회사", example = "AWESOME")
+    private Company company;
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/entity/AnnualLeaveDispatchHistory.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/entity/AnnualLeaveDispatchHistory.java
@@ -3,6 +3,8 @@ package kr.co.awesomelead.groupware_backend.domain.annualleave.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -10,13 +12,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 
+import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -26,9 +29,8 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@Setter
 @Builder
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 public class AnnualLeaveDispatchHistory {
@@ -53,7 +55,20 @@ public class AnnualLeaveDispatchHistory {
     @Column(nullable = true)
     private LocalDate baseDate;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private Company company;
+
     @CreatedDate
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
+
+    public void updateDispatch(User uploader, String originalFileName, String sheetName, String fileKey, LocalDate baseDate, Company company) {
+        this.uploadedBy = uploader;
+        this.originalFileName = originalFileName;
+        this.sheetName = sheetName;
+        this.fileKey = fileKey;
+        this.baseDate = baseDate;
+        this.company = company;
+    }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/entity/AnnualLeaveDispatchHistory.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/entity/AnnualLeaveDispatchHistory.java
@@ -63,7 +63,13 @@ public class AnnualLeaveDispatchHistory {
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    public void updateDispatch(User uploader, String originalFileName, String sheetName, String fileKey, LocalDate baseDate, Company company) {
+    public void updateDispatch(
+            User uploader,
+            String originalFileName,
+            String sheetName,
+            String fileKey,
+            LocalDate baseDate,
+            Company company) {
         this.uploadedBy = uploader;
         this.originalFileName = originalFileName;
         this.sheetName = sheetName;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/repository/AnnualLeaveDispatchHistoryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/repository/AnnualLeaveDispatchHistoryRepository.java
@@ -1,9 +1,11 @@
 package kr.co.awesomelead.groupware_backend.domain.annualleave.repository;
 
 import kr.co.awesomelead.groupware_backend.domain.annualleave.entity.AnnualLeaveDispatchHistory;
+import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -14,7 +16,16 @@ public interface AnnualLeaveDispatchHistoryRepository
     @Query("SELECT h FROM AnnualLeaveDispatchHistory h ORDER BY h.createdAt DESC, h.id DESC")
     List<AnnualLeaveDispatchHistory> findAllOrderByCreatedAtDesc();
 
+    @Query("SELECT h FROM AnnualLeaveDispatchHistory h WHERE (:company IS NULL OR h.company = :company) ORDER BY h.createdAt DESC, h.id DESC")
+    List<AnnualLeaveDispatchHistory> findAllByCompanyOrderByCreatedAtDesc(
+            @Param("company") Company company);
+
     boolean existsByBaseDateBetween(LocalDate start, LocalDate end);
 
     boolean existsByIdNotAndBaseDateBetween(Long id, LocalDate start, LocalDate end);
+
+    boolean existsByCompanyAndBaseDateBetween(Company company, LocalDate start, LocalDate end);
+
+    boolean existsByIdNotAndCompanyAndBaseDateBetween(
+            Long id, Company company, LocalDate start, LocalDate end);
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/repository/AnnualLeaveDispatchHistoryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/repository/AnnualLeaveDispatchHistoryRepository.java
@@ -16,7 +16,9 @@ public interface AnnualLeaveDispatchHistoryRepository
     @Query("SELECT h FROM AnnualLeaveDispatchHistory h ORDER BY h.createdAt DESC, h.id DESC")
     List<AnnualLeaveDispatchHistory> findAllOrderByCreatedAtDesc();
 
-    @Query("SELECT h FROM AnnualLeaveDispatchHistory h WHERE (:company IS NULL OR h.company = :company) ORDER BY h.createdAt DESC, h.id DESC")
+    @Query(
+            "SELECT h FROM AnnualLeaveDispatchHistory h WHERE (:company IS NULL OR h.company ="
+                + " :company) ORDER BY h.createdAt DESC, h.id DESC")
     List<AnnualLeaveDispatchHistory> findAllByCompanyOrderByCreatedAtDesc(
             @Param("company") Company company);
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
@@ -75,7 +75,10 @@ public class AnnualLeaveService {
 
         if (processResult.baseDate() != null) {
             LocalDate start = processResult.baseDate().withDayOfMonth(1);
-            LocalDate end = processResult.baseDate().withDayOfMonth(processResult.baseDate().lengthOfMonth());
+            LocalDate end =
+                    processResult
+                            .baseDate()
+                            .withDayOfMonth(processResult.baseDate().lengthOfMonth());
             if (annualLeaveDispatchHistoryRepository.existsByCompanyAndBaseDateBetween(
                     company, start, end)) {
                 throw new CustomException(ErrorCode.DUPLICATE_ANNUAL_LEAVE_DISPATCH);
@@ -114,7 +117,10 @@ public class AnnualLeaveService {
 
         if (processResult.baseDate() != null) {
             LocalDate start = processResult.baseDate().withDayOfMonth(1);
-            LocalDate end = processResult.baseDate().withDayOfMonth(processResult.baseDate().lengthOfMonth());
+            LocalDate end =
+                    processResult
+                            .baseDate()
+                            .withDayOfMonth(processResult.baseDate().lengthOfMonth());
             if (annualLeaveDispatchHistoryRepository.existsByIdNotAndCompanyAndBaseDateBetween(
                     dispatchId, company, start, end)) {
                 throw new CustomException(ErrorCode.DUPLICATE_ANNUAL_LEAVE_DISPATCH);

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
@@ -11,6 +11,7 @@ import kr.co.awesomelead.groupware_backend.domain.annualleave.entity.AnnualLeave
 import kr.co.awesomelead.groupware_backend.domain.annualleave.mapper.AnnualLeaveMapper;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.repository.AnnualLeaveDispatchHistoryRepository;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.repository.AnnualLeaveRepository;
+import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Authority;
@@ -62,37 +63,38 @@ public class AnnualLeaveService {
 
     @Transactional
     public ExcelUploadResponseDto uploadAnnualLeaveFile(
-            MultipartFile file, String sheetName, Long userId) {
+            MultipartFile file, String sheetName, Long userId, Company company) {
         User currentUser = validateAnnualLeaveEditAuthority(userId);
         String normalizedSheetName = normalizeSheetName(sheetName);
-
-        YearMonth sheetYearMonth = parseYearMonthFromSheetName(normalizedSheetName);
-        if (sheetYearMonth != null) {
-            LocalDate start = sheetYearMonth.atDay(1);
-            LocalDate end = sheetYearMonth.atEndOfMonth();
-            if (annualLeaveDispatchHistoryRepository.existsByBaseDateBetween(start, end)) {
-                throw new CustomException(ErrorCode.DUPLICATE_ANNUAL_LEAVE_DISPATCH);
-            }
-        }
 
         // S3 업로드를 트랜잭션 전에 수행 (네트워크 I/O를 DB 커넥션 점유 시간에서 분리)
         String fileKey = uploadAnnualLeaveSourceFile(file);
 
-        ProcessResult processResult = processAnnualLeaveFile(file, normalizedSheetName);
+        ProcessResult processResult = processAnnualLeaveFile(file, normalizedSheetName, company);
         validateSheetMonthMatchesBaseDate(normalizedSheetName, processResult.baseDate());
+
+        if (processResult.baseDate() != null) {
+            LocalDate start = processResult.baseDate().withDayOfMonth(1);
+            LocalDate end = processResult.baseDate().withDayOfMonth(processResult.baseDate().lengthOfMonth());
+            if (annualLeaveDispatchHistoryRepository.existsByCompanyAndBaseDateBetween(
+                    company, start, end)) {
+                throw new CustomException(ErrorCode.DUPLICATE_ANNUAL_LEAVE_DISPATCH);
+            }
+        }
 
         saveDispatchHistory(
                 currentUser,
                 file.getOriginalFilename(),
                 normalizedSheetName,
                 fileKey,
-                processResult.baseDate());
+                processResult.baseDate(),
+                company);
         return processResult.response();
     }
 
     @Transactional
     public ExcelUploadResponseDto updateAnnualLeaveDispatchForAdmin(
-            Long userId, Long dispatchId, MultipartFile file, String sheetName) {
+            Long userId, Long dispatchId, MultipartFile file, String sheetName, Company company) {
         User currentUser = validateAnnualLeaveEditAuthority(userId);
         AnnualLeaveDispatchHistory history =
                 annualLeaveDispatchHistoryRepository
@@ -103,28 +105,29 @@ public class AnnualLeaveService {
                                                 ErrorCode.ANNUAL_LEAVE_DISPATCH_HISTORY_NOT_FOUND));
         String normalizedSheetName = normalizeSheetName(sheetName);
 
-        YearMonth sheetYearMonth = parseYearMonthFromSheetName(normalizedSheetName);
-        if (sheetYearMonth != null) {
-            LocalDate start = sheetYearMonth.atDay(1);
-            LocalDate end = sheetYearMonth.atEndOfMonth();
-            if (annualLeaveDispatchHistoryRepository.existsByIdNotAndBaseDateBetween(
-                    dispatchId, start, end)) {
-                throw new CustomException(ErrorCode.DUPLICATE_ANNUAL_LEAVE_DISPATCH);
-            }
-        }
-
         // S3 업로드를 DB 작업 전에 수행 (트랜잭션 내 네트워크 I/O 제거)
         String oldFileKey = history.getFileKey();
         String newFileKey = uploadAnnualLeaveSourceFile(file);
 
-        ProcessResult processResult = processAnnualLeaveFile(file, normalizedSheetName);
+        ProcessResult processResult = processAnnualLeaveFile(file, normalizedSheetName, company);
         validateSheetMonthMatchesBaseDate(normalizedSheetName, processResult.baseDate());
 
-        history.setUploadedBy(currentUser);
-        history.setOriginalFileName(normalizeOriginalFileName(file.getOriginalFilename()));
-        history.setSheetName(normalizeSheetName(sheetName));
-        history.setFileKey(newFileKey);
-        history.setBaseDate(processResult.baseDate());
+        if (processResult.baseDate() != null) {
+            LocalDate start = processResult.baseDate().withDayOfMonth(1);
+            LocalDate end = processResult.baseDate().withDayOfMonth(processResult.baseDate().lengthOfMonth());
+            if (annualLeaveDispatchHistoryRepository.existsByIdNotAndCompanyAndBaseDateBetween(
+                    dispatchId, company, start, end)) {
+                throw new CustomException(ErrorCode.DUPLICATE_ANNUAL_LEAVE_DISPATCH);
+            }
+        }
+
+        history.updateDispatch(
+                currentUser,
+                normalizeOriginalFileName(file.getOriginalFilename()),
+                normalizeSheetName(sheetName),
+                newFileKey,
+                processResult.baseDate(),
+                company);
 
         if (oldFileKey != null && !oldFileKey.isBlank() && !oldFileKey.equals(newFileKey)) {
             try {
@@ -174,16 +177,17 @@ public class AnnualLeaveService {
 
     private record ProcessResult(ExcelUploadResponseDto response, LocalDate baseDate) {}
 
-    private ProcessResult processAnnualLeaveFile(MultipartFile file, String normalizedSheetName) {
+    private ProcessResult processAnnualLeaveFile(
+            MultipartFile file, String normalizedSheetName, Company company) {
         try (InputStream is = file.getInputStream()) {
-            return processAnnualLeaveFile(is, normalizedSheetName, true);
+            return processAnnualLeaveFile(is, normalizedSheetName, true, company);
         } catch (IOException e) {
             throw new CustomException(ErrorCode.FILE_UPLOAD_ERROR);
         }
     }
 
     private ProcessResult processAnnualLeaveFile(
-            InputStream is, String normalizedSheetName, boolean sendNotification) {
+            InputStream is, String normalizedSheetName, boolean sendNotification, Company company) {
         List<FailureDetail> failures = new ArrayList<>();
         int successCount = 0;
         int totalProcessed = 0;
@@ -208,8 +212,10 @@ public class AnnualLeaveService {
 
                 totalProcessed++; // 파싱 작업 수 증가
                 try {
-                    processAnnualLeaveRow(row, baseUpdateDate, sendNotification);
+                    processAnnualLeaveRow(row, baseUpdateDate, sendNotification, company);
                     successCount++; // 성공 작업 수 증가
+                } catch (CustomException e) {
+                    throw e;
                 } catch (Exception e) {
                     log.warn("엑셀 업로드 실패 - 행 {}: {}", i + 1, e.getMessage());
                     failures.add(
@@ -235,7 +241,8 @@ public class AnnualLeaveService {
         return new ProcessResult(response, baseUpdateDate);
     }
 
-    private void processAnnualLeaveRow(Row row, LocalDate updateDate, boolean sendNotification) {
+    private void processAnnualLeaveRow(
+            Row row, LocalDate updateDate, boolean sendNotification, Company requestedCompany) {
         // 엑셀 컬럼 정의 기반 데이터 추출
         String name = getCellValueAsString(row.getCell(3)).trim();
         LocalDate joinDate = getCellValueAsLocalDate(row.getCell(4));
@@ -249,6 +256,12 @@ public class AnnualLeaveService {
                 userRepository
                         .findByNameAndJoinDate(name, joinDate)
                         .orElseThrow(() -> new RuntimeException("일치하는 직원을 찾을 수 없습니다."));
+
+        if (requestedCompany != null
+                && targetUser.getWorkLocation() != null
+                && targetUser.getWorkLocation() != requestedCompany) {
+            throw new CustomException(ErrorCode.ANNUAL_LEAVE_COMPANY_MISMATCH);
+        }
 
         // 연차 정보 추출 (Double 타입 대응)
         Double total = getCellValueAsDouble(row.getCell(5));
@@ -348,11 +361,12 @@ public class AnnualLeaveService {
         return annualLeaveMapper.toAnnualLeaveResponseDto(user.getAnnualLeave());
     }
 
-    public List<AdminAnnualLeaveDispatchGroupResponseDto> getAnnualLeavesForAdmin(Long userId) {
+    public List<AdminAnnualLeaveDispatchGroupResponseDto> getAnnualLeavesForAdmin(
+            Long userId, Company company) {
         validateAnnualLeaveEditAuthority(userId);
 
         List<AnnualLeaveDispatchHistory> histories =
-                annualLeaveDispatchHistoryRepository.findAllOrderByCreatedAtDesc();
+                annualLeaveDispatchHistoryRepository.findAllByCompanyOrderByCreatedAtDesc(company);
         Map<String, List<AnnualLeaveDispatchHistory>> groupedByYear =
                 histories.stream()
                         .collect(
@@ -386,6 +400,7 @@ public class AnnualLeaveService {
                 .originalFileName(history.getOriginalFileName())
                 .sheetName(normalizeSheetName(history.getSheetName()))
                 .fileUrl(s3Service.getPresignedViewUrl(history.getFileKey()))
+                .company(history.getCompany())
                 .build();
     }
 
@@ -446,7 +461,8 @@ public class AnnualLeaveService {
             processAnnualLeaveFile(
                     new ByteArrayInputStream(fileBytes),
                     normalizeSheetName(history.getSheetName()),
-                    false);
+                    false,
+                    history.getCompany());
         }
     }
 
@@ -480,6 +496,8 @@ public class AnnualLeaveService {
                 .sheetName(normalizeSheetName(history.getSheetName()))
                 .createdAt(history.getCreatedAt())
                 .fileUrl(s3Service.getPresignedViewUrl(history.getFileKey()))
+                .title(resolveDispatchMonthTitle(history))
+                .company(history.getCompany())
                 .build();
     }
 
@@ -499,7 +517,8 @@ public class AnnualLeaveService {
             String originalFileName,
             String sheetName,
             String fileKey,
-            LocalDate baseDate) {
+            LocalDate baseDate,
+            Company company) {
         AnnualLeaveDispatchHistory history =
                 AnnualLeaveDispatchHistory.builder()
                         .uploadedBy(uploader)
@@ -507,28 +526,9 @@ public class AnnualLeaveService {
                         .sheetName(normalizeSheetName(sheetName))
                         .fileKey(fileKey)
                         .baseDate(baseDate)
+                        .company(company)
                         .build();
         annualLeaveDispatchHistoryRepository.save(history);
-    }
-
-    private YearMonth parseYearMonthFromSheetName(String sheetName) {
-        if (sheetName == null || sheetName.isBlank()) {
-            return null;
-        }
-        // "2026-06" 형식
-        YearMonth strictYearMonth = parseStrictYearMonthFromSheetName(sheetName);
-        if (strictYearMonth != null) {
-            return strictYearMonth;
-        }
-        // "8월", "08월", "8" 형식 — 연도는 현재 연도로 추정
-        try {
-            Integer month = parseMonthFromSheetName(sheetName);
-            if (month != null) {
-                return YearMonth.of(java.time.LocalDate.now().getYear(), month);
-            }
-        } catch (Exception ignored) {
-        }
-        return null;
     }
 
     private YearMonth parseStrictYearMonthFromSheetName(String sheetName) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
@@ -79,7 +79,8 @@ public enum ErrorCode {
     SAFETY_TRAINING_ABSENT_REASON_REQUIRED(
             HttpStatus.BAD_REQUEST, "결석자가 있을 경우 교육 미참석 사유 입력은 필수입니다."),
     ANNUAL_LEAVE_MONTH_MISMATCH(HttpStatus.BAD_REQUEST, "시트명의 월 정보와 엑셀 기준일의 월 정보가 일치하지 않습니다."),
-    ANNUAL_LEAVE_COMPANY_MISMATCH(HttpStatus.BAD_REQUEST, "업로드 요청한 회사 정보와 엑셀 데이터 내 직원의 소속 회사가 일치하지 않습니다."),
+    ANNUAL_LEAVE_COMPANY_MISMATCH(
+            HttpStatus.BAD_REQUEST, "업로드 요청한 회사 정보와 엑셀 데이터 내 직원의 소속 회사가 일치하지 않습니다."),
 
     // 401 Unauthorized
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
@@ -79,6 +79,7 @@ public enum ErrorCode {
     SAFETY_TRAINING_ABSENT_REASON_REQUIRED(
             HttpStatus.BAD_REQUEST, "결석자가 있을 경우 교육 미참석 사유 입력은 필수입니다."),
     ANNUAL_LEAVE_MONTH_MISMATCH(HttpStatus.BAD_REQUEST, "시트명의 월 정보와 엑셀 기준일의 월 정보가 일치하지 않습니다."),
+    ANNUAL_LEAVE_COMPANY_MISMATCH(HttpStatus.BAD_REQUEST, "업로드 요청한 회사 정보와 엑셀 데이터 내 직원의 소속 회사가 일치하지 않습니다."),
 
     // 401 Unauthorized
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
@@ -9,6 +9,8 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AdminAnnualLeaveDispatchDetailResponseDto;
+import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AdminAnnualLeaveDispatchItemResponseDto;
+import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AdminAnnualLeaveDispatchGroupResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AnnualLeaveResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.ExcelUploadResponseDto;
@@ -80,7 +82,7 @@ public class AnnualLeaveServiceTest {
                 assertThatThrownBy(
                                 () ->
                                         annualLeaveService.uploadAnnualLeaveFile(
-                                                null, sheetName, loginUserId))
+                                                null, sheetName, loginUserId, Company.AWESOME))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining("연차 발송 권한이 없습니다.");
             }
@@ -111,7 +113,8 @@ public class AnnualLeaveServiceTest {
 
                 // when
                 ExcelUploadResponseDto response =
-                        annualLeaveService.uploadAnnualLeaveFile(mockFile, sheetName, loginUserId);
+                        annualLeaveService.uploadAnnualLeaveFile(
+                                mockFile, sheetName, loginUserId, Company.AWESOME);
 
                 // then
                 assertThat(response.getSuccessCount()).isGreaterThan(0);
@@ -139,7 +142,7 @@ public class AnnualLeaveServiceTest {
                 assertThatThrownBy(
                                 () ->
                                         annualLeaveService.uploadAnnualLeaveFile(
-                                                invalidFile, sheetName, loginUserId))
+                                                invalidFile, sheetName, loginUserId, Company.AWESOME))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(
                                 "유효하지 않은 기준일자 형식입니다. (yyyy-MM-dd)"); // ErrorCode 메시지에 따라 수정
@@ -163,7 +166,8 @@ public class AnnualLeaveServiceTest {
 
                 // when
                 ExcelUploadResponseDto response =
-                        annualLeaveService.uploadAnnualLeaveFile(mockFile, sheetName, loginUserId);
+                        annualLeaveService.uploadAnnualLeaveFile(
+                                mockFile, sheetName, loginUserId, Company.AWESOME);
 
                 // then
                 assertThat(response.getSuccessCount()).isEqualTo(0);
@@ -191,7 +195,7 @@ public class AnnualLeaveServiceTest {
                 assertThatThrownBy(
                                 () ->
                                         annualLeaveService.uploadAnnualLeaveFile(
-                                                mockFile, sheetName, loginUserId))
+                                                mockFile, sheetName, loginUserId, Company.AWESOME))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining("파일 업로드 중 오류가 발생했습니다."); // ErrorCode의 메시지에 맞춰 수정
             }
@@ -273,7 +277,7 @@ public class AnnualLeaveServiceTest {
             given(userRepository.findById(userId)).willReturn(Optional.of(createMockUser(null)));
 
             // when & then
-            assertThatThrownBy(() -> annualLeaveService.getAnnualLeavesForAdmin(userId))
+            assertThatThrownBy(() -> annualLeaveService.getAnnualLeavesForAdmin(userId, null))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining("연차 발송 권한이 없습니다.");
         }
@@ -294,6 +298,7 @@ public class AnnualLeaveServiceTest {
                             .sheetName("2026-06")
                             .fileKey("annual-leave/2026-06-first.xlsx")
                             .baseDate(LocalDate.of(2026, 6, 1))
+                            .company(Company.AWESOME)
                             .build();
             AnnualLeaveDispatchHistory second =
                     AnnualLeaveDispatchHistory.builder()
@@ -303,6 +308,7 @@ public class AnnualLeaveServiceTest {
                             .sheetName("2026-06")
                             .fileKey("annual-leave/2026-06-second.xlsx")
                             .baseDate(LocalDate.of(2026, 6, 1))
+                            .company(Company.AWESOME)
                             .build();
             AnnualLeaveDispatchHistory third =
                     AnnualLeaveDispatchHistory.builder()
@@ -312,8 +318,9 @@ public class AnnualLeaveServiceTest {
                             .sheetName("2026-07")
                             .fileKey("annual-leave/2026-07-first.xlsx")
                             .baseDate(LocalDate.of(2026, 7, 1))
+                            .company(Company.AWESOME)
                             .build();
-            given(annualLeaveDispatchHistoryRepository.findAllOrderByCreatedAtDesc())
+            given(annualLeaveDispatchHistoryRepository.findAllByCompanyOrderByCreatedAtDesc(null))
                     .willReturn(List.of(first, second, third));
             given(s3Service.getPresignedViewUrl("annual-leave/2026-06-first.xlsx"))
                     .willReturn("https://example.com/annual-leave-2026-06-first");
@@ -324,7 +331,7 @@ public class AnnualLeaveServiceTest {
 
             // when
             List<AdminAnnualLeaveDispatchGroupResponseDto> result =
-                    annualLeaveService.getAnnualLeavesForAdmin(adminId);
+                    annualLeaveService.getAnnualLeavesForAdmin(adminId, null);
 
             // then
             assertThat(result.size()).isEqualTo(1);
@@ -336,6 +343,7 @@ public class AnnualLeaveServiceTest {
             assertThat(result.get(0).getItems().get(0).getOriginalFileName())
                     .isEqualTo("2026_연차현황.xlsx");
             assertThat(result.get(0).getItems().get(0).getSheetName()).isEqualTo("2026-06");
+            assertThat(result.get(0).getItems().get(0).getCompany()).isEqualTo(Company.AWESOME);
             assertThat(result.get(0).getItems().get(1).getTitle()).isEqualTo("6월");
             assertThat(result.get(0).getItems().get(1).getOriginalFileName())
                     .isEqualTo("2026_연차현황_수정본.xlsx");
@@ -363,7 +371,7 @@ public class AnnualLeaveServiceTest {
             assertThatThrownBy(
                             () ->
                                     annualLeaveService.updateAnnualLeaveDispatchForAdmin(
-                                            userId, 10L, mockFile, "8월"))
+                                            userId, 10L, mockFile, "8월", Company.AWESOME))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining("연차 발송 권한이 없습니다.");
         }
@@ -382,7 +390,7 @@ public class AnnualLeaveServiceTest {
             assertThatThrownBy(
                             () ->
                                     annualLeaveService.updateAnnualLeaveDispatchForAdmin(
-                                            adminId, 999L, mockFile, "8월"))
+                                            adminId, 999L, mockFile, "8월", Company.AWESOME))
                     .isInstanceOf(CustomException.class)
                     .hasMessageContaining("해당 연차 발송 이력을 찾을 수 없습니다.");
         }
@@ -418,7 +426,7 @@ public class AnnualLeaveServiceTest {
             // when
             ExcelUploadResponseDto result =
                     annualLeaveService.updateAnnualLeaveDispatchForAdmin(
-                            adminId, dispatchId, mockFile, "8월");
+                            adminId, dispatchId, mockFile, "8월", Company.AWESOME);
 
             // then
             assertThat(result.getSuccessCount()).isGreaterThan(0);
@@ -605,6 +613,7 @@ public class AnnualLeaveServiceTest {
                             .sheetName("2026-06")
                             .fileKey("annual-leave/2026-06-first.xlsx")
                             .createdAt(LocalDateTime.of(2026, 5, 31, 15, 29, 4))
+                            .company(Company.AWESOME)
                             .build();
 
             given(annualLeaveDispatchHistoryRepository.findById(10L))
@@ -622,6 +631,8 @@ public class AnnualLeaveServiceTest {
             assertThat(result.getSheetName()).isEqualTo("2026-06");
             assertThat(result.getFileUrl())
                     .isEqualTo("https://example.com/annual-leave-2026-06-first");
+            assertThat(result.getTitle()).isEqualTo("6월");
+            assertThat(result.getCompany()).isEqualTo(Company.AWESOME);
         }
     }
 
@@ -733,6 +744,53 @@ public class AnnualLeaveServiceTest {
                 assertThat(history.getBaseDate()).isNull();
             }
         }
+
+        @Nested
+        @DisplayName("company 필드는")
+        class Context_with_company {
+
+            @Test
+            @DisplayName("company 값을 포함하여 빌더로 생성하면 getCompany()가 해당 값을 반환한다")
+            void it_stores_company() {
+                // given
+                User admin = User.builder().id(1L).nameKor("테스트 업로더").build();
+
+                // when
+                AnnualLeaveDispatchHistory history =
+                        AnnualLeaveDispatchHistory.builder()
+                                .id(20L)
+                                .uploadedBy(admin)
+                                .originalFileName("2026_연차현황.xlsx")
+                                .sheetName("2026-06")
+                                .fileKey("annual-leave/2026-06.xlsx")
+                                .baseDate(LocalDate.of(2026, 6, 1))
+                                .company(Company.AWESOME)
+                                .build();
+
+                // then
+                assertThat(history.getCompany()).isEqualTo(Company.AWESOME);
+            }
+
+            @Test
+            @DisplayName("company 없이 빌더로 생성하면 null을 반환한다")
+            void it_returns_null_when_company_not_set() {
+                // given
+                User admin = User.builder().id(1L).nameKor("테스트 업로더").build();
+
+                // when
+                AnnualLeaveDispatchHistory history =
+                        AnnualLeaveDispatchHistory.builder()
+                                .id(21L)
+                                .uploadedBy(admin)
+                                .originalFileName("legacy_2025.xlsx")
+                                .sheetName("2025-12")
+                                .fileKey("annual-leave/legacy.xlsx")
+                                .build();
+
+                // then
+                assertThat(history.getCompany()).isNull();
+            }
+        }
     }
 
     @Nested
@@ -776,6 +834,27 @@ public class AnnualLeaveServiceTest {
                 assertThat(code.getMessage()).isEqualTo("시트명의 월 정보와 엑셀 기준일의 월 정보가 일치하지 않습니다.");
             }
         }
+
+        @Nested
+        @DisplayName("ANNUAL_LEAVE_COMPANY_MISMATCH 상수가")
+        class Context_ANNUAL_LEAVE_COMPANY_MISMATCH {
+
+            @Test
+            @DisplayName("정의되어 있어야 하고 HttpStatus.BAD_REQUEST와 지정된 메시지를 가진다")
+            void it_has_correct_status_and_message() {
+                // given & when
+                kr.co.awesomelead.groupware_backend.global.error.ErrorCode code =
+                        kr.co.awesomelead.groupware_backend.global.error.ErrorCode.valueOf(
+                                "ANNUAL_LEAVE_COMPANY_MISMATCH");
+
+                // then
+                assertThat(code.getHttpStatus())
+                        .isEqualTo(org.springframework.http.HttpStatus.BAD_REQUEST);
+                assertThat(code.getMessage())
+                        .isEqualTo(
+                                "업로드 요청한 회사 정보와 엑셀 데이터 내 직원의 소속 회사가 일치하지 않습니다.");
+            }
+        }
     }
 
     @Nested
@@ -796,18 +875,21 @@ public class AnnualLeaveServiceTest {
                 User admin = createMockUser(Authority.EDIT_EMPLOYEE_INFO);
                 given(userRepository.findById(loginUserId)).willReturn(Optional.of(admin));
 
-                LocalDate start = LocalDate.of(2026, 6, 1);
-                LocalDate end = LocalDate.of(2026, 6, 30);
-                given(annualLeaveDispatchHistoryRepository.existsByBaseDateBetween(start, end))
+                // 엑셀 파일의 baseDate는 2026-08-01이므로 중복 체크는 8월 기준으로 수행
+                LocalDate start = LocalDate.of(2026, 8, 1);
+                LocalDate end = LocalDate.of(2026, 8, 31);
+                given(annualLeaveDispatchHistoryRepository.existsByCompanyAndBaseDateBetween(
+                                Company.AWESOME, start, end))
                         .willReturn(true);
 
                 MultipartFile mockFile = createMockExcelFile();
+                given(s3Service.uploadFile(mockFile)).willReturn("annual-leave/history.xlsx");
 
                 // when & then
                 assertThatThrownBy(
                                 () ->
                                         annualLeaveService.uploadAnnualLeaveFile(
-                                                mockFile, sheetName, loginUserId))
+                                                mockFile, sheetName, loginUserId, Company.AWESOME))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining("이미 해당 월에 연차가 발송되었습니다.");
             }
@@ -824,9 +906,11 @@ public class AnnualLeaveServiceTest {
                 User admin = createMockUser(Authority.EDIT_EMPLOYEE_INFO);
                 given(userRepository.findById(loginUserId)).willReturn(Optional.of(admin));
 
-                LocalDate start = LocalDate.of(2026, 6, 1);
-                LocalDate end = LocalDate.of(2026, 6, 30);
-                given(annualLeaveDispatchHistoryRepository.existsByBaseDateBetween(start, end))
+                // 엑셀 파일의 baseDate는 2026-08-01이므로 중복 체크는 8월 기준으로 수행
+                LocalDate start = LocalDate.of(2026, 8, 1);
+                LocalDate end = LocalDate.of(2026, 8, 31);
+                given(annualLeaveDispatchHistoryRepository.existsByCompanyAndBaseDateBetween(
+                                Company.AWESOME, start, end))
                         .willReturn(false);
 
                 MultipartFile mockFile = createMockExcelFile();
@@ -842,7 +926,8 @@ public class AnnualLeaveServiceTest {
 
                 // when
                 ExcelUploadResponseDto response =
-                        annualLeaveService.uploadAnnualLeaveFile(mockFile, sheetName, loginUserId);
+                        annualLeaveService.uploadAnnualLeaveFile(
+                                mockFile, sheetName, loginUserId, Company.AWESOME);
 
                 // then
                 assertThat(response.getSuccessCount()).isGreaterThan(0);
@@ -873,7 +958,7 @@ public class AnnualLeaveServiceTest {
                 assertThatThrownBy(
                                 () ->
                                         annualLeaveService.uploadAnnualLeaveFile(
-                                                mockFile, "5월", loginUserId))
+                                                mockFile, "5월", loginUserId, Company.AWESOME))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining("시트명의 월 정보와 엑셀 기준일의 월 정보가 일치하지 않습니다.");
             }
@@ -924,7 +1009,8 @@ public class AnnualLeaveServiceTest {
 
                 // when
                 ExcelUploadResponseDto response =
-                        annualLeaveService.uploadAnnualLeaveFile(mockFile, sheetName, loginUserId);
+                        annualLeaveService.uploadAnnualLeaveFile(
+                                mockFile, sheetName, loginUserId, Company.AWESOME);
 
                 // then: 기존 연차가 더 최신이므로 save와 알림 전송이 호출되지 않아야 한다
                 org.mockito.Mockito.verify(annualLeaveRepository, org.mockito.Mockito.never())
@@ -967,20 +1053,24 @@ public class AnnualLeaveServiceTest {
                 given(annualLeaveDispatchHistoryRepository.findById(dispatchId))
                         .willReturn(Optional.of(history));
 
-                LocalDate start = LocalDate.of(2026, 6, 1);
-                LocalDate end = LocalDate.of(2026, 6, 30);
+                // 엑셀 파일의 baseDate는 2026-08-01이므로 중복 체크는 8월 기준으로 수행
+                LocalDate start = LocalDate.of(2026, 8, 1);
+                LocalDate end = LocalDate.of(2026, 8, 31);
                 given(
                                 annualLeaveDispatchHistoryRepository
-                                        .existsByIdNotAndBaseDateBetween(dispatchId, start, end))
+                                        .existsByIdNotAndCompanyAndBaseDateBetween(
+                                                dispatchId, Company.AWESOME, start, end))
                         .willReturn(true);
 
                 MultipartFile mockFile = createMockExcelFile();
+                given(s3Service.uploadFile(mockFile)).willReturn("annual-leave/history.xlsx");
 
                 // when & then
                 assertThatThrownBy(
                                 () ->
                                         annualLeaveService.updateAnnualLeaveDispatchForAdmin(
-                                                adminId, dispatchId, mockFile, sheetName))
+                                                adminId, dispatchId, mockFile, sheetName,
+                                                Company.AWESOME))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining("이미 해당 월에 연차가 발송되었습니다.");
             }
@@ -1009,11 +1099,13 @@ public class AnnualLeaveServiceTest {
                 given(annualLeaveDispatchHistoryRepository.findById(dispatchId))
                         .willReturn(Optional.of(history));
 
-                LocalDate start = LocalDate.of(2026, 6, 1);
-                LocalDate end = LocalDate.of(2026, 6, 30);
+                // 엑셀 파일의 baseDate는 2026-08-01이므로 중복 체크는 8월 기준으로 수행
+                LocalDate start = LocalDate.of(2026, 8, 1);
+                LocalDate end = LocalDate.of(2026, 8, 31);
                 given(
                                 annualLeaveDispatchHistoryRepository
-                                        .existsByIdNotAndBaseDateBetween(dispatchId, start, end))
+                                        .existsByIdNotAndCompanyAndBaseDateBetween(
+                                                dispatchId, Company.AWESOME, start, end))
                         .willReturn(false);
 
                 MultipartFile mockFile = createMockExcelFile();
@@ -1030,10 +1122,246 @@ public class AnnualLeaveServiceTest {
                 // when
                 ExcelUploadResponseDto result =
                         annualLeaveService.updateAnnualLeaveDispatchForAdmin(
-                                adminId, dispatchId, mockFile, sheetName);
+                                adminId, dispatchId, mockFile, sheetName, Company.AWESOME);
 
                 // then
                 assertThat(result.getSuccessCount()).isGreaterThan(0);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("AnnualLeaveDispatchHistoryRepository는")
+    class Describe_AnnualLeaveDispatchHistoryRepository {
+
+        @Nested
+        @DisplayName("company 기반 쿼리 메서드가")
+        class Context_company_based_methods {
+
+            @Test
+            @DisplayName("findAllByCompanyOrderByCreatedAtDesc 메서드가 컴파일 레벨에서 호출 가능하다")
+            void findAllByCompanyOrderByCreatedAtDesc_methodExists() {
+                // given & when
+                java.util.List<AnnualLeaveDispatchHistory> result =
+                        annualLeaveDispatchHistoryRepository
+                                .findAllByCompanyOrderByCreatedAtDesc(Company.AWESOME);
+
+                // then: mock 기본값은 빈 리스트 — 메서드 존재 자체를 컴파일 레벨에서 검증
+                assertThat(result).isNotNull();
+            }
+
+            @Test
+            @DisplayName("existsByCompanyAndBaseDateBetween 메서드가 컴파일 레벨에서 호출 가능하다")
+            void existsByCompanyAndBaseDateBetween_methodExists() {
+                // given
+                LocalDate start = LocalDate.of(2026, 6, 1);
+                LocalDate end = LocalDate.of(2026, 6, 30);
+
+                // when
+                boolean result =
+                        annualLeaveDispatchHistoryRepository.existsByCompanyAndBaseDateBetween(
+                                Company.AWESOME, start, end);
+
+                // then: mock 기본값은 false — 메서드 존재 자체를 컴파일 레벨에서 검증
+                assertThat(result).isFalse();
+            }
+
+            @Test
+            @DisplayName("existsByIdNotAndCompanyAndBaseDateBetween 메서드가 컴파일 레벨에서 호출 가능하다")
+            void existsByIdNotAndCompanyAndBaseDateBetween_methodExists() {
+                // given
+                LocalDate start = LocalDate.of(2026, 6, 1);
+                LocalDate end = LocalDate.of(2026, 6, 30);
+
+                // when
+                boolean result =
+                        annualLeaveDispatchHistoryRepository
+                                .existsByIdNotAndCompanyAndBaseDateBetween(
+                                        10L, Company.AWESOME, start, end);
+
+                // then: mock 기본값은 false — 메서드 존재 자체를 컴파일 레벨에서 검증
+                assertThat(result).isFalse();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("AdminAnnualLeaveDispatchDetailResponseDto는")
+    class Describe_AdminAnnualLeaveDispatchDetailResponseDto {
+
+        @Nested
+        @DisplayName("title과 company 필드를 포함하여 빌더로 생성하면")
+        class Context_with_title_and_company {
+
+            @Test
+            @DisplayName("각각 올바른 값을 반환한다")
+            void it_returns_title_and_company() {
+                // given
+                String expectedTitle = "7월";
+                Company expectedCompany = Company.AWESOME;
+
+                // when
+                AdminAnnualLeaveDispatchDetailResponseDto dto =
+                        AdminAnnualLeaveDispatchDetailResponseDto.builder()
+                                .dispatchId(10L)
+                                .originalFileName("2026_연차현황.xlsx")
+                                .sheetName("2026-07")
+                                .title(expectedTitle)
+                                .company(expectedCompany)
+                                .build();
+
+                // then
+                assertThat(dto.getTitle()).isEqualTo(expectedTitle);
+                assertThat(dto.getCompany()).isEqualTo(expectedCompany);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("AdminAnnualLeaveDispatchItemResponseDto는")
+    class Describe_AdminAnnualLeaveDispatchItemResponseDto {
+
+        @Nested
+        @DisplayName("company 필드를 포함하여 빌더로 생성하면")
+        class Context_with_company {
+
+            @Test
+            @DisplayName("올바른 값을 반환한다")
+            void it_returns_company() {
+                // given
+                Company expectedCompany = Company.AWESOME;
+
+                // when
+                AdminAnnualLeaveDispatchItemResponseDto dto =
+                        AdminAnnualLeaveDispatchItemResponseDto.builder()
+                                .dispatchId(10L)
+                                .title("7월")
+                                .originalFileName("2026_연차현황.xlsx")
+                                .sheetName("2026-07")
+                                .company(expectedCompany)
+                                .build();
+
+                // then
+                assertThat(dto.getCompany()).isEqualTo(expectedCompany);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("uploadAnnualLeaveFile Company별 중복 발송 체크는")
+    class Describe_uploadAnnualLeaveFile_company_duplicate_check {
+
+        private final Long loginUserId = 1L;
+        private final String sheetName = "2026-06";
+
+        @Nested
+        @DisplayName("같은 Company + 같은 월에 이미 이력이 존재하면")
+        class Context_when_same_company_same_month_exists {
+
+            @Test
+            @DisplayName("DUPLICATE_ANNUAL_LEAVE_DISPATCH 예외를 던진다")
+            void uploadAnnualLeaveFile_throwsWhenSameCompanySameMonthExists() throws IOException {
+                // given
+                User admin = createMockUser(Authority.EDIT_EMPLOYEE_INFO);
+                given(userRepository.findById(loginUserId)).willReturn(Optional.of(admin));
+
+                // 엑셀 파일의 baseDate는 2026-08-01이므로 중복 체크는 8월 기준으로 수행
+                LocalDate start = LocalDate.of(2026, 8, 1);
+                LocalDate end = LocalDate.of(2026, 8, 31);
+                given(annualLeaveDispatchHistoryRepository.existsByCompanyAndBaseDateBetween(
+                                Company.MARUI, start, end))
+                        .willReturn(true);
+
+                MultipartFile mockFile = createMockExcelFile();
+                given(s3Service.uploadFile(mockFile)).willReturn("annual-leave/history.xlsx");
+
+                // when & then
+                assertThatThrownBy(
+                                () ->
+                                        annualLeaveService.uploadAnnualLeaveFile(
+                                                mockFile, sheetName, loginUserId, Company.MARUI))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessageContaining("이미 해당 월에 연차가 발송되었습니다.");
+            }
+        }
+
+        @Nested
+        @DisplayName("다른 Company + 같은 월에 이력이 존재해도")
+        class Context_when_different_company_same_month {
+
+            @Test
+            @DisplayName("중복으로 보지 않고 정상 처리된다")
+            void uploadAnnualLeaveFile_succeedsWhenDifferentCompanySameMonth() throws IOException {
+                // given: MARUI 6월 이력 있음 → AWESOME 8월은 중복 아님 (엑셀 baseDate 기준)
+                User admin = createMockUser(Authority.EDIT_EMPLOYEE_INFO);
+                given(userRepository.findById(loginUserId)).willReturn(Optional.of(admin));
+
+                // 엑셀 파일의 baseDate는 2026-08-01이므로 중복 체크는 8월 기준으로 수행
+                LocalDate start = LocalDate.of(2026, 8, 1);
+                LocalDate end = LocalDate.of(2026, 8, 31);
+                given(annualLeaveDispatchHistoryRepository.existsByCompanyAndBaseDateBetween(
+                                Company.AWESOME, start, end))
+                        .willReturn(false);
+
+                MultipartFile mockFile = createMockExcelFile();
+                User targetUser =
+                        User.builder()
+                                .nameKor("테스트 유저")
+                                .hireDate(LocalDate.of(2025, 12, 31))
+                                .workLocation(Company.AWESOME)
+                                .build();
+                given(userRepository.findByNameAndJoinDate(anyString(), any()))
+                        .willReturn(Optional.of(targetUser));
+                given(annualLeaveRepository.findByUser(targetUser)).willReturn(Optional.empty());
+                given(s3Service.uploadFile(mockFile)).willReturn("annual-leave/2026-06.xlsx");
+
+                // when
+                ExcelUploadResponseDto response =
+                        annualLeaveService.uploadAnnualLeaveFile(
+                                mockFile, sheetName, loginUserId, Company.AWESOME);
+
+                // then
+                assertThat(response.getSuccessCount()).isGreaterThan(0);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("uploadAnnualLeaveFile Company 불일치 검증은")
+    class Describe_uploadAnnualLeaveFile_company_mismatch {
+
+        private final Long loginUserId = 1L;
+        private final String sheetName = "8월";
+
+        @Nested
+        @DisplayName("엑셀 직원의 workLocation이 요청 Company와 다르면")
+        class Context_when_user_work_location_differs_from_requested_company {
+
+            @Test
+            @DisplayName("ANNUAL_LEAVE_COMPANY_MISMATCH 예외를 던지고 전체 롤백한다")
+            void uploadAnnualLeaveFile_throwsWhenCompanyMismatch() throws IOException {
+                // given: 요청은 AWESOME이지만 엑셀 직원의 workLocation은 MARUI
+                User admin = createMockUser(Authority.EDIT_EMPLOYEE_INFO);
+                given(userRepository.findById(loginUserId)).willReturn(Optional.of(admin));
+
+                MultipartFile mockFile = createMockExcelFile();
+
+                User targetUser =
+                        User.builder()
+                                .nameKor("테스트 유저")
+                                .hireDate(LocalDate.of(2025, 12, 31))
+                                .workLocation(Company.MARUI)
+                                .build();
+                given(userRepository.findByNameAndJoinDate(anyString(), any()))
+                        .willReturn(Optional.of(targetUser));
+
+                // when & then
+                assertThatThrownBy(
+                                () ->
+                                        annualLeaveService.uploadAnnualLeaveFile(
+                                                mockFile, sheetName, loginUserId, Company.AWESOME))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessageContaining("업로드 요청한 회사 정보와 엑셀 데이터 내 직원의 소속 회사가 일치하지 않습니다.");
             }
         }
     }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
@@ -9,9 +9,8 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AdminAnnualLeaveDispatchDetailResponseDto;
-import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AdminAnnualLeaveDispatchItemResponseDto;
-import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AdminAnnualLeaveDispatchGroupResponseDto;
+import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AdminAnnualLeaveDispatchItemResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.AnnualLeaveResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.dto.response.ExcelUploadResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.entity.AnnualLeave;
@@ -20,6 +19,7 @@ import kr.co.awesomelead.groupware_backend.domain.annualleave.mapper.AnnualLeave
 import kr.co.awesomelead.groupware_backend.domain.annualleave.repository.AnnualLeaveDispatchHistoryRepository;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.repository.AnnualLeaveRepository;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.service.AnnualLeaveService;
+import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Authority;
@@ -142,7 +142,10 @@ public class AnnualLeaveServiceTest {
                 assertThatThrownBy(
                                 () ->
                                         annualLeaveService.uploadAnnualLeaveFile(
-                                                invalidFile, sheetName, loginUserId, Company.AWESOME))
+                                                invalidFile,
+                                                sheetName,
+                                                loginUserId,
+                                                Company.AWESOME))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(
                                 "유효하지 않은 기준일자 형식입니다. (yyyy-MM-dd)"); // ErrorCode 메시지에 따라 수정
@@ -851,8 +854,7 @@ public class AnnualLeaveServiceTest {
                 assertThat(code.getHttpStatus())
                         .isEqualTo(org.springframework.http.HttpStatus.BAD_REQUEST);
                 assertThat(code.getMessage())
-                        .isEqualTo(
-                                "업로드 요청한 회사 정보와 엑셀 데이터 내 직원의 소속 회사가 일치하지 않습니다.");
+                        .isEqualTo("업로드 요청한 회사 정보와 엑셀 데이터 내 직원의 소속 회사가 일치하지 않습니다.");
             }
         }
     }
@@ -878,8 +880,10 @@ public class AnnualLeaveServiceTest {
                 // 엑셀 파일의 baseDate는 2026-08-01이므로 중복 체크는 8월 기준으로 수행
                 LocalDate start = LocalDate.of(2026, 8, 1);
                 LocalDate end = LocalDate.of(2026, 8, 31);
-                given(annualLeaveDispatchHistoryRepository.existsByCompanyAndBaseDateBetween(
-                                Company.AWESOME, start, end))
+                given(
+                                annualLeaveDispatchHistoryRepository
+                                        .existsByCompanyAndBaseDateBetween(
+                                                Company.AWESOME, start, end))
                         .willReturn(true);
 
                 MultipartFile mockFile = createMockExcelFile();
@@ -909,8 +913,10 @@ public class AnnualLeaveServiceTest {
                 // 엑셀 파일의 baseDate는 2026-08-01이므로 중복 체크는 8월 기준으로 수행
                 LocalDate start = LocalDate.of(2026, 8, 1);
                 LocalDate end = LocalDate.of(2026, 8, 31);
-                given(annualLeaveDispatchHistoryRepository.existsByCompanyAndBaseDateBetween(
-                                Company.AWESOME, start, end))
+                given(
+                                annualLeaveDispatchHistoryRepository
+                                        .existsByCompanyAndBaseDateBetween(
+                                                Company.AWESOME, start, end))
                         .willReturn(false);
 
                 MultipartFile mockFile = createMockExcelFile();
@@ -1069,7 +1075,10 @@ public class AnnualLeaveServiceTest {
                 assertThatThrownBy(
                                 () ->
                                         annualLeaveService.updateAnnualLeaveDispatchForAdmin(
-                                                adminId, dispatchId, mockFile, sheetName,
+                                                adminId,
+                                                dispatchId,
+                                                mockFile,
+                                                sheetName,
                                                 Company.AWESOME))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining("이미 해당 월에 연차가 발송되었습니다.");
@@ -1143,8 +1152,8 @@ public class AnnualLeaveServiceTest {
             void findAllByCompanyOrderByCreatedAtDesc_methodExists() {
                 // given & when
                 java.util.List<AnnualLeaveDispatchHistory> result =
-                        annualLeaveDispatchHistoryRepository
-                                .findAllByCompanyOrderByCreatedAtDesc(Company.AWESOME);
+                        annualLeaveDispatchHistoryRepository.findAllByCompanyOrderByCreatedAtDesc(
+                                Company.AWESOME);
 
                 // then: mock 기본값은 빈 리스트 — 메서드 존재 자체를 컴파일 레벨에서 검증
                 assertThat(result).isNotNull();
@@ -1268,8 +1277,10 @@ public class AnnualLeaveServiceTest {
                 // 엑셀 파일의 baseDate는 2026-08-01이므로 중복 체크는 8월 기준으로 수행
                 LocalDate start = LocalDate.of(2026, 8, 1);
                 LocalDate end = LocalDate.of(2026, 8, 31);
-                given(annualLeaveDispatchHistoryRepository.existsByCompanyAndBaseDateBetween(
-                                Company.MARUI, start, end))
+                given(
+                                annualLeaveDispatchHistoryRepository
+                                        .existsByCompanyAndBaseDateBetween(
+                                                Company.MARUI, start, end))
                         .willReturn(true);
 
                 MultipartFile mockFile = createMockExcelFile();
@@ -1299,8 +1310,10 @@ public class AnnualLeaveServiceTest {
                 // 엑셀 파일의 baseDate는 2026-08-01이므로 중복 체크는 8월 기준으로 수행
                 LocalDate start = LocalDate.of(2026, 8, 1);
                 LocalDate end = LocalDate.of(2026, 8, 31);
-                given(annualLeaveDispatchHistoryRepository.existsByCompanyAndBaseDateBetween(
-                                Company.AWESOME, start, end))
+                given(
+                                annualLeaveDispatchHistoryRepository
+                                        .existsByCompanyAndBaseDateBetween(
+                                                Company.AWESOME, start, end))
                         .willReturn(false);
 
                 MultipartFile mockFile = createMockExcelFile();


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #433

## 📝작업 내용

- `AnnualLeaveDispatchHistory` 엔티티에 `company` 필드 추가 및 불변 구조 적용
  - `@Setter` 제거, `@NoArgsConstructor(access = AccessLevel.PROTECTED)`, `updateDispatch(...)` 도메인 메서드 추가
- `AnnualLeaveDispatchHistoryRepository`에 Company 기반 조회/존재 검사 메서드 3개 추가
  - JPQL `:company IS NULL OR h.company = :company` 패턴으로 company=null 시 전체 조회 지원
- 연차 업로드/조회 Service 비즈니스 로직을 Company 기준으로 전환
  - `processAnnualLeaveRow`에 Company 불일치 검증 추가 → `ANNUAL_LEAVE_COMPANY_MISMATCH` 예외로 전체 롤백 보장
  - 중복 검사를 Company 기준으로 전환 (`existsByCompanyAndBaseDateBetween` 등)
  - `rebuildAnnualLeavesFromDispatchHistories`에서 Company 전달로 재계산 시 정합성 유지
- Controller 3개 엔드포인트에 `@RequestParam company` 파라미터 추가
- Response DTO 불변 구조 적용 (`@Builder` 방식, `@NoArgsConstructor`/`@AllArgsConstructor` 제거)
- `AnnualLeaveController` 7개 메서드에 Swagger `@ApiResponses` 명세 추가
- `parseYearMonthFromSheetName` 제거 — baseDate 기준 중복 체크로 이동하여 현재 연도 강제 매핑 취약점 해소

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)

- X