### PR TITLE
feat(443): 회사별 당월 연차 발송 여부 조회 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ src/main/resources/firebase/serviceAccountKey.json
 **/generated/
 build/
 out/
+
+# Claude Code
+CLAUDE.md

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/controller/AnnualLeaveController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/controller/AnnualLeaveController.java
@@ -32,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/annualleaves")
@@ -194,5 +195,27 @@ public class AnnualLeaveController {
             @PathVariable Long dispatchId, @AuthenticationPrincipal CustomUserDetails userDetails) {
         annualLeaveService.deleteAnnualLeaveDispatchForAdmin(userDetails.getId(), dispatchId);
         return ResponseEntity.ok(ApiResponse.onNoContent("연차 발송 이력이 성공적으로 삭제되었습니다."));
+    }
+
+    @Operation(summary = "회사별 당월 연차 발송 현황 조회", description = "당월 회사별 연차 발송 여부를 조회합니다. EDIT_EMPLOYEE_INFO 권한 필요.")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "조회 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        schema =
+                                                @Schema(
+                                                        example =
+                                                                "{\"isSuccess\":true,\"code\":\"COMMON200\",\"message\":\"요청에 성공하였습니다.\",\"result\":{\"어썸리드\":true,\"한국마루이\":false}}")))
+            })
+    @GetMapping("/admin/dispatch-status")
+    public ResponseEntity<ApiResponse<Map<String, Boolean>>> getMonthlyDispatchStatus(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Map<String, Boolean> result =
+                annualLeaveService.getMonthlyDispatchStatus(userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/controller/AnnualLeaveController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/controller/AnnualLeaveController.java
@@ -197,7 +197,9 @@ public class AnnualLeaveController {
         return ResponseEntity.ok(ApiResponse.onNoContent("연차 발송 이력이 성공적으로 삭제되었습니다."));
     }
 
-    @Operation(summary = "회사별 당월 연차 발송 현황 조회", description = "당월 회사별 연차 발송 여부를 조회합니다. EDIT_EMPLOYEE_INFO 권한 필요.")
+    @Operation(
+            summary = "회사별 당월 연차 발송 현황 조회",
+            description = "당월 회사별 연차 발송 여부를 조회합니다. EDIT_EMPLOYEE_INFO 권한 필요.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -209,7 +211,8 @@ public class AnnualLeaveController {
                                         schema =
                                                 @Schema(
                                                         example =
-                                                                "{\"isSuccess\":true,\"code\":\"COMMON200\",\"message\":\"요청에 성공하였습니다.\",\"result\":{\"어썸리드\":true,\"한국마루이\":false}}")))
+                                                                "{\"isSuccess\":true,\"code\":\"COMMON200\",\"message\":\"요청에"
+                                                                    + " 성공하였습니다.\",\"result\":{\"어썸리드\":true,\"한국마루이\":false}}")))
             })
     @GetMapping("/admin/dispatch-status")
     public ResponseEntity<ApiResponse<Map<String, Boolean>>> getMonthlyDispatchStatus(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
@@ -516,8 +516,9 @@ public class AnnualLeaveService {
 
         Map<String, Boolean> result = new LinkedHashMap<>();
         for (Company company : Company.values()) {
-            boolean dispatched = annualLeaveDispatchHistoryRepository
-                    .existsByCompanyAndBaseDateBetween(company, start, end);
+            boolean dispatched =
+                    annualLeaveDispatchHistoryRepository.existsByCompanyAndBaseDateBetween(
+                            company, start, end);
             result.put(company.getDescription(), dispatched);
         }
         return result;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -505,6 +506,21 @@ public class AnnualLeaveService {
                 .title(resolveDispatchMonthTitle(history))
                 .company(history.getCompany())
                 .build();
+    }
+
+    public Map<String, Boolean> getMonthlyDispatchStatus(Long userId) {
+        validateAnnualLeaveEditAuthority(userId);
+        LocalDate now = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        LocalDate start = now.withDayOfMonth(1);
+        LocalDate end = now.withDayOfMonth(now.lengthOfMonth());
+
+        Map<String, Boolean> result = new LinkedHashMap<>();
+        for (Company company : Company.values()) {
+            boolean dispatched = annualLeaveDispatchHistoryRepository
+                    .existsByCompanyAndBaseDateBetween(company, start, end);
+            result.put(company.getDescription(), dispatched);
+        }
+        return result;
     }
 
     private User validateAnnualLeaveEditAuthority(Long userId) {

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
@@ -25,6 +25,7 @@ import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Authority;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
 import kr.co.awesomelead.groupware_backend.global.error.CustomException;
+import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
 import kr.co.awesomelead.groupware_backend.global.infra.s3.service.S3Service;
 
 import org.junit.jupiter.api.DisplayName;
@@ -1375,6 +1376,72 @@ public class AnnualLeaveServiceTest {
                                                 mockFile, sheetName, loginUserId, Company.AWESOME))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining("업로드 요청한 회사 정보와 엑셀 데이터 내 직원의 소속 회사가 일치하지 않습니다.");
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getMonthlyDispatchStatus 메서드는")
+    class Describe_getMonthlyDispatchStatus {
+
+        private final Long loginUserId = 1L;
+
+        @Nested
+        @DisplayName("권한이 있는 관리자가 요청하면")
+        class Context_with_authority {
+
+            @Test
+            @DisplayName("각 회사별 당월 발송 이력 존재 여부를 Map으로 반환한다")
+            void getMonthlyDispatchStatus_success() {
+                // given
+                User admin = createMockUser(Authority.EDIT_EMPLOYEE_INFO);
+                given(userRepository.findById(loginUserId)).willReturn(Optional.of(admin));
+
+                given(annualLeaveDispatchHistoryRepository.existsByCompanyAndBaseDateBetween(
+                                org.mockito.ArgumentMatchers.eq(Company.AWESOME),
+                                any(LocalDate.class),
+                                any(LocalDate.class)))
+                        .willReturn(true);
+                given(annualLeaveDispatchHistoryRepository.existsByCompanyAndBaseDateBetween(
+                                org.mockito.ArgumentMatchers.eq(Company.MARUI),
+                                any(LocalDate.class),
+                                any(LocalDate.class)))
+                        .willReturn(false);
+
+                // when
+                java.util.Map<String, Boolean> result =
+                        annualLeaveService.getMonthlyDispatchStatus(loginUserId);
+
+                // then
+                assertThat(result).isNotNull();
+                assertThat(result.get("어썸리드")).isEqualTo(true);
+                assertThat(result.get("한국마루이")).isEqualTo(false);
+
+                // 키 순서가 Company.values() 순서(AWESOME → MARUI)와 일치하는지 검증
+                java.util.List<String> keys = new java.util.ArrayList<>(result.keySet());
+                assertThat(keys.get(0)).isEqualTo("어썸리드");
+                assertThat(keys.get(1)).isEqualTo("한국마루이");
+            }
+        }
+
+        @Nested
+        @DisplayName("권한이 없는 사용자가 요청하면")
+        class Context_without_authority {
+
+            @Test
+            @DisplayName("NO_AUTHORITY_FOR_ANNUAL_LEAVE 예외를 던진다")
+            void getMonthlyDispatchStatus_throwsWhenNoAuthority() {
+                // given
+                User userWithoutAuth = createMockUser(null);
+                given(userRepository.findById(loginUserId))
+                        .willReturn(Optional.of(userWithoutAuth));
+
+                // when & then
+                assertThatThrownBy(
+                                () -> annualLeaveService.getMonthlyDispatchStatus(loginUserId))
+                        .isInstanceOf(CustomException.class)
+                        .extracting("errorCode")
+                        .isEqualTo(ErrorCode.NO_AUTHORITY_FOR_ANNUAL_LEAVE);
             }
         }
     }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
@@ -1397,15 +1397,19 @@ public class AnnualLeaveServiceTest {
                 User admin = createMockUser(Authority.EDIT_EMPLOYEE_INFO);
                 given(userRepository.findById(loginUserId)).willReturn(Optional.of(admin));
 
-                given(annualLeaveDispatchHistoryRepository.existsByCompanyAndBaseDateBetween(
-                                org.mockito.ArgumentMatchers.eq(Company.AWESOME),
-                                any(LocalDate.class),
-                                any(LocalDate.class)))
+                given(
+                                annualLeaveDispatchHistoryRepository
+                                        .existsByCompanyAndBaseDateBetween(
+                                                org.mockito.ArgumentMatchers.eq(Company.AWESOME),
+                                                any(LocalDate.class),
+                                                any(LocalDate.class)))
                         .willReturn(true);
-                given(annualLeaveDispatchHistoryRepository.existsByCompanyAndBaseDateBetween(
-                                org.mockito.ArgumentMatchers.eq(Company.MARUI),
-                                any(LocalDate.class),
-                                any(LocalDate.class)))
+                given(
+                                annualLeaveDispatchHistoryRepository
+                                        .existsByCompanyAndBaseDateBetween(
+                                                org.mockito.ArgumentMatchers.eq(Company.MARUI),
+                                                any(LocalDate.class),
+                                                any(LocalDate.class)))
                         .willReturn(false);
 
                 // when
@@ -1437,8 +1441,7 @@ public class AnnualLeaveServiceTest {
                         .willReturn(Optional.of(userWithoutAuth));
 
                 // when & then
-                assertThatThrownBy(
-                                () -> annualLeaveService.getMonthlyDispatchStatus(loginUserId))
+                assertThatThrownBy(() -> annualLeaveService.getMonthlyDispatchStatus(loginUserId))
                         .isInstanceOf(CustomException.class)
                         .extracting("errorCode")
                         .isEqualTo(ErrorCode.NO_AUTHORITY_FOR_ANNUAL_LEAVE);


### PR DESCRIPTION
## #️⃣연관된 이슈 번호

- #443

## 📝작업 내용

- `GET /api/annualleaves/admin/dispatch-status` 엔드포인트 추가
  - `EDIT_EMPLOYEE_INFO` 권한 보유 사용자만 호출 가능
  - 당월 1일~말일 범위로 회사별 발송 이력 존재 여부 조회
  - `LinkedHashMap`으로 순서 보장 (`{"어썸리드": true/false, "한국마루이": true/false}`)
- `AnnualLeaveService.getMonthlyDispatchStatus(Long userId)` 구현
  - `LocalDate.now(ZoneId.of("Asia/Seoul"))` 적용으로 타임존 안정성 확보
- Swagger `@ApiResponses`에 `@Content`/`@Schema(example)` 응답 예시 추가
- `AnnualLeaveServiceTest` 단위 테스트 추가 및 예외 검증 컨벤션 적용

## 🧪 테스트 여부

- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함