### PR TITLE
feat(448): 조직도 구조 및 회사별 조회 정책 개선

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/department/config/DepartmentDataInitializer.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/department/config/DepartmentDataInitializer.java
@@ -1,0 +1,78 @@
+package kr.co.awesomelead.groupware_backend.domain.department.config;
+
+import kr.co.awesomelead.groupware_backend.domain.department.entity.Department;
+import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
+import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
+import kr.co.awesomelead.groupware_backend.domain.department.repository.DepartmentRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class DepartmentDataInitializer implements ApplicationRunner {
+
+    private final DepartmentRepository departmentRepository;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        Department awesomeGroup = createOrUpdate(DepartmentName.AWESOME_GROUP, null, null);
+        Department root = createOrUpdate(DepartmentName.CHUNGNAM_HQ, null, awesomeGroup);
+
+        createOrUpdate(DepartmentName.MARUI_LAB, Company.MARUI, root);
+        createOrUpdate(DepartmentName.AWESOME_LAB, Company.AWESOME, root);
+        createOrUpdate(DepartmentName.SALES_DEPT, Company.AWESOME, root);
+
+        Department planning =
+                createOrUpdate(DepartmentName.CHUNGNAM_PLANNING, Company.AWESOME, root);
+        Department awesomeProduction =
+                createOrUpdate(DepartmentName.AWESOME_PROD_HQ, Company.AWESOME, root);
+        Department maruiProduction =
+                createOrUpdate(DepartmentName.MARUI_PROD_HQ, Company.MARUI, root);
+
+        createOrUpdate(DepartmentName.TECHNICAL_ADVISOR, Company.AWESOME, root);
+        createOrUpdate(DepartmentName.ENVIRONMENT_SAFETY, Company.AWESOME, root);
+        createOrUpdate(DepartmentName.QUALITY_CONTROL, Company.AWESOME, root);
+        createOrUpdate(DepartmentName.AWESOME_SECURITY_DEPT, Company.AWESOME, root);
+        createOrUpdate(DepartmentName.MARUI_SECURITY_DEPT, Company.MARUI, root);
+
+        createOrUpdate(DepartmentName.MANAGEMENT_SUPPORT, Company.AWESOME, planning);
+        createOrUpdate(DepartmentName.CHAMBER_PROD, Company.AWESOME, awesomeProduction);
+        createOrUpdate(DepartmentName.PARTS_PROD, Company.AWESOME, awesomeProduction);
+        createOrUpdate(DepartmentName.PRODUCTION, Company.MARUI, maruiProduction);
+    }
+
+    private Department createOrUpdate(DepartmentName name, Company company, Department parent) {
+        return departmentRepository
+                .findByName(name)
+                .map(department -> updateIfNeeded(department, company, parent))
+                .orElseGet(() -> create(name, company, parent));
+    }
+
+    private Department create(DepartmentName name, Company company, Department parent) {
+        return departmentRepository.save(
+                Department.builder().name(name).company(company).parent(parent).build());
+    }
+
+    private Department updateIfNeeded(Department department, Company company, Department parent) {
+        if (department.getCompany() != company) {
+            department.setCompany(company);
+        }
+        if (!isSameParent(department.getParent(), parent)) {
+            department.setParent(parent);
+        }
+        return department;
+    }
+
+    private boolean isSameParent(Department currentParent, Department targetParent) {
+        if (currentParent == null || targetParent == null) {
+            return currentParent == targetParent;
+        }
+        return currentParent.getId().equals(targetParent.getId());
+    }
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/department/controller/DepartmentController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/department/controller/DepartmentController.java
@@ -48,7 +48,7 @@ public class DepartmentController {
 
     private final DepartmentService departmentService;
 
-    @Operation(summary = "조직도 트리 조회", description = "충남사업본부 기준 부서 트리와 회사 전체 선택 옵션을 함께 조회합니다.")
+    @Operation(summary = "조직도 트리 조회", description = "어썸그룹 기준 부서 트리와 회사 전체 선택 옵션을 함께 조회합니다.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/department/enums/DepartmentName.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/department/enums/DepartmentName.java
@@ -12,9 +12,12 @@ import java.util.Arrays;
 public enum DepartmentName {
 
     // Level 0: 최상위 부서
+    AWESOME_GROUP("어썸그룹"),
+
+    // Level 1: 어썸그룹 하위
     CHUNGNAM_HQ("충남사업본부"),
 
-    // Level 1: 충남사업본부 하위
+    // Level 2: 충남사업본부 하위
     MARUI_LAB("(주)한국마루이 연구소"),
     AWESOME_LAB("(주)어썸리드 연구소"),
     SALES_DEPT("영업부"),
@@ -27,7 +30,7 @@ public enum DepartmentName {
     AWESOME_SECURITY_DEPT("어썸리드 경비"),
     MARUI_SECURITY_DEPT("마루이 경비"),
 
-    // Level 2: 하위 부서들
+    // Level 3: 하위 부서들
     MANAGEMENT_SUPPORT("경영지원부"),
     CHAMBER_PROD("챔버생산부"),
     PARTS_PROD("부품생산부"),

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/department/service/DepartmentService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/department/service/DepartmentService.java
@@ -50,7 +50,7 @@ public class DepartmentService {
 
         Department rootDepartment =
                 allRootDepartments.stream()
-                        .filter(department -> department.getName() == DepartmentName.CHUNGNAM_HQ)
+                        .filter(department -> department.getName() == DepartmentName.AWESOME_GROUP)
                         .findFirst()
                         .orElseGet(
                                 () ->

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/EduReportService.java
@@ -1412,13 +1412,20 @@ public class EduReportService {
 
         Department cursor = department.getParent();
         while (cursor != null) {
-            departmentIds.add(cursor.getId());
+            if (!isDepartmentNotificationRoot(cursor)) {
+                departmentIds.add(cursor.getId());
+            }
             cursor = cursor.getParent();
         }
 
         return userRepository.findAllByDepartmentIdIn(new ArrayList<>(departmentIds)).stream()
                 .map(User::getId)
                 .toList();
+    }
+
+    private boolean isDepartmentNotificationRoot(Department department) {
+        return department.getName() == DepartmentName.AWESOME_GROUP
+                || department.getName() == DepartmentName.CHUNGNAM_HQ;
     }
 
     private long calculateTargetPeopleCount(EduReport report) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/controller/AdminRequestHistoryController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/controller/AdminRequestHistoryController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 import jakarta.validation.Valid;
 
+import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.requesthistory.dto.request.RequestHistoryRejectRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.requesthistory.dto.response.AdminRequestHistoryDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.requesthistory.dto.response.AdminRequestHistorySummaryResponseDto;
@@ -98,6 +99,9 @@ public class AdminRequestHistoryController {
     @GetMapping
     public ResponseEntity<ApiResponse<Page<AdminRequestHistorySummaryResponseDto>>> getAllRequests(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(description = "회사 필터", required = false, example = "AWESOME")
+                    @RequestParam(required = false)
+                    Company company,
             @Parameter(
                             description = "상태 필터 (선택값: 발급 대기, 발급 완료, 반려, 취소)",
                             required = false,
@@ -106,7 +110,8 @@ public class AdminRequestHistoryController {
                     RequestHistoryStatus status,
             @ParameterObject @PageableDefault(page = 0, size = 20) Pageable pageable) {
         Page<AdminRequestHistorySummaryResponseDto> result =
-                requestHistoryService.getAllRequestsForAdmin(userDetails.getId(), status, pageable);
+                requestHistoryService.getAllRequestsForAdmin(
+                        userDetails.getId(), company, status, pageable);
         return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/repository/RequestHistoryQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/repository/RequestHistoryQueryRepository.java
@@ -2,9 +2,11 @@ package kr.co.awesomelead.groupware_backend.domain.requesthistory.repository;
 
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.requesthistory.entity.QRequestHistory;
 import kr.co.awesomelead.groupware_backend.domain.requesthistory.entity.RequestHistory;
 import kr.co.awesomelead.groupware_backend.domain.requesthistory.enums.RequestHistoryStatus;
@@ -28,7 +30,7 @@ public class RequestHistoryQueryRepository {
     private final JPAQueryFactory queryFactory;
 
     public Page<RequestHistory> findAllWithUserAndDepartmentByStatus(
-            RequestHistoryStatus status, Pageable pageable) {
+            Company company, RequestHistoryStatus status, Pageable pageable) {
 
         QRequestHistory rh = QRequestHistory.requestHistory;
         QUser user = QUser.user;
@@ -40,7 +42,7 @@ public class RequestHistoryQueryRepository {
                         .fetchJoin()
                         .leftJoin(user.department)
                         .fetchJoin()
-                        .where(status != null ? rh.approvalStatus.eq(status) : null)
+                        .where(statusFilter(rh, status), companyFilter(user, company))
                         .orderBy(orderSpecifiers(rh, pageable))
                         .offset(pageable.getOffset())
                         .limit(pageable.getPageSize())
@@ -54,10 +56,19 @@ public class RequestHistoryQueryRepository {
                             queryFactory
                                     .select(rh.count())
                                     .from(rh)
-                                    .where(status != null ? rh.approvalStatus.eq(status) : null)
+                                    .innerJoin(rh.user, user)
+                                    .where(statusFilter(rh, status), companyFilter(user, company))
                                     .fetchOne();
                     return count != null ? count : 0L;
                 });
+    }
+
+    private BooleanExpression statusFilter(QRequestHistory rh, RequestHistoryStatus status) {
+        return status != null ? rh.approvalStatus.eq(status) : null;
+    }
+
+    private BooleanExpression companyFilter(QUser user, Company company) {
+        return company != null ? user.workLocation.eq(company) : null;
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/service/RequestHistoryService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/service/RequestHistoryService.java
@@ -1,5 +1,6 @@
 package kr.co.awesomelead.groupware_backend.domain.requesthistory.service;
 
+import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationDomainType;
 import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationMessage;
 import kr.co.awesomelead.groupware_backend.domain.notification.repository.NotificationRepository;
@@ -144,7 +145,7 @@ public class RequestHistoryService {
 
     @Transactional(readOnly = true)
     public Page<AdminRequestHistorySummaryResponseDto> getAllRequestsForAdmin(
-            Long adminId, RequestHistoryStatus status, Pageable pageable) {
+            Long adminId, Company company, RequestHistoryStatus status, Pageable pageable) {
         User admin =
                 userRepository
                         .findById(adminId)
@@ -152,7 +153,7 @@ public class RequestHistoryService {
         validateAdminAuthority(admin);
 
         return requestHistoryQueryRepository
-                .findAllWithUserAndDepartmentByStatus(status, pageable)
+                .findAllWithUserAndDepartmentByStatus(company, status, pageable)
                 .map(AdminRequestHistorySummaryResponseDto::from);
     }
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/EduReportServiceTest.java
@@ -2338,6 +2338,68 @@ public class EduReportServiceTest {
         }
 
         @Test
+        @DisplayName("DEPARTMENT 타입 - 알림 대상에서 어썸그룹과 충남사업본부 상위 부서는 제외")
+        void remindEduReport_departmentType_excludesRootAncestorsFromNotificationTargets() {
+            // given
+            User user = createNormalUser();
+            user.addAuthority(Authority.MANAGE_DEPARTMENT_EDUCATION);
+
+            Department awesomeGroup =
+                    Department.builder().id(1L).name(DepartmentName.AWESOME_GROUP).build();
+            Department chungnam =
+                    Department.builder()
+                            .id(2L)
+                            .name(DepartmentName.CHUNGNAM_HQ)
+                            .parent(awesomeGroup)
+                            .build();
+            Department planning =
+                    Department.builder()
+                            .id(3L)
+                            .name(DepartmentName.CHUNGNAM_PLANNING)
+                            .parent(chungnam)
+                            .build();
+            Department managementSupport =
+                    Department.builder()
+                            .id(4L)
+                            .name(DepartmentName.MANAGEMENT_SUPPORT)
+                            .parent(planning)
+                            .build();
+
+            EduReport report =
+                    EduReport.builder()
+                            .id(10L)
+                            .eduType(EduType.DEPARTMENT)
+                            .title("부서 교육")
+                            .department(managementSupport)
+                            .createdBy(user)
+                            .build();
+            List<Long> targetDepartmentIds = List.of(4L, 3L);
+            List<User> targets =
+                    List.of(User.builder().id(100L).build(), User.builder().id(200L).build());
+
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            when(eduReportRepository.findById(10L)).thenReturn(Optional.of(report));
+            when(userRepository.findAllByDepartmentIdIn(targetDepartmentIds)).thenReturn(targets);
+
+            // when
+            eduReportService.remindEduReport(10L, 1L);
+
+            // then
+            verify(userRepository, times(1)).findAllByDepartmentIdIn(targetDepartmentIds);
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<List<Long>> targetIdsCaptor = ArgumentCaptor.forClass(List.class);
+            verify(notificationService, times(1))
+                    .sendEduReportRemindAlertToTargets(
+                            anyString(),
+                            anyString(),
+                            anyLong(),
+                            targetIdsCaptor.capture(),
+                            any(Map.class));
+            assertThat(targetIdsCaptor.getValue()).isEqualTo(List.of(100L, 200L));
+        }
+
+        @Test
         @DisplayName("sendEduReportRemindAlertToTargets 호출 검증 - 올바른 인자 전달")
         void remindEduReport_callsNotificationServiceWithCorrectArgs() {
             // given

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/RequestHistoryServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/RequestHistoryServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.notification.dto.response.NotificationResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.notification.entity.Notification;
 import kr.co.awesomelead.groupware_backend.domain.notification.enums.NotificationDomainType;
@@ -243,18 +244,47 @@ class RequestHistoryServiceTest {
             given(userRepository.findById(100L)).willReturn(Optional.of(admin));
             given(
                             requestHistoryQueryRepository.findAllWithUserAndDepartmentByStatus(
-                                    RequestHistoryStatus.PENDING, pageable))
+                                    null, RequestHistoryStatus.PENDING, pageable))
                     .willReturn(page);
 
             // when
             Page<AdminRequestHistorySummaryResponseDto> result =
                     requestHistoryService.getAllRequestsForAdmin(
-                            100L, RequestHistoryStatus.PENDING, pageable);
+                            100L, null, RequestHistoryStatus.PENDING, pageable);
 
             // then
             assertThat(result.getTotalElements()).isEqualTo(1);
             assertThat(result.getContent()).hasSize(1);
             assertThat(result.getContent().get(0).getRequestId()).isEqualTo(10L);
+        }
+
+        @Test
+        @DisplayName("회사 필터가 있으면 해당 회사 조건으로 신청 목록을 조회한다")
+        void it_returns_requests_filtered_by_company_for_admin() {
+            // given
+            User admin = new User();
+            ReflectionTestUtils.setField(admin, "id", 100L);
+            admin.addAuthority(Authority.MANAGE_CERTIFICATE_REQUEST);
+
+            PageRequest pageable = PageRequest.of(0, 20);
+            Page<RequestHistory> page = new PageImpl<>(List.of(), pageable, 0);
+
+            given(userRepository.findById(100L)).willReturn(Optional.of(admin));
+            given(
+                            requestHistoryQueryRepository.findAllWithUserAndDepartmentByStatus(
+                                    Company.AWESOME, RequestHistoryStatus.PENDING, pageable))
+                    .willReturn(page);
+
+            // when
+            Page<AdminRequestHistorySummaryResponseDto> result =
+                    requestHistoryService.getAllRequestsForAdmin(
+                            100L, Company.AWESOME, RequestHistoryStatus.PENDING, pageable);
+
+            // then
+            assertThat(result.getTotalElements()).isZero();
+            verify(requestHistoryQueryRepository)
+                    .findAllWithUserAndDepartmentByStatus(
+                            Company.AWESOME, RequestHistoryStatus.PENDING, pageable);
         }
 
         @Test
@@ -270,7 +300,7 @@ class RequestHistoryServiceTest {
             assertThatThrownBy(
                             () ->
                                     requestHistoryService.getAllRequestsForAdmin(
-                                            200L, null, PageRequest.of(0, 20)))
+                                            200L, null, null, PageRequest.of(0, 20)))
                     .isInstanceOf(CustomException.class)
                     .extracting("errorCode")
                     .isEqualTo(ErrorCode.NO_AUTHORITY_FOR_CERTIFICATE_REQUEST_REVIEW);


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #448 

## 📝작업 내용
- 어썸그룹을 최상위 부서로 추가하고 충남사업본부 이하 기본 부서 구조를 서버 시작 시 자동 초기화하도록 구현했습니다.
- 조직도 조회 API의 root 기준을 충남사업본부에서 어썸그룹으로 변경했습니다.
- 부서교육 알림 대상 계산 시 상위 부서는 유지하되, 구조용 최상위 조직인 어썸그룹/충남사업본부는 제외하도록 수정했습니다.
- 제증명 발급 신청 관리자 목록 조회 API에 `company` 파라미터를 추가해 신청자 근무 회사 기준으로 필터링할 수 있게 했습니다.
- 부서교육 알림 대상 및 제증명 회사 필터 관련 테스트를 추가했습니다.

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X