### PR TITLE
bug(451): 안전보건 카테고리 및 마스터 관리자 권한 보정

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
@@ -156,8 +156,8 @@ public class AdminService {
                 user.addAuthority(Authority.SEND_NOTIFICATION);
                 user.addAuthority(Authority.MANAGE_DEPARTMENT_EDUCATION);
             }
-            // ADMIN 역할인 경우 모든 권한 부여
-            if (requestDto.getRole() == Role.ADMIN) {
+            // ADMIN/MASTER_ADMIN 역할인 경우 모든 권한 부여
+            if (requestDto.getRole() == Role.ADMIN || requestDto.getRole() == Role.MASTER_ADMIN) {
                 for (Authority authority : Authority.values()) {
                     user.addAuthority(authority);
                 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/config/EducationCategoryDataInitializer.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/config/EducationCategoryDataInitializer.java
@@ -105,12 +105,10 @@ public class EducationCategoryDataInitializer implements ApplicationRunner {
                             .orElseThrow(
                                     () ->
                                             new IllegalStateException(
-                                                    "교육 카테고리 부모 코드를 찾을 수 없습니다: "
-                                                            + parentCode));
+                                                    "교육 카테고리 부모 코드를 찾을 수 없습니다: " + parentCode));
         }
 
-        EducationCategory category =
-                educationCategoryRepository.findByCode(code).orElse(null);
+        EducationCategory category = educationCategoryRepository.findByCode(code).orElse(null);
         if (category != null) {
             category.setName(name);
             category.setCategoryType(type);

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/config/EducationCategoryDataInitializer.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/config/EducationCategoryDataInitializer.java
@@ -21,67 +21,67 @@ public class EducationCategoryDataInitializer implements ApplicationRunner {
     @Transactional
     public void run(ApplicationArguments args) {
         // PSM 루트
-        createIfAbsent("PSM_OVERVIEW", "사업개요", EducationCategoryType.PSM, null, 0, 1);
-        createIfAbsent("PSM_HAZARDOUS_MATERIAL", "유해위험물질", EducationCategoryType.PSM, null, 0, 2);
-        createIfAbsent("PSM_RISK_ASSESSMENT", "위험성평가", EducationCategoryType.PSM, null, 0, 3);
-        createIfAbsent("PSM_SAFE_OPERATION", "안전운전계획", EducationCategoryType.PSM, null, 0, 4);
-        createIfAbsent("PSM_EMERGENCY_PLAN", "비상조치계획", EducationCategoryType.PSM, null, 0, 5);
+        createOrUpdate("PSM_OVERVIEW", "사업개요", EducationCategoryType.PSM, null, 0, 1);
+        createOrUpdate("PSM_HAZARDOUS_MATERIAL", "유해위험물질", EducationCategoryType.PSM, null, 0, 2);
+        createOrUpdate("PSM_RISK_ASSESSMENT", "위험성평가", EducationCategoryType.PSM, null, 0, 3);
+        createOrUpdate("PSM_SAFE_OPERATION", "안전운전계획", EducationCategoryType.PSM, null, 0, 4);
+        createOrUpdate("PSM_EMERGENCY_PLAN", "비상조치계획", EducationCategoryType.PSM, null, 0, 5);
 
         // 안전보건 루트
-        createIfAbsent("SAFETY_EDUCATION", "안전보건교육", EducationCategoryType.SAFETY, null, 0, 1);
-        createIfAbsent("SAFETY_RESOURCE", "안전보건 자료", EducationCategoryType.SAFETY, null, 0, 2);
+        createOrUpdate("SAFETY_EDUCATION", "안전보건교육", EducationCategoryType.SAFETY, null, 0, 1);
+        createOrUpdate("SAFETY_RESOURCE", "안전보건 자료", EducationCategoryType.SAFETY, null, 0, 2);
 
-        createIfAbsent(
+        createOrUpdate(
                 "SAFETY_EDUCATION_PLAN",
                 "안전보건교육계획서",
                 EducationCategoryType.SAFETY,
-                "SAFETY_EDUCATION_SHORTCUT",
+                "SAFETY_EDUCATION",
                 1,
                 1);
-        createIfAbsent(
+        createOrUpdate(
                 "SAFETY_EDUCATION_LOG_ATTENDEE",
                 "안전보건교육 교육일지 및 참석자 명단",
                 EducationCategoryType.SAFETY,
-                "SAFETY_EDUCATION_SHORTCUT",
+                "SAFETY_EDUCATION",
                 1,
                 2);
 
-        createIfAbsent(
+        createOrUpdate(
                 "SAFETY_MANAGEMENT_POLICY",
                 "안전보건경영방침",
                 EducationCategoryType.SAFETY,
                 "SAFETY_RESOURCE",
                 1,
                 1);
-        createIfAbsent(
+        createOrUpdate(
                 "SAFETY_MANAGEMENT_REGULATION",
                 "안전보건관리규정",
                 EducationCategoryType.SAFETY,
                 "SAFETY_RESOURCE",
                 1,
                 2);
-        createIfAbsent(
+        createOrUpdate(
                 "SAFETY_AIR_ENV_MEASUREMENT_RECORD",
                 "대기환경측정기록부",
                 EducationCategoryType.SAFETY,
                 "SAFETY_RESOURCE",
                 1,
                 3);
-        createIfAbsent(
+        createOrUpdate(
                 "SAFETY_WORK_ENV_MEASUREMENT_RECORD",
                 "작업환경측정기록부",
                 EducationCategoryType.SAFETY,
                 "SAFETY_RESOURCE",
                 1,
                 4);
-        createIfAbsent(
+        createOrUpdate(
                 "SAFETY_CHEMICAL_ACCIDENT_PREVENTION_PLAN",
                 "화학사고예방관리계획서",
                 EducationCategoryType.SAFETY,
                 "SAFETY_RESOURCE",
                 1,
                 5);
-        createIfAbsent(
+        createOrUpdate(
                 "SAFETY_INDUSTRIAL_SAFETY_HEALTH_COMMITTEE",
                 "산업안전보건위원회(게시판)",
                 EducationCategoryType.SAFETY,
@@ -90,23 +90,38 @@ public class EducationCategoryDataInitializer implements ApplicationRunner {
                 6);
     }
 
-    private void createIfAbsent(
+    private void createOrUpdate(
             String code,
             String name,
             EducationCategoryType type,
             String parentCode,
             int depth,
             int sortOrder) {
-        if (educationCategoryRepository.findByCode(code).isPresent()) {
-            return;
-        }
-
         EducationCategory parent = null;
         if (parentCode != null) {
-            parent = educationCategoryRepository.findByCode(parentCode).orElse(null);
+            parent =
+                    educationCategoryRepository
+                            .findByCode(parentCode)
+                            .orElseThrow(
+                                    () ->
+                                            new IllegalStateException(
+                                                    "교육 카테고리 부모 코드를 찾을 수 없습니다: "
+                                                            + parentCode));
         }
 
         EducationCategory category =
+                educationCategoryRepository.findByCode(code).orElse(null);
+        if (category != null) {
+            category.setName(name);
+            category.setCategoryType(type);
+            category.setParent(parent);
+            category.setDepth(depth);
+            category.setSortOrder(sortOrder);
+            category.setActive(true);
+            return;
+        }
+
+        category =
                 EducationCategory.builder()
                         .code(code)
                         .name(name)

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
@@ -113,6 +113,33 @@ class AdminServiceTest {
                 assertThat(savedUser.getStatus()).isEqualTo(Status.AVAILABLE);
                 assertThat(savedUser.getRole()).isEqualTo(Role.USER);
             }
+
+            @Test
+            @DisplayName("MASTER_ADMIN으로 승인하면 모든 권한을 부여한다")
+            void it_grants_all_authorities_to_master_admin() {
+                // given
+                Department department =
+                        Department.builder().id(1L).name(DepartmentName.SALES_DEPT).build();
+                User pendingUser = new User();
+                pendingUser.setId(userId);
+                pendingUser.setStatus(Status.PENDING);
+
+                UserApprovalRequestDto masterAdminRequestDto = createRequestDto();
+                masterAdminRequestDto.setRole(Role.MASTER_ADMIN);
+
+                when(userRepository.findById(userId)).thenReturn(Optional.of(pendingUser));
+                when(departmentRepository.findByName(any())).thenReturn(Optional.of(department));
+
+                // when
+                adminService.approveUserRegistration(userId, masterAdminRequestDto, adminId);
+
+                // then
+                assertThat(pendingUser.getRole()).isEqualTo(Role.MASTER_ADMIN);
+                assertThat(pendingUser.getAuthorities().size()).isEqualTo(Authority.values().length);
+                for (Authority authority : Authority.values()) {
+                    assertThat(pendingUser.hasAuthority(authority)).isEqualTo(true);
+                }
+            }
         }
 
         @Nested

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
@@ -135,7 +135,8 @@ class AdminServiceTest {
 
                 // then
                 assertThat(pendingUser.getRole()).isEqualTo(Role.MASTER_ADMIN);
-                assertThat(pendingUser.getAuthorities().size()).isEqualTo(Authority.values().length);
+                assertThat(pendingUser.getAuthorities().size())
+                        .isEqualTo(Authority.values().length);
                 for (Authority authority : Authority.values()) {
                     assertThat(pendingUser.hasAuthority(authority)).isEqualTo(true);
                 }


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #451 

## 📝작업 내용
- 안전보건 하위 카테고리의 부모 코드가 잘못 지정되어 루트 카테고리처럼 노출되던 문제를 수정했습니다.
- `안전보건교육계획서`, `안전보건교육 교육일지 및 참석자 명단`이 `안전보건교육` 하위에 포함되도록 부모 코드를 보정했습니다.
- 기존 DB에 잘못 저장된 카테고리도 서버 재실행 시 `parent`, `depth`, `sortOrder`, `active` 값이 현재 코드 기준으로 보정되도록 초기화 로직을 개선했습니다.
- 회원가입 승인 시 `MASTER_ADMIN`으로 승인된 사용자도 `ADMIN`과 동일하게 모든 권한을 자동 부여하도록 수정했습니다.

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X