### PR TITLE
fix(459): 마스터 관리자 노출 제외 및 이메일 인증 템플릿 개선

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
@@ -69,7 +69,9 @@ public class AdminController {
 
     private final AdminService adminService;
 
-    @Operation(summary = "직원 목록 조회", description = "직원 관리 화면용 사용자 목록을 조회합니다.")
+    @Operation(
+            summary = "직원 목록 조회",
+            description = "직원 관리 화면용 사용자 목록을 조회합니다. MASTER_ADMIN 계정은 조회 결과에서 제외됩니다.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -1016,7 +1018,9 @@ public class AdminController {
         return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
 
-    @Operation(summary = "관리자 직원 목록 엑셀 다운로드")
+    @Operation(
+            summary = "관리자 직원 목록 엑셀 다운로드",
+            description = "직원 관리 목록을 엑셀로 다운로드합니다. MASTER_ADMIN 계정은 다운로드 결과에서 제외됩니다.")
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "200",

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/EmailAuthService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/EmailAuthService.java
@@ -2,17 +2,21 @@ package kr.co.awesomelead.groupware_backend.domain.auth.service;
 
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
-import java.security.SecureRandom;
-import java.util.concurrent.TimeUnit;
+
 import kr.co.awesomelead.groupware_backend.global.error.CustomException;
 import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
@@ -45,8 +49,8 @@ public class EmailAuthService {
         // Redis에 인증번호 저장 (5분 유효)
         String key = AUTH_CODE_PREFIX + email;
         redisTemplate
-            .opsForValue()
-            .set(key, authCode, AUTH_CODE_EXPIRATION_MINUTES, TimeUnit.MINUTES);
+                .opsForValue()
+                .set(key, authCode, AUTH_CODE_EXPIRATION_MINUTES, TimeUnit.MINUTES);
     }
 
     // 이메일 인증번호 검증
@@ -107,7 +111,7 @@ public class EmailAuthService {
         helper.setSubject("[어썸그룹] 이메일 인증번호 안내");
 
         String htmlContent =
-            """
+                """
                     <!DOCTYPE html>
                     <html lang="ko">
                     <head>
@@ -119,16 +123,16 @@ public class EmailAuthService {
                             body, table, td, p, a {
                                 font-family: 'Pretendard', 'Apple SD Gothic Neo', 'Malgun Gothic', 'Noto Sans KR', Arial, sans-serif !important;
                             }
-                
+
                             @media only screen and (max-width: 620px) {
                                 .wrapper {
                                     width: 100% !important;
                                 }
-                
+
                                 .card {
                                     padding: 24px 20px !important;
                                 }
-                
+
                                 .code {
                                     font-size: 30px !important;
                                     letter-spacing: 6px !important;
@@ -140,7 +144,7 @@ public class EmailAuthService {
                         <div style="display: none; max-height: 0; overflow: hidden; opacity: 0;">
                             어썸그룹 이메일 인증번호 안내 메일입니다.
                         </div>
-                
+
                         <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #F4F6F8;">
                             <tr>
                                 <td align="center" style="padding: 32px 16px;">
@@ -152,7 +156,7 @@ public class EmailAuthService {
                                                 </span>
                                             </td>
                                         </tr>
-                
+
                                         <tr>
                                             <td class="card" style="background-color: #FFFFFF; border: 1px solid #E7E7E7; border-radius: 16px; padding: 32px;">
                                                 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
@@ -167,7 +171,7 @@ public class EmailAuthService {
                                                         </td>
                                                     </tr>
                                                 </table>
-                
+
                                                 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="margin-top: 24px; background-color: #F3F7FC; border-radius: 14px;">
                                                     <tr>
                                                         <td style="padding: 18px 20px;">
@@ -182,7 +186,7 @@ public class EmailAuthService {
                                                         </td>
                                                     </tr>
                                                 </table>
-                
+
                                                 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="margin-top: 18px; border: 1px solid #E7E7E7; border-radius: 12px;">
                                                     <tr>
                                                         <td style="padding: 18px 20px; font-size: 14px; line-height: 1.7; color: #414141;">
@@ -205,7 +209,7 @@ public class EmailAuthService {
                                                 </table>
                                             </td>
                                         </tr>
-                
+
                                         <tr>
                                             <td style="padding-top: 16px; text-align: center; font-size: 12px; line-height: 1.6; color: #9D9D9D;">
                                                 본 메일은 발신전용 메일입니다.<br />
@@ -218,7 +222,7 @@ public class EmailAuthService {
                         </table>
                     </body>
                 """
-                .replace(AUTH_CODE_PLACEHOLDER, authCode);
+                        .replace(AUTH_CODE_PLACEHOLDER, authCode);
 
         helper.setText(htmlContent, true);
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/EmailAuthService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/EmailAuthService.java
@@ -2,21 +2,17 @@ package kr.co.awesomelead.groupware_backend.domain.auth.service;
 
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
-
+import java.security.SecureRandom;
+import java.util.concurrent.TimeUnit;
 import kr.co.awesomelead.groupware_backend.global.error.CustomException;
 import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
-
-import java.security.SecureRandom;
-import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
@@ -30,6 +26,7 @@ public class EmailAuthService {
     private String fromEmail;
 
     private static final String AUTH_CODE_PREFIX = "auth:email:";
+    private static final String AUTH_CODE_PLACEHOLDER = "{{AUTH_CODE}}";
     private static final int AUTH_CODE_EXPIRATION_MINUTES = 5;
 
     // 이메일 인증번호 발송
@@ -48,8 +45,8 @@ public class EmailAuthService {
         // Redis에 인증번호 저장 (5분 유효)
         String key = AUTH_CODE_PREFIX + email;
         redisTemplate
-                .opsForValue()
-                .set(key, authCode, AUTH_CODE_EXPIRATION_MINUTES, TimeUnit.MINUTES);
+            .opsForValue()
+            .set(key, authCode, AUTH_CODE_EXPIRATION_MINUTES, TimeUnit.MINUTES);
     }
 
     // 이메일 인증번호 검증
@@ -107,48 +104,121 @@ public class EmailAuthService {
 
         helper.setFrom(fromEmail);
         helper.setTo(to);
-        helper.setSubject("[어썸그룹] 이메일 인증번호");
+        helper.setSubject("[어썸그룹] 이메일 인증번호 안내");
 
         String htmlContent =
+            """
+                    <!DOCTYPE html>
+                    <html lang="ko">
+                    <head>
+                        <meta charset="UTF-8" />
+                        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+                        <title>어썸그룹 이메일 인증</title>
+                        <style>
+                            body, table, td, p, a {
+                                font-family: 'Pretendard', 'Apple SD Gothic Neo', 'Malgun Gothic', 'Noto Sans KR', Arial, sans-serif !important;
+                            }
+                
+                            @media only screen and (max-width: 620px) {
+                                .wrapper {
+                                    width: 100% !important;
+                                }
+                
+                                .card {
+                                    padding: 24px 20px !important;
+                                }
+                
+                                .code {
+                                    font-size: 30px !important;
+                                    letter-spacing: 6px !important;
+                                }
+                            }
+                        </style>
+                    </head>
+                    <body style="margin: 0; padding: 0; background-color: #F4F6F8; color: #121212;">
+                        <div style="display: none; max-height: 0; overflow: hidden; opacity: 0;">
+                            어썸그룹 이메일 인증번호 안내 메일입니다.
+                        </div>
+                
+                        <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #F4F6F8;">
+                            <tr>
+                                <td align="center" style="padding: 32px 16px;">
+                                    <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="600" class="wrapper" style="width: 100%; max-width: 600px;">
+                                        <tr>
+                                            <td style="padding-bottom: 12px;">
+                                                <span style="display: inline-block; padding: 8px 12px; border-radius: 999px; background-color: #F3F7FC; color: #1E6CED; font-size: 12px; font-weight: 600; line-height: 1;">
+                                                    AWESOME GROUP
+                                                </span>
+                                            </td>
+                                        </tr>
+                
+                                        <tr>
+                                            <td class="card" style="background-color: #FFFFFF; border: 1px solid #E7E7E7; border-radius: 16px; padding: 32px;">
+                                                <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+                                                    <tr>
+                                                        <td style="font-size: 24px; font-weight: 700; line-height: 1.4; color: #121212;">
+                                                            이메일 인증을 진행해주세요
+                                                        </td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td style="padding-top: 10px; font-size: 15px; line-height: 1.7; color: #737373;">
+                                                            어썸그룹 계정 확인을 위해 아래 인증번호를 입력해주세요.
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                
+                                                <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="margin-top: 24px; background-color: #F3F7FC; border-radius: 14px;">
+                                                    <tr>
+                                                        <td style="padding: 18px 20px;">
+                                                            <div style="font-size: 12px; font-weight: 600; color: #1E6CED; margin-bottom: 8px;">
+                                                                인증번호
+                                                            </div>
+                                                            <div style="background-color: #FFFFFF; border: 1px solid #88A9E1; border-radius: 12px; padding: 20px; text-align: center;">
+                                                                <div class="code" style="font-size: 34px; line-height: 1; font-weight: 700; color: #1E6CED; letter-spacing: 8px;">
+                                                                    {{AUTH_CODE}}
+                                                                </div>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                
+                                                <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="margin-top: 18px; border: 1px solid #E7E7E7; border-radius: 12px;">
+                                                    <tr>
+                                                        <td style="padding: 18px 20px; font-size: 14px; line-height: 1.7; color: #414141;">
+                                                            <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%">
+                                                                <tr>
+                                                                    <td style="width: 64px; padding-bottom: 6px; color: #737373; white-space: nowrap; vertical-align: top;">유효시간</td>
+                                                                    <td style="padding-bottom: 6px; color: #414141; vertical-align: top;">
+                                                                        <strong style="color: #1E6CED;">5분</strong>
+                                                                    </td>
+                                                                </tr>
+                                                                <tr>
+                                                                    <td style="width: 64px; color: #737373; white-space: nowrap; vertical-align: top;">안내</td>
+                                                                    <td style="color: #414141; vertical-align: top;">
+                                                                        본인이 요청하지 않았다면 이 메일은 무시하셔도 됩니다.
+                                                                    </td>
+                                                                </tr>
+                                                            </table>
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                                            </td>
+                                        </tr>
+                
+                                        <tr>
+                                            <td style="padding-top: 16px; text-align: center; font-size: 12px; line-height: 1.6; color: #9D9D9D;">
+                                                본 메일은 발신전용 메일입니다.<br />
+                                                © Awesome Group. All rights reserved.
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </td>
+                            </tr>
+                        </table>
+                    </body>
                 """
-                <!DOCTYPE html>
-                <html>
-                <head>
-                    <meta charset="UTF-8">
-                    <style>
-                        body { font-family: 'Malgun Gothic', Arial, sans-serif; line-height: 1.6; }
-                        .container { max-width: 600px; margin: 0 auto; padding: 20px; }
-                        .header { background-color: #4A90E2; color: white; padding: 20px; text-align: center; }
-                        .content { background-color: #f9f9f9; padding: 30px; border: 1px solid #ddd; }
-                        .code-box { background-color: white; border: 2px dashed #4A90E2; padding: 20px; text-align: center; font-size: 32px; font-weight: bold; color: #4A90E2; margin: 20px 0; letter-spacing: 5px; }
-                        .footer { text-align: center; color: #666; font-size: 12px; margin-top: 20px; }
-                    </style>
-                </head>
-                <body>
-                    <div class="container">
-                        <div class="header">
-                            <h1>어썸그룹 이메일 인증</h1>
-                        </div>
-                        <div class="content">
-                            <p>안녕하세요,</p>
-                            <p>어썸그룹 이메일 인증번호입니다.</p>
-                            <p>아래 인증번호를 입력하여 이메일 인증을 완료해주세요.</p>
-
-                            <div class="code-box">
-                                %s
-                            </div>
-
-                            <p style="color: #E74C3C;">※ 인증번호는 <strong>5분간 유효</strong>합니다.</p>
-                            <p>본인이 요청하지 않은 경우, 이 이메일을 무시하셔도 됩니다.</p>
-                        </div>
-                        <div class="footer">
-                            <p>© 어썸그룹. All rights reserved.</p>
-                        </div>
-                    </div>
-                </body>
-                </html>
-                """
-                        .formatted(authCode);
+                .replace(AUTH_CODE_PLACEHOLDER, authCode);
 
         helper.setText(htmlContent, true);
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/department/controller/DepartmentController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/department/controller/DepartmentController.java
@@ -48,7 +48,9 @@ public class DepartmentController {
 
     private final DepartmentService departmentService;
 
-    @Operation(summary = "조직도 트리 조회", description = "어썸그룹 기준 부서 트리와 회사 전체 선택 옵션을 함께 조회합니다.")
+    @Operation(
+            summary = "조직도 트리 조회",
+            description = "어썸그룹 기준 부서 트리와 회사 전체 선택 옵션을 함께 조회합니다. MASTER_ADMIN 계정은 사용자 노드에서 제외됩니다.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/department/controller/DepartmentController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/department/controller/DepartmentController.java
@@ -162,7 +162,9 @@ public class DepartmentController {
         return ResponseEntity.ok(ApiResponse.onSuccess(hierarchy));
     }
 
-    @Operation(summary = "부서 및 하위 부서 사용자 조회", description = "지정한 부서와 그 하위 부서에 속한 모든 사용자를 조회합니다.")
+    @Operation(
+            summary = "부서 및 하위 부서 사용자 조회",
+            description = "지정한 부서와 그 하위 부서에 속한 모든 사용자를 조회합니다. MASTER_ADMIN 계정은 조회 결과에서 제외됩니다.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -182,16 +184,12 @@ public class DepartmentController {
                                   "message": "요청에 성공했습니다.",
                                   "result": [
                                     {
-                                      "userId": 1,
-                                      "name": "홍길동",
-                                      "position": "팀장",
-                                      "departmentName": "인사팀"
+                                      "id": 1,
+                                      "name": "홍길동"
                                     },
                                     {
-                                      "userId": 5,
-                                      "name": "김철수",
-                                      "position": "사원",
-                                      "departmentName": "인사팀"
+                                      "id": 5,
+                                      "name": "김철수"
                                     }
                                   ]
                                 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/department/service/DepartmentService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/department/service/DepartmentService.java
@@ -96,7 +96,10 @@ public class DepartmentService {
         List<User> users = userRepository.findAllByDepartmentIdIn(allDeptIds);
 
         // DTO 변환 및 반환
-        return users.stream().map(userMapper::toSummaryDto).toList();
+        return users.stream()
+                .filter(this::isNotMasterAdmin)
+                .map(userMapper::toSummaryDto)
+                .toList();
     }
 
     private void collectDepartmentIdsRecursive(Department department, List<Long> ids) {
@@ -114,7 +117,7 @@ public class DepartmentService {
         List<OrganizationUserNodeResponseDto> users =
                 department.getUsers().stream()
                         .filter(user -> user.getStatus() == Status.AVAILABLE)
-                        .filter(user -> user.getRole() != Role.MASTER_ADMIN)
+                        .filter(this::isNotMasterAdmin)
                         .sorted(Comparator.comparing(User::getId))
                         .map(OrganizationUserNodeResponseDto::from)
                         .toList();
@@ -133,5 +136,9 @@ public class DepartmentService {
                 .users(users)
                 .children(children)
                 .build();
+    }
+
+    private boolean isNotMasterAdmin(User user) {
+        return user.getRole() != Role.MASTER_ADMIN;
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/department/service/DepartmentService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/department/service/DepartmentService.java
@@ -11,6 +11,7 @@ import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
 import kr.co.awesomelead.groupware_backend.domain.department.repository.DepartmentRepository;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
 import kr.co.awesomelead.groupware_backend.domain.user.mapper.UserMapper;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
@@ -113,6 +114,7 @@ public class DepartmentService {
         List<OrganizationUserNodeResponseDto> users =
                 department.getUsers().stream()
                         .filter(user -> user.getStatus() == Status.AVAILABLE)
+                        .filter(user -> user.getRole() != Role.MASTER_ADMIN)
                         .sorted(Comparator.comparing(User::getId))
                         .map(OrganizationUserNodeResponseDto::from)
                         .toList();

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/department/service/DepartmentService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/department/service/DepartmentService.java
@@ -96,10 +96,7 @@ public class DepartmentService {
         List<User> users = userRepository.findAllByDepartmentIdIn(allDeptIds);
 
         // DTO 변환 및 반환
-        return users.stream()
-                .filter(this::isNotMasterAdmin)
-                .map(userMapper::toSummaryDto)
-                .toList();
+        return users.stream().filter(this::isNotMasterAdmin).map(userMapper::toSummaryDto).toList();
     }
 
     private void collectDepartmentIdsRecursive(Department department, List<Long> ids) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/EduReportController.java
@@ -67,6 +67,7 @@ public class EduReportController {
                                         - `files`(파일 파트)는 선택입니다.
                                         - 부서 교육 관리 권한(`MANAGE_DEPARTMENT_EDUCATION`)이 있어야 생성할 수 있습니다.
                                         - 본문은 `content`(plain) 또는 `contentDelta`/`contentHtml`(에디터 원본/렌더링용)으로 전달할 수 있습니다.
+                                        - 알림 대상자 산정 시 MASTER_ADMIN 계정은 제외됩니다.
                                         """,
             requestBody =
                     @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -177,6 +178,7 @@ public class EduReportController {
                                         - `companyScope`는 회사 목록 배열입니다.
                                         - `[AWESOME]`처럼 1개를 보내면 해당 회사 게시물로 생성됩니다.
                                         - `[AWESOME, MARUI]`, `null`, `[]`는 모든 회사 공통 게시물로 생성됩니다.
+                                        - 알림 대상자 산정 시 MASTER_ADMIN 계정은 제외됩니다.
                                         """,
             requestBody =
                     @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -285,6 +287,7 @@ public class EduReportController {
                                         - `companyScope`는 회사 목록 배열입니다.
                                         - `[AWESOME]`처럼 1개를 보내면 해당 회사 게시물로 생성됩니다.
                                         - `[AWESOME, MARUI]`, `null`, `[]`는 모든 회사 공통 게시물로 생성됩니다.
+                                        - 알림 대상자 산정 시 MASTER_ADMIN 계정은 제외됩니다.
                                         """,
             requestBody =
                     @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -1412,6 +1415,7 @@ public class EduReportController {
                         - 안전보건: `MANAGE_SAFETY`
 
                         - 생성 시와 동일한 대상자에게 title에 `[리마인드]` prefix를 붙여 알림을 재전송합니다.
+                        - MASTER_ADMIN 계정은 리마인드 대상자에서 제외됩니다.
                         - 부서교육 / PSM / 안전보건 모든 타입에 사용 가능합니다.
                         """)
     @ApiResponses({

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/DepartmentEduReportCreateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/DepartmentEduReportCreateRequestDto.java
@@ -39,7 +39,7 @@ public class DepartmentEduReportCreateRequestDto {
     @Schema(description = "서명 필요 여부", example = "true", defaultValue = "false")
     private boolean signatureRequired;
 
-    @Schema(description = "대상 부서 ID", example = "3")
+    @Schema(description = "대상 부서 ID (알림 대상자 산정 시 MASTER_ADMIN 제외)", example = "3")
     @NotNull(message = "부서 ID는 필수입니다.")
     private Long departmentId;
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/EduReportUpdateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/EduReportUpdateRequestDto.java
@@ -43,14 +43,16 @@ public class EduReportUpdateRequestDto {
     @Schema(description = "서명 필요 여부", example = "true", defaultValue = "false")
     private boolean signatureRequired;
 
-    @Schema(description = "부서 ID (부서 교육 수정 시 필수)", example = "3")
+    @Schema(description = "부서 ID (부서 교육 수정 시 필수, 알림 대상자 산정 시 MASTER_ADMIN 제외)", example = "3")
     private Long departmentId;
 
     @Schema(description = "카테고리 ID (PSM/안전보건 수정 시 선택)", example = "2")
     private Long categoryId;
 
     @Schema(
-            description = "회사 범위(PSM/안전보건 수정 시 선택)." + " [AWESOME, MARUI]를 함께 넣으면 공통 게시물로 저장됩니다.",
+            description =
+                    "회사 범위(PSM/안전보건 수정 시 선택). [AWESOME, MARUI]를 함께 넣으면 공통 게시물로 저장됩니다."
+                            + " 알림 대상자 산정 시 MASTER_ADMIN 계정은 제외됩니다.",
             example = "[\"AWESOME\"]")
     private List<Company> companyScope;
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/PsmEduReportCreateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/PsmEduReportCreateRequestDto.java
@@ -47,7 +47,9 @@ public class PsmEduReportCreateRequestDto {
     private Long categoryId;
 
     @Schema(
-            description = "대상 회사 범위 (예: [AWESOME], [AWESOME, MARUI], null/빈 배열이면 모든 회사 공통 게시물)",
+            description =
+                    "대상 회사 범위 (예: [AWESOME], [AWESOME, MARUI], null/빈 배열이면 모든 회사 공통 게시물,"
+                            + " 알림 대상자 산정 시 MASTER_ADMIN 제외)",
             example = "[\"AWESOME\", \"MARUI\"]",
             nullable = true)
     @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/SafetyEduReportCreateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/request/SafetyEduReportCreateRequestDto.java
@@ -47,7 +47,9 @@ public class SafetyEduReportCreateRequestDto {
     private Long categoryId;
 
     @Schema(
-            description = "대상 회사 범위 (예: [AWESOME], [AWESOME, MARUI], null/빈 배열이면 모든 회사 공통 게시물)",
+            description =
+                    "대상 회사 범위 (예: [AWESOME], [AWESOME, MARUI], null/빈 배열이면 모든 회사 공통 게시물,"
+                            + " 알림 대상자 산정 시 MASTER_ADMIN 제외)",
             example = "[\"AWESOME\", \"MARUI\"]",
             nullable = true)
     @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/controller/NoticeController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/controller/NoticeController.java
@@ -82,6 +82,7 @@ public class NoticeController {
                 3. **개인(targetUserIds)**: 특정 유저를 직접 대상으로 지정합니다.
 
                 *위 세 조건은 **합집합(OR)**으로 계산되어 최종 공지 대상자(NoticeTarget)가 결정됩니다.*
+                *MASTER_ADMIN 계정은 회사/부서/개인 지정 여부와 관계없이 최종 대상자에서 제외됩니다.*
                 """,
             requestBody =
                     @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -481,7 +482,8 @@ public class NoticeController {
             summary = "공지 수정",
             description =
                     "특정 공지를 수정합니다. multipart/form-data 기반으로"
-                            + " 제목/본문(content/contentDelta/contentHtml)/유형/대상자/첨부파일을 수정할 수 있습니다.",
+                            + " 제목/본문(content/contentDelta/contentHtml)/유형/대상자/첨부파일을 수정할 수 있습니다."
+                            + " MASTER_ADMIN 계정은 최종 공지 대상자에서 제외됩니다.",
             requestBody =
                     @io.swagger.v3.oas.annotations.parameters.RequestBody(
                             required = true,

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/dto/request/NoticeCreateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/dto/request/NoticeCreateRequestDto.java
@@ -77,12 +77,16 @@ public class NoticeCreateRequestDto {
     @Schema(description = "상단 고정 여부", example = "false", defaultValue = "false")
     private Boolean pinned = false;
 
-    @Schema(description = "공지 대상 회사 목록 (해당 회사의 전사 공지 시 활용)", example = "[\"어썸리드\"]")
+    @Schema(
+            description = "공지 대상 회사 목록 (해당 회사의 전사 공지 시 활용, MASTER_ADMIN 제외)",
+            example = "[\"어썸리드\"]")
     private List<Company> targetCompanies;
 
-    @Schema(description = "공지 대상 부서 ID 목록 (부서 및 하위 부서원 자동 포함)", example = "[1, 5, 12]")
+    @Schema(
+            description = "공지 대상 부서 ID 목록 (부서 및 하위 부서원 자동 포함, MASTER_ADMIN 제외)",
+            example = "[1, 5, 12]")
     private List<Long> targetDepartmentIds;
 
-    @Schema(description = "공지 대상 특정 유저 ID 목록 (개별 지정 시 활용)", example = "[101, 205]")
+    @Schema(description = "공지 대상 특정 유저 ID 목록 (개별 지정 시 활용, MASTER_ADMIN 제외)", example = "[101, 205]")
     private List<Long> targetUserIds;
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/dto/request/NoticeUpdateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/dto/request/NoticeUpdateRequestDto.java
@@ -71,13 +71,13 @@ public class NoticeUpdateRequestDto {
     @Schema(description = "상단 고정 여부 (수정하지 않으려면 null)", example = "true")
     private Boolean pinned;
 
-    @Schema(description = "공지 대상 회사 목록 (수정하지 않으려면 null, 전체 초기화하려면 [])")
+    @Schema(description = "공지 대상 회사 목록 (수정하지 않으려면 null, 전체 초기화하려면 [], MASTER_ADMIN 제외)")
     private List<Company> targetCompanies;
 
-    @Schema(description = "공지 대상 부서 ID 목록 (수정하지 않으려면 null, 전체 초기화하려면 [])")
+    @Schema(description = "공지 대상 부서 ID 목록 (수정하지 않으려면 null, 전체 초기화하려면 [], MASTER_ADMIN 제외)")
     private List<Long> targetDepartmentIds;
 
-    @Schema(description = "공지 대상 특정 유저 ID 목록 (수정하지 않으려면 null, 전체 초기화하려면 [])")
+    @Schema(description = "공지 대상 특정 유저 ID 목록 (수정하지 않으려면 null, 전체 초기화하려면 [], MASTER_ADMIN 제외)")
     private List<Long> targetUserIds;
 
     @Schema(description = "삭제할 첨부파일 ID 목록", example = "[1, 2, 3]")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/service/NoticeService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/service/NoticeService.java
@@ -353,9 +353,7 @@ public class NoticeService {
         }
 
         Set<Long> masterAdminIds = findMasterAdminIds();
-        return targetUserIds.stream()
-                .filter(userId -> !masterAdminIds.contains(userId))
-                .toList();
+        return targetUserIds.stream().filter(userId -> !masterAdminIds.contains(userId)).toList();
     }
 
     private Set<Long> findMasterAdminIds() {
@@ -363,9 +361,7 @@ public class NoticeService {
         if (masterAdmins == null || masterAdmins.isEmpty()) {
             return Set.of();
         }
-        return masterAdmins.stream()
-                .map(User::getId)
-                .collect(java.util.stream.Collectors.toSet());
+        return masterAdmins.stream().map(User::getId).collect(java.util.stream.Collectors.toSet());
     }
 
     private void validateTargetsNotEmpty(Set<Long> finalTargetUserIds) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/service/NoticeService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/service/NoticeService.java
@@ -22,6 +22,7 @@ import kr.co.awesomelead.groupware_backend.domain.notice.respository.NoticeTarge
 import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Authority;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
 import kr.co.awesomelead.groupware_backend.global.error.CustomException;
 import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
@@ -75,7 +76,20 @@ public class NoticeService {
             throws IOException {
         User author = validateAndGetAuthor(userId);
 
+        List<Long> targetUserIds = excludeMasterAdminTargetIds(requestDto.getTargetUserIds());
+
         Notice notice = noticeMapper.toNoticeEntity(requestDto, author);
+        notice.update(
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                requestDto.getTargetCompanies(),
+                requestDto.getTargetDepartmentIds(),
+                targetUserIds);
         NoticeContentFields contentFields =
                 resolveCreateContentFields(
                         requestDto.getContent(),
@@ -105,10 +119,11 @@ public class NoticeService {
             }
         }
 
-        if (requestDto.getTargetUserIds() != null) {
-            finalTargetUserIds.addAll(requestDto.getTargetUserIds());
+        if (targetUserIds != null) {
+            finalTargetUserIds.addAll(targetUserIds);
         }
 
+        excludeMasterAdminTargets(finalTargetUserIds);
         validateTargetsNotEmpty(finalTargetUserIds);
 
         List<NoticeTarget> targets =
@@ -216,6 +231,8 @@ public class NoticeService {
                 resolveUpdateContentFields(
                         notice, dto.getContent(), dto.getContentDelta(), dto.getContentHtml());
 
+        List<Long> targetUserIds = excludeMasterAdminTargetIds(dto.getTargetUserIds());
+
         notice.update(
                 dto.getType(),
                 dto.getTitle(),
@@ -226,7 +243,7 @@ public class NoticeService {
                 dto.getPinned(),
                 dto.getTargetCompanies(),
                 dto.getTargetDepartmentIds(),
-                dto.getTargetUserIds());
+                targetUserIds);
 
         boolean shouldRebuildTargets =
                 dto.getTargetCompanies() != null
@@ -243,9 +260,13 @@ public class NoticeService {
                             ? dto.getTargetDepartmentIds()
                             : notice.getTargetDepartments();
             List<Long> effectiveUserIds =
-                    dto.getTargetUserIds() != null
-                            ? dto.getTargetUserIds()
-                            : notice.getTargetUsers();
+                    targetUserIds != null
+                            ? targetUserIds
+                            : excludeMasterAdminTargetIds(notice.getTargetUsers());
+            if (targetUserIds == null && effectiveUserIds != null) {
+                notice.update(
+                        null, null, null, null, null, null, null, null, null, effectiveUserIds);
+            }
 
             Set<Long> finalTargetUserIds =
                     resolveTargetUserIds(
@@ -318,7 +339,33 @@ public class NoticeService {
             finalTargetUserIds.addAll(targetUserIds);
         }
 
+        excludeMasterAdminTargets(finalTargetUserIds);
         return finalTargetUserIds;
+    }
+
+    private void excludeMasterAdminTargets(Set<Long> targetUserIds) {
+        targetUserIds.removeAll(findMasterAdminIds());
+    }
+
+    private List<Long> excludeMasterAdminTargetIds(List<Long> targetUserIds) {
+        if (targetUserIds == null || targetUserIds.isEmpty()) {
+            return targetUserIds;
+        }
+
+        Set<Long> masterAdminIds = findMasterAdminIds();
+        return targetUserIds.stream()
+                .filter(userId -> !masterAdminIds.contains(userId))
+                .toList();
+    }
+
+    private Set<Long> findMasterAdminIds() {
+        List<User> masterAdmins = userRepository.findAllByRole(Role.MASTER_ADMIN);
+        if (masterAdmins == null || masterAdmins.isEmpty()) {
+            return Set.of();
+        }
+        return masterAdmins.stream()
+                .map(User::getId)
+                .collect(java.util.stream.Collectors.toSet());
     }
 
     private void validateTargetsNotEmpty(Set<Long> finalTargetUserIds) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/controller/SafetyTrainingSessionController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/controller/SafetyTrainingSessionController.java
@@ -684,7 +684,7 @@ public class SafetyTrainingSessionController {
 
     @Operation(
             summary = "안전보건 교육일지 등록",
-            description = "안전 보건 관리 권한 사용자가 교육일지를 등록합니다.",
+            description = "안전 보건 관리 권한 사용자가 교육일지를 등록합니다. MASTER_ADMIN 계정은 참석 대상자에서 제외됩니다.",
             requestBody =
                     @io.swagger.v3.oas.annotations.parameters.RequestBody(
                             required = true,
@@ -800,6 +800,7 @@ public class SafetyTrainingSessionController {
                     교육 생성자(createdBy)만 요청 가능합니다.
 
                     - companyScope 기준 현재 활성 사용자에게 `[리마인드]` prefix를 붙여 알림을 재전송합니다.
+                    - MASTER_ADMIN 계정은 리마인드 대상자에서 제외됩니다.
                     """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/request/SafetyTrainingSessionCreateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/request/SafetyTrainingSessionCreateRequestDto.java
@@ -82,7 +82,7 @@ public class SafetyTrainingSessionCreateRequestDto {
 
     @NotNull(message = "회사 선택은 필수입니다.")
     @Schema(
-            description = "회사 범위 코드 (AWESOME: 어썸리드, MARUI: 마루이)",
+            description = "회사 범위 코드 (AWESOME: 어썸리드, MARUI: 마루이, MASTER_ADMIN 참석 대상 제외)",
             example = "AWESOME",
             allowableValues = {"AWESOME", "MARUI"})
     private Company companyScope;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/controller/UserController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/controller/UserController.java
@@ -107,7 +107,8 @@ public class UserController {
                     "전 직원 목록을 페이징으로 조회합니다. "
                             + "기본값(excludeSuspended=false)은 AVAILABLE·SUSPENDED 상태 직원을 모두 반환하며, "
                             + "excludeSuspended=true이면 SUSPENDED 상태 직원을 제외하고 AVAILABLE 상태만 반환합니다. "
-                            + "keyword 파라미터를 전달하면 이름·영문이름·이메일 부분 일치로 검색합니다.")
+                            + "keyword 파라미터를 전달하면 이름·영문이름·이메일 부분 일치로 검색합니다. "
+                            + "MASTER_ADMIN 계정은 조회 결과에서 제외됩니다.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/UserRepository.java
@@ -27,7 +27,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     long countByDepartment(Department department);
 
-    @Query("SELECT u FROM User u JOIN FETCH u.department d WHERE d.id IN :departmentIds")
+    @Query(
+            "SELECT u FROM User u JOIN FETCH u.department d WHERE d.id IN :departmentIds AND"
+                    + " u.role <> 'MASTER_ADMIN'")
     List<User> findAllByDepartmentIdIn(@Param("departmentIds") List<Long> departmentIds);
 
     List<User> findAllByNameKor(String nameKor);
@@ -61,17 +63,18 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("SELECT u.id FROM User u WHERE u.department.id = :departmentId")
     List<Long> findAllIdsByDepartmentId(@Param("departmentId") Long departmentId);
 
-    @Query("SELECT u.id FROM User u WHERE u.status = 'AVAILABLE'")
+    @Query("SELECT u.id FROM User u WHERE u.status = 'AVAILABLE' AND u.role <> 'MASTER_ADMIN'")
     List<Long> findAllActiveUserIds();
 
-    @Query("SELECT u.id FROM User u WHERE u.workLocation = :company")
+    @Query("SELECT u.id FROM User u WHERE u.workLocation = :company AND u.role <> 'MASTER_ADMIN'")
     List<Long> findAllIdsByCompany(@Param("company") Company company);
 
     @Query(
             "SELECT u FROM User u "
                     + "WHERE u.workLocation = :company "
                     + "AND u.status = :status "
-                    + "AND u.position <> :excludedPosition")
+                    + "AND u.position <> :excludedPosition "
+                    + "AND u.role <> 'MASTER_ADMIN'")
     List<User> findAllByCompanyAndStatusExcludingPosition(
             @Param("company") Company company,
             @Param("status") Status status,

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/querydsl/UserQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/querydsl/UserQueryRepository.java
@@ -63,7 +63,8 @@ public class UserQueryRepository {
                                 departmentFilter(departmentId),
                                 jobTypeFilter(jobType),
                                 roleFilter(role),
-                                workLocationFilter(workLocation))
+                                workLocationFilter(workLocation),
+                                excludeMasterAdmin())
                         .orderBy(user.id.desc())
                         .offset(pageable.getOffset())
                         .limit(pageable.getPageSize())
@@ -83,7 +84,8 @@ public class UserQueryRepository {
                                         departmentFilter(departmentId),
                                         jobTypeFilter(jobType),
                                         roleFilter(role),
-                                        workLocationFilter(workLocation))
+                                        workLocationFilter(workLocation),
+                                        excludeMasterAdmin())
                                 .fetchOne());
     }
 
@@ -119,7 +121,8 @@ public class UserQueryRepository {
                                 jobTypeFilter(jobType),
                                 roleFilter(role),
                                 workLocationFilter(workLocation),
-                                adminStatusFilter(statuses))
+                                adminStatusFilter(statuses),
+                                excludeMasterAdmin())
                         .orderBy(user.id.desc())
                         .offset(pageable.getOffset())
                         .limit(pageable.getPageSize())
@@ -139,7 +142,8 @@ public class UserQueryRepository {
                                         jobTypeFilter(jobType),
                                         roleFilter(role),
                                         workLocationFilter(workLocation),
-                                        adminStatusFilter(statuses))
+                                        adminStatusFilter(statuses),
+                                        excludeMasterAdmin())
                                 .fetchOne());
     }
 
@@ -162,7 +166,8 @@ public class UserQueryRepository {
                         jobTypeFilter(jobType),
                         roleFilter(role),
                         workLocationFilter(workLocation),
-                        adminStatusFilter(statuses))
+                        adminStatusFilter(statuses),
+                        excludeMasterAdmin())
                 .orderBy(user.id.desc())
                 .fetch();
     }
@@ -200,6 +205,10 @@ public class UserQueryRepository {
 
     private BooleanExpression roleFilter(Role role) {
         return role != null ? user.role.eq(role) : null;
+    }
+
+    private BooleanExpression excludeMasterAdmin() {
+        return user.role.ne(Role.MASTER_ADMIN);
     }
 
     private BooleanExpression workLocationFilter(Company workLocation) {

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/EmailAuthServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/EmailAuthServiceTest.java
@@ -1,0 +1,58 @@
+package kr.co.awesomelead.groupware_backend.domain.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+
+import kr.co.awesomelead.groupware_backend.domain.auth.service.EmailAuthService;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EmailAuthService 클래스의")
+class EmailAuthServiceTest {
+
+    @InjectMocks private EmailAuthService emailAuthService;
+    @Mock private JavaMailSender mailSender;
+    @Mock private StringRedisTemplate redisTemplate;
+    @Mock private ValueOperations<String, String> valueOperations;
+
+    @Test
+    @DisplayName("sendAuthCode 메서드는 인증번호 메일을 발송하고 Redis에 인증번호를 저장한다")
+    void sendAuthCode_sends_email_and_stores_auth_code() throws Exception {
+        // given
+        String email = "user@example.com";
+        MimeMessage mimeMessage = new MimeMessage(Session.getInstance(new Properties()));
+
+        ReflectionTestUtils.setField(emailAuthService, "fromEmail", "noreply@example.com");
+        given(mailSender.createMimeMessage()).willReturn(mimeMessage);
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+        // when & then
+        assertThatCode(() -> emailAuthService.sendAuthCode(email)).doesNotThrowAnyException();
+
+        assertThat(mimeMessage.getSubject()).isEqualTo("[어썸그룹] 이메일 인증번호 안내");
+        verify(mailSender).send(any(MimeMessage.class));
+        verify(valueOperations)
+                .set(eq("auth:email:" + email), anyString(), eq(5L), eq(TimeUnit.MINUTES));
+    }
+}

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/department/DepartmentServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/department/DepartmentServiceTest.java
@@ -116,12 +116,19 @@ public class DepartmentServiceTest {
     }
 
     @Test
-    @DisplayName("부서원 통합 조회 성공 - 하위 부서 구성원 포함 확인")
+    @DisplayName("부서원 통합 조회 성공 - 하위 부서 구성원을 포함하고 MASTER_ADMIN은 제외한다")
     void getUsersByDepartmentHierarchy_Success() {
         Long targetId = 5L;
         User manager = User.builder().id(1L).nameKor("이생산").department(awesomeProdDept).build();
         User chamberStaff = User.builder().id(2L).nameKor("박챔버").department(chamberDept).build();
         User partStaff = User.builder().id(3L).nameKor("김부품").department(partDept).build();
+        User masterAdmin =
+                User.builder()
+                        .id(4L)
+                        .nameKor("마스터관리자")
+                        .role(Role.MASTER_ADMIN)
+                        .department(partDept)
+                        .build();
 
         given(departmentRepository.findById(targetId)).willReturn(Optional.of(awesomeProdDept));
 
@@ -129,18 +136,28 @@ public class DepartmentServiceTest {
         given(
                         userRepository.findAllByDepartmentIdIn(
                                 argThat(list -> list.containsAll(expectedIds))))
-                .willReturn(List.of(manager, chamberStaff, partStaff));
+                .willReturn(List.of(manager, chamberStaff, partStaff, masterAdmin));
 
         given(userMapper.toSummaryDto(any(User.class)))
-                .willReturn(UserSummaryResponseDto.builder().build());
+                .willAnswer(
+                        invocation -> {
+                            User user = invocation.getArgument(0);
+                            return UserSummaryResponseDto.builder()
+                                    .id(user.getId())
+                                    .name(user.getNameKor())
+                                    .build();
+                        });
 
         // when
         List<UserSummaryResponseDto> result =
                 departmentService.getUsersByDepartmentHierarchy(targetId);
 
         // then
-        assertThat(result).hasSize(3);
+        assertThat(result)
+                .extracting(UserSummaryResponseDto::getName)
+                .containsExactly("이생산", "박챔버", "김부품");
         verify(userRepository, times(1)).findAllByDepartmentIdIn(anyList());
+        verify(userMapper, times(3)).toSummaryDto(any(User.class));
     }
 
     @Test

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/department/DepartmentServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/department/DepartmentServiceTest.java
@@ -20,6 +20,7 @@ import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentNam
 import kr.co.awesomelead.groupware_backend.domain.department.repository.DepartmentRepository;
 import kr.co.awesomelead.groupware_backend.domain.department.service.DepartmentService;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
 import kr.co.awesomelead.groupware_backend.domain.user.mapper.UserMapper;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
@@ -172,7 +173,15 @@ public class DepartmentServiceTest {
                         .status(Status.SUSPENDED)
                         .department(chamberDept)
                         .build();
-        chamberDept.setUsers(new ArrayList<>(List.of(availableUser, suspendedUser)));
+        User masterAdmin =
+                User.builder()
+                        .id(19L)
+                        .nameKor("마스터관리자")
+                        .status(Status.AVAILABLE)
+                        .role(Role.MASTER_ADMIN)
+                        .department(chamberDept)
+                        .build();
+        chamberDept.setUsers(new ArrayList<>(List.of(availableUser, suspendedUser, masterAdmin)));
 
         given(departmentRepository.findByParentIsNull()).willReturn(List.of(rootDept));
 
@@ -184,7 +193,8 @@ public class DepartmentServiceTest {
         assertThat(result.getRootDepartment().getCode()).isEqualTo("CHUNGNAM_HQ");
         assertThat(result.getRootDepartment().getChildren()).isNotEmpty();
         assertThat(result.getRootDepartment().getChildren().get(0).getChildren().get(0).getUsers())
-                .hasSize(1);
+                .extracting("name")
+                .containsExactly("고영민");
         assertThat(result.getCompanyOptions()).hasSize(2);
         assertThat(result.getCompanyOptions().get(0).getCompany()).isEqualTo(Company.AWESOME);
         assertThat(result.getCompanyOptions().get(1).getCompany()).isEqualTo(Company.MARUI);

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/UserQueryRepositoryTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/UserQueryRepositoryTest.java
@@ -31,9 +31,12 @@ class UserQueryRepositoryTest {
     @DisplayName("findAllForAdminWithFilters 메서드는 MASTER_ADMIN을 제외한다")
     void findAllForAdminWithFilters_excludes_master_admin() {
         // given
-        User user = createUser("user@example.com", "일반사용자", "900101-1234567", "01011112222", Role.USER);
-        User admin = createUser("admin@example.com", "관리자", "900102-1234567", "01022223333", Role.ADMIN);
-        createUser("master@example.com", "마스터관리자", "900103-1234567", "01033334444", Role.MASTER_ADMIN);
+        User user =
+                createUser("user@example.com", "일반사용자", "900101-1234567", "01011112222", Role.USER);
+        User admin =
+                createUser("admin@example.com", "관리자", "900102-1234567", "01022223333", Role.ADMIN);
+        createUser(
+                "master@example.com", "마스터관리자", "900103-1234567", "01033334444", Role.MASTER_ADMIN);
         userRepository.saveAll(List.of(user, admin));
         userRepository.save(
                 createUser(
@@ -49,7 +52,9 @@ class UserQueryRepositoryTest {
                         null, null, null, null, null, null, null, PageRequest.of(0, 20));
 
         // then
-        assertThat(result.getContent()).extracting(User::getRole).containsExactlyInAnyOrder(Role.USER, Role.ADMIN);
+        assertThat(result.getContent())
+                .extracting(User::getRole)
+                .containsExactlyInAnyOrder(Role.USER, Role.ADMIN);
     }
 
     @Test
@@ -57,7 +62,12 @@ class UserQueryRepositoryTest {
     void findAllForAdminWithFiltersNoPaging_excludes_master_admin() {
         // given
         userRepository.save(
-                createUser("user-excel@example.com", "엑셀사용자", "900105-1234567", "01055556666", Role.USER));
+                createUser(
+                        "user-excel@example.com",
+                        "엑셀사용자",
+                        "900105-1234567",
+                        "01055556666",
+                        Role.USER));
         userRepository.save(
                 createUser(
                         "master-excel@example.com",
@@ -80,7 +90,12 @@ class UserQueryRepositoryTest {
     void findAllAvailableWithFilters_excludes_master_admin() {
         // given
         userRepository.save(
-                createUser("user-list@example.com", "목록사용자", "900107-1234567", "01077778888", Role.USER));
+                createUser(
+                        "user-list@example.com",
+                        "목록사용자",
+                        "900107-1234567",
+                        "01077778888",
+                        Role.USER));
         userRepository.save(
                 createUser(
                         "master-list@example.com",
@@ -99,7 +114,11 @@ class UserQueryRepositoryTest {
     }
 
     private User createUser(
-            String email, String nameKor, String registrationNumber, String phoneNumber, Role role) {
+            String email,
+            String nameKor,
+            String registrationNumber,
+            String phoneNumber,
+            Role role) {
         User user = new User();
         user.setEmail(email);
         user.setPassword("password");

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/UserQueryRepositoryTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/UserQueryRepositoryTest.java
@@ -1,0 +1,118 @@
+package kr.co.awesomelead.groupware_backend.domain.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
+import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
+import kr.co.awesomelead.groupware_backend.domain.user.repository.querydsl.UserQueryRepository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("UserQueryRepository 클래스의")
+class UserQueryRepositoryTest {
+
+    @Autowired private UserRepository userRepository;
+    @Autowired private UserQueryRepository userQueryRepository;
+
+    @Test
+    @DisplayName("findAllForAdminWithFilters 메서드는 MASTER_ADMIN을 제외한다")
+    void findAllForAdminWithFilters_excludes_master_admin() {
+        // given
+        User user = createUser("user@example.com", "일반사용자", "900101-1234567", "01011112222", Role.USER);
+        User admin = createUser("admin@example.com", "관리자", "900102-1234567", "01022223333", Role.ADMIN);
+        createUser("master@example.com", "마스터관리자", "900103-1234567", "01033334444", Role.MASTER_ADMIN);
+        userRepository.saveAll(List.of(user, admin));
+        userRepository.save(
+                createUser(
+                        "saved-master@example.com",
+                        "저장된마스터관리자",
+                        "900104-1234567",
+                        "01044445555",
+                        Role.MASTER_ADMIN));
+
+        // when
+        var result =
+                userQueryRepository.findAllForAdminWithFilters(
+                        null, null, null, null, null, null, null, PageRequest.of(0, 20));
+
+        // then
+        assertThat(result.getContent()).extracting(User::getRole).containsExactlyInAnyOrder(Role.USER, Role.ADMIN);
+    }
+
+    @Test
+    @DisplayName("findAllForAdminWithFiltersNoPaging 메서드는 MASTER_ADMIN을 제외한다")
+    void findAllForAdminWithFiltersNoPaging_excludes_master_admin() {
+        // given
+        userRepository.save(
+                createUser("user-excel@example.com", "엑셀사용자", "900105-1234567", "01055556666", Role.USER));
+        userRepository.save(
+                createUser(
+                        "master-excel@example.com",
+                        "엑셀마스터관리자",
+                        "900106-1234567",
+                        "01066667777",
+                        Role.MASTER_ADMIN));
+
+        // when
+        List<User> result =
+                userQueryRepository.findAllForAdminWithFiltersNoPaging(
+                        null, null, null, null, null, null, null);
+
+        // then
+        assertThat(result).extracting(User::getRole).containsExactly(Role.USER);
+    }
+
+    @Test
+    @DisplayName("findAllAvailableWithFilters 메서드는 MASTER_ADMIN을 제외한다")
+    void findAllAvailableWithFilters_excludes_master_admin() {
+        // given
+        userRepository.save(
+                createUser("user-list@example.com", "목록사용자", "900107-1234567", "01077778888", Role.USER));
+        userRepository.save(
+                createUser(
+                        "master-list@example.com",
+                        "목록마스터관리자",
+                        "900108-1234567",
+                        "01088889999",
+                        Role.MASTER_ADMIN));
+
+        // when
+        var result =
+                userQueryRepository.findAllAvailableWithFilters(
+                        null, null, null, null, null, null, PageRequest.of(0, 20));
+
+        // then
+        assertThat(result.getContent()).extracting(User::getRole).containsExactly(Role.USER);
+    }
+
+    private User createUser(
+            String email, String nameKor, String registrationNumber, String phoneNumber, Role role) {
+        User user = new User();
+        user.setEmail(email);
+        user.setPassword("password");
+        user.setNameKor(nameKor);
+        user.setNameEng(nameKor);
+        user.setNationality("대한민국");
+        user.setZipcode("06234");
+        user.setAddress1("서울시 강남구 테헤란로 123");
+        user.setAddress2("어썸빌딩 5층");
+        user.setRegistrationNumber(registrationNumber);
+        user.setPhoneNumber(phoneNumber);
+        user.setRole(role);
+        user.setStatus(Status.AVAILABLE);
+        return user;
+    }
+}

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/UserRepositoryTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/UserRepositoryTest.java
@@ -1,0 +1,207 @@
+package kr.co.awesomelead.groupware_backend.domain.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import kr.co.awesomelead.groupware_backend.domain.department.entity.Department;
+import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
+import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
+import kr.co.awesomelead.groupware_backend.domain.department.repository.DepartmentRepository;
+import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
+import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("UserRepository 클래스의")
+class UserRepositoryTest {
+
+    @Autowired private UserRepository userRepository;
+    @Autowired private DepartmentRepository departmentRepository;
+
+    private int userSequence = 0;
+
+    @Test
+    @DisplayName("findAllActiveUserIds 메서드는 MASTER_ADMIN을 제외한다")
+    void findAllActiveUserIds_excludes_master_admin() {
+        User user =
+                saveUser(
+                        "active-user",
+                        Role.USER,
+                        Status.AVAILABLE,
+                        Company.AWESOME,
+                        Position.STAFF,
+                        null);
+        User admin =
+                saveUser(
+                        "active-admin",
+                        Role.ADMIN,
+                        Status.AVAILABLE,
+                        Company.AWESOME,
+                        Position.MANAGER,
+                        null);
+        User masterAdmin =
+                saveUser(
+                        "active-master",
+                        Role.MASTER_ADMIN,
+                        Status.AVAILABLE,
+                        Company.AWESOME,
+                        Position.STAFF,
+                        null);
+
+        List<Long> result = userRepository.findAllActiveUserIds();
+
+        assertThat(result)
+                .contains(user.getId(), admin.getId())
+                .doesNotContain(masterAdmin.getId());
+    }
+
+    @Test
+    @DisplayName("findAllIdsByCompany 메서드는 MASTER_ADMIN을 제외한다")
+    void findAllIdsByCompany_excludes_master_admin() {
+        User user =
+                saveUser(
+                        "company-user",
+                        Role.USER,
+                        Status.AVAILABLE,
+                        Company.AWESOME,
+                        Position.STAFF,
+                        null);
+        User masterAdmin =
+                saveUser(
+                        "company-master",
+                        Role.MASTER_ADMIN,
+                        Status.AVAILABLE,
+                        Company.AWESOME,
+                        Position.STAFF,
+                        null);
+        User otherCompanyUser =
+                saveUser(
+                        "other-company-user",
+                        Role.USER,
+                        Status.AVAILABLE,
+                        Company.MARUI,
+                        Position.STAFF,
+                        null);
+
+        List<Long> result = userRepository.findAllIdsByCompany(Company.AWESOME);
+
+        assertThat(result)
+                .contains(user.getId())
+                .doesNotContain(masterAdmin.getId(), otherCompanyUser.getId());
+    }
+
+    @Test
+    @DisplayName("findAllByDepartmentIdIn 메서드는 MASTER_ADMIN을 제외한다")
+    void findAllByDepartmentIdIn_excludes_master_admin() {
+        Department department = saveDepartment();
+        User user =
+                saveUser(
+                        "department-user",
+                        Role.USER,
+                        Status.AVAILABLE,
+                        Company.AWESOME,
+                        Position.STAFF,
+                        department);
+        User masterAdmin =
+                saveUser(
+                        "department-master",
+                        Role.MASTER_ADMIN,
+                        Status.AVAILABLE,
+                        Company.AWESOME,
+                        Position.STAFF,
+                        department);
+
+        List<User> result = userRepository.findAllByDepartmentIdIn(List.of(department.getId()));
+
+        assertThat(result)
+                .extracting(User::getId)
+                .contains(user.getId())
+                .doesNotContain(masterAdmin.getId());
+    }
+
+    @Test
+    @DisplayName("findAllByCompanyAndStatusExcludingPosition 메서드는 MASTER_ADMIN을 제외한다")
+    void findAllByCompanyAndStatusExcludingPosition_excludes_master_admin() {
+        User user =
+                saveUser(
+                        "safety-user",
+                        Role.USER,
+                        Status.AVAILABLE,
+                        Company.AWESOME,
+                        Position.STAFF,
+                        null);
+        User masterAdmin =
+                saveUser(
+                        "safety-master",
+                        Role.MASTER_ADMIN,
+                        Status.AVAILABLE,
+                        Company.AWESOME,
+                        Position.STAFF,
+                        null);
+        User ceo =
+                saveUser(
+                        "safety-ceo",
+                        Role.USER,
+                        Status.AVAILABLE,
+                        Company.AWESOME,
+                        Position.CEO,
+                        null);
+
+        List<User> result =
+                userRepository.findAllByCompanyAndStatusExcludingPosition(
+                        Company.AWESOME, Status.AVAILABLE, Position.CEO);
+
+        assertThat(result)
+                .extracting(User::getId)
+                .contains(user.getId())
+                .doesNotContain(masterAdmin.getId(), ceo.getId());
+    }
+
+    private Department saveDepartment() {
+        Department department =
+                Department.builder()
+                        .name(DepartmentName.CHAMBER_PROD)
+                        .company(Company.AWESOME)
+                        .build();
+        return departmentRepository.save(department);
+    }
+
+    private User saveUser(
+            String key,
+            Role role,
+            Status status,
+            Company workLocation,
+            Position position,
+            Department department) {
+        int sequence = ++userSequence;
+        User user = new User();
+        user.setEmail(key + "@example.com");
+        user.setPassword("password");
+        user.setNameKor(key);
+        user.setNameEng(key);
+        user.setNationality("대한민국");
+        user.setZipcode("06234");
+        user.setAddress1("서울시 강남구 테헤란로 123");
+        user.setAddress2("어썸빌딩 5층");
+        user.setRegistrationNumber(String.format("9001%02d1%06d", sequence, sequence));
+        user.setPhoneNumber(String.format("010%08d", sequence));
+        user.setRole(role);
+        user.setStatus(status);
+        user.setWorkLocation(workLocation);
+        user.setPosition(position);
+        user.setDepartment(department);
+        return userRepository.save(user);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #459 

## 📝작업 내용
- 이메일 인증번호 메일 제목과 본문 포맷을 개선하고, 모바일에서 안내 문구가 어색하게 줄바꿈되는 문제를 수정했습니다.
- 직원 조회, 관리자 직원 목록, 관리자 직원 엑셀 다운로드에서 MASTER_ADMIN 계정이 노출되지 않도록 제외했습니다.
- 조직도 트리와 부서 및 하위 부서 사용자 조회에서 MASTER_ADMIN 계정이 사용자로 노출되지 않도록 제외했습니다.
- 공지 대상자 산정 시 회사/부서/개인 지정 여부와 관계없이 MASTER_ADMIN 계정이 최종 대상자에서 제외되도록 처리했습니다.
- 교육 및 안전보건 교육일지 대상자/리마인드 대상자 산정에서 MASTER_ADMIN 계정이 제외되도록 처리했습니다.

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X