### PR TITLE
fix(471): 개발 서버에서 테스트 API 활성화

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
@@ -21,7 +21,6 @@ import kr.co.awesomelead.groupware_backend.domain.notification.service.Notificat
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.repository.SafetyTrainingSessionRepository;
 import kr.co.awesomelead.groupware_backend.domain.user.dto.response.MyInfoAuthorityItemDto;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
-import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
 import kr.co.awesomelead.groupware_backend.domain.user.mapper.UserMapper;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/test/controller/TestController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/test/controller/TestController.java
@@ -28,7 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/test")
 @RequiredArgsConstructor
-@Profile("local")
+@Profile({"local", "dev"})
 @Tag(name = "Test", description = """
             ## 개발 중 테스트 API
             """)

--- a/src/main/java/kr/co/awesomelead/groupware_backend/test/service/TestService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/test/service/TestService.java
@@ -33,7 +33,7 @@ import java.util.List;
 
 @Slf4j
 @Service
-@Profile("local")
+@Profile({"local", "dev"})
 @RequiredArgsConstructor
 @Transactional
 public class TestService {


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #471 

## 📝작업 내용
- `TestController`를 `local`, `dev` 프로필에서 활성화했습니다.
- `TestService`를 `local`, `dev` 프로필에서 활성화했습니다.
- 개발 서버 Swagger에서 `/api/test/**` API를 확인하고 실행할 수 있도록 변경했습니다.
- `prod` 프로필에서는 테스트 API가 생성되지 않도록 기존 제한을 유지했습니다.

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X