### PR TITLE
fix: 한글 이름 최대 길이를 50자로 확장

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/dto/request/AdminUserUpdateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/dto/request/AdminUserUpdateRequestDto.java
@@ -3,6 +3,8 @@ package kr.co.awesomelead.groupware_backend.domain.admin.dto.request;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import jakarta.validation.constraints.Size;
+
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Authority;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.JobType;
@@ -20,7 +22,8 @@ import java.util.List;
 @Schema(description = "관리자 직원 정보 수정 요청 (이메일 제외)")
 public class AdminUserUpdateRequestDto {
 
-    @Schema(description = "한글 이름", example = "홍길동")
+    @Schema(description = "한글 이름", example = "홍길동", maxLength = 50)
+    @Size(max = 50, message = "한글 이름은 최대 50자까지 입력 가능합니다.")
     private String nameKor;
 
     @Schema(description = "영문 이름", example = "HONG GILDONG")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/dto/request/UserApprovalRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/dto/request/UserApprovalRequestDto.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.DepartmentName;
@@ -22,7 +23,8 @@ import java.util.List;
 @Setter
 public class UserApprovalRequestDto {
 
-    @Schema(description = "한글 이름", example = "홍길동")
+    @Schema(description = "한글 이름", example = "홍길동", maxLength = 50)
+    @Size(max = 50, message = "한글 이름은 최대 50자까지 입력 가능합니다.")
     private String nameKor;
 
     @Schema(description = "영문 이름", example = "HONG GILDONG")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/dto/request/SignupRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/dto/request/SignupRequestDto.java
@@ -18,8 +18,9 @@ import lombok.Setter;
 @Schema(description = "회원가입 요청")
 public class SignupRequestDto {
 
-    @Schema(description = "한글 이름", example = "홍길동", required = true)
+    @Schema(description = "한글 이름", example = "홍길동", required = true, maxLength = 50)
     @NotBlank(message = "성명은 필수입니다.")
+    @Size(max = 50, message = "한글 이름은 최대 50자까지 입력 가능합니다.")
     private String nameKor;
 
     @Schema(description = "영문 이름", example = "Hong Gildong", required = true)

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/entity/User.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/entity/User.java
@@ -2,7 +2,6 @@ package kr.co.awesomelead.groupware_backend.domain.user.entity;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
@@ -22,7 +21,17 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
-
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import kr.co.awesomelead.groupware_backend.domain.annualleave.entity.AnnualLeave;
 import kr.co.awesomelead.groupware_backend.domain.checksheet.entity.CheckSheet;
 import kr.co.awesomelead.groupware_backend.domain.department.entity.Department;
@@ -35,24 +44,11 @@ import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
 import kr.co.awesomelead.groupware_backend.global.encryption.Encryptor;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 @Entity
 @Getter
@@ -74,7 +70,7 @@ public class User {
     @Column(nullable = false, columnDefinition = "CHAR(60)")
     private String password; // 비밀번호
 
-    @Column(nullable = false, length = 20)
+    @Column(nullable = false, length = 50)
     private String nameKor; // 한글 이름
 
     @Column(length = 50)
@@ -147,10 +143,10 @@ public class User {
     private LocalDate birthDate; // 생년월일
 
     @OneToOne(
-            mappedBy = "user",
-            cascade = CascadeType.ALL,
-            orphanRemoval = true,
-            fetch = FetchType.LAZY)
+        mappedBy = "user",
+        cascade = CascadeType.ALL,
+        orphanRemoval = true,
+        fetch = FetchType.LAZY)
     @JsonManagedReference
     private AnnualLeave annualLeave;
 
@@ -264,12 +260,12 @@ public class User {
 
         // 3. 세기 판단 (그룹화)
         String century =
-                switch (genderDigit) {
-                    case '1', '2', '5', '6' -> "19";
-                    case '3', '4', '7', '8' -> "20";
-                    case '9', '0' -> "18"; // 혹시 모를 1800년대생 대비
-                    default -> "20"; // 기본값
-                };
+            switch (genderDigit) {
+                case '1', '2', '5', '6' -> "19";
+                case '3', '4', '7', '8' -> "20";
+                case '9', '0' -> "18"; // 혹시 모를 1800년대생 대비
+                default -> "20"; // 기본값
+            };
 
         // 4. LocalDate로 변환
         return LocalDate.parse(century + birthPart, DateTimeFormatter.ofPattern("yyyyMMdd"));

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/entity/User.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/entity/User.java
@@ -2,6 +2,7 @@ package kr.co.awesomelead.groupware_backend.domain.user.entity;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
@@ -21,17 +22,7 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+
 import kr.co.awesomelead.groupware_backend.domain.annualleave.entity.AnnualLeave;
 import kr.co.awesomelead.groupware_backend.domain.checksheet.entity.CheckSheet;
 import kr.co.awesomelead.groupware_backend.domain.department.entity.Department;
@@ -44,11 +35,24 @@ import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
 import kr.co.awesomelead.groupware_backend.global.encryption.Encryptor;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -143,10 +147,10 @@ public class User {
     private LocalDate birthDate; // 생년월일
 
     @OneToOne(
-        mappedBy = "user",
-        cascade = CascadeType.ALL,
-        orphanRemoval = true,
-        fetch = FetchType.LAZY)
+            mappedBy = "user",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY)
     @JsonManagedReference
     private AnnualLeave annualLeave;
 
@@ -260,12 +264,12 @@ public class User {
 
         // 3. 세기 판단 (그룹화)
         String century =
-            switch (genderDigit) {
-                case '1', '2', '5', '6' -> "19";
-                case '3', '4', '7', '8' -> "20";
-                case '9', '0' -> "18"; // 혹시 모를 1800년대생 대비
-                default -> "20"; // 기본값
-            };
+                switch (genderDigit) {
+                    case '1', '2', '5', '6' -> "19";
+                    case '3', '4', '7', '8' -> "20";
+                    case '9', '0' -> "18"; // 혹시 모를 1800년대생 대비
+                    default -> "20"; // 기본값
+                };
 
         // 4. LocalDate로 변환
         return LocalDate.parse(century + birthPart, DateTimeFormatter.ofPattern("yyyyMMdd"));


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #473 

## 📝작업 내용
- 한글 이름 최대 길이를 50자로 확장했습니다.
- 운영 DB는 ddl-auto=none이라 아래 쿼리 적용했습니다.
ALTER TABLE users
MODIFY COLUMN name_kor VARCHAR(50) NOT NULL;

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [ ] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X