### PR TITLE
fix(482): 내방객 조회 및 다운로드 응답 개선

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/config/SecurityConfig.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/config/SecurityConfig.java
@@ -104,6 +104,7 @@ public class SecurityConfig {
                                         "/api/auth/find-email",
                                         "/api/auth/reset-password/phone",
                                         "/api/auth/reset-password/email",
+                                        "/api/users/list",
                                         "/api/visits/**") // 내방객이 본인 방문기록 조회
                                 .permitAll()
                                 .requestMatchers(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
@@ -1149,6 +1149,7 @@ public class AdminController {
         }
         return ResponseEntity.ok()
                 .header("Content-Disposition", "attachment; filename*=UTF-8''" + encodedFilename)
+                .header("Access-Control-Expose-Headers", "Content-Disposition")
                 .header(
                         "Content-Type",
                         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/service/VisitService.java
@@ -295,11 +295,25 @@ public class VisitService {
                 visitRepository.findByVisitorNameAndPhoneNumberHashOrderByIdDesc(
                         dto.getName(), inputPhoneHash);
 
-        return visits.stream()
-                .filter(visit -> StringUtils.hasText(visit.getPassword()))
-                .filter(visit -> passwordEncoder.matches(dto.getPassword(), visit.getPassword()))
-                .map(visitMapper::toMyVisitListResponseDto)
-                .toList();
+        if (visits.isEmpty()) {
+            throw new CustomException(ErrorCode.VISIT_NOT_FOUND);
+        }
+
+        List<MyVisitListResponseDto> matchedVisits =
+                visits.stream()
+                        .filter(visit -> StringUtils.hasText(visit.getPassword()))
+                        .filter(
+                                visit ->
+                                        passwordEncoder.matches(
+                                                dto.getPassword(), visit.getPassword()))
+                        .map(visitMapper::toMyVisitListResponseDto)
+                        .toList();
+
+        if (matchedVisits.isEmpty()) {
+            throw new CustomException(ErrorCode.VISITOR_AUTHENTICATION_FAILED);
+        }
+
+        return matchedVisits;
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
@@ -354,13 +354,10 @@ public class VisitServiceTest {
             @DisplayName("VISIT_NOT_FOUND 예외를 던진다.")
             void it_throws_visit_not_found() {
                 // given
-                VisitSearchRequestDto dto =
-                        new VisitSearchRequestDto("홍길동", "01012345678", "1234");
+                VisitSearchRequestDto dto = new VisitSearchRequestDto("홍길동", "01012345678", "1234");
                 given(
-                                visitRepository
-                                        .findByVisitorNameAndPhoneNumberHashOrderByIdDesc(
-                                                dto.getName(),
-                                                Visit.hashValue(dto.getPhoneNumber())))
+                                visitRepository.findByVisitorNameAndPhoneNumberHashOrderByIdDesc(
+                                        dto.getName(), Visit.hashValue(dto.getPhoneNumber())))
                         .willReturn(List.of());
 
                 // when & then
@@ -378,14 +375,11 @@ public class VisitServiceTest {
             @DisplayName("VISITOR_AUTHENTICATION_FAILED 예외를 던진다.")
             void it_throws_visitor_authentication_failed() {
                 // given
-                VisitSearchRequestDto dto =
-                        new VisitSearchRequestDto("홍길동", "01012345678", "1234");
+                VisitSearchRequestDto dto = new VisitSearchRequestDto("홍길동", "01012345678", "1234");
                 Visit visit = createBaseVisit(VisitStatus.NOT_VISITED, VisitCategory.PRE_ONE_DAY);
                 given(
-                                visitRepository
-                                        .findByVisitorNameAndPhoneNumberHashOrderByIdDesc(
-                                                dto.getName(),
-                                                Visit.hashValue(dto.getPhoneNumber())))
+                                visitRepository.findByVisitorNameAndPhoneNumberHashOrderByIdDesc(
+                                        dto.getName(), Visit.hashValue(dto.getPhoneNumber())))
                         .willReturn(List.of(visit));
                 given(passwordEncoder.matches(dto.getPassword(), ENCODED_PASSWORD))
                         .willReturn(false);
@@ -405,14 +399,11 @@ public class VisitServiceTest {
             @DisplayName("내 방문 목록을 반환한다.")
             void it_returns_my_visit_list() {
                 // given
-                VisitSearchRequestDto dto =
-                        new VisitSearchRequestDto("홍길동", "01012345678", "1234");
+                VisitSearchRequestDto dto = new VisitSearchRequestDto("홍길동", "01012345678", "1234");
                 Visit visit = createBaseVisit(VisitStatus.NOT_VISITED, VisitCategory.PRE_ONE_DAY);
                 given(
-                                visitRepository
-                                        .findByVisitorNameAndPhoneNumberHashOrderByIdDesc(
-                                                dto.getName(),
-                                                Visit.hashValue(dto.getPhoneNumber())))
+                                visitRepository.findByVisitorNameAndPhoneNumberHashOrderByIdDesc(
+                                        dto.getName(), Visit.hashValue(dto.getPhoneNumber())))
                         .willReturn(List.of(visit));
                 given(passwordEncoder.matches(dto.getPassword(), ENCODED_PASSWORD))
                         .willReturn(true);

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
@@ -26,6 +26,8 @@ import kr.co.awesomelead.groupware_backend.domain.visit.dto.request.MyVisitUpdat
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.request.OnSiteVisitRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.request.OneDayVisitRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.request.VisitProcessRequestDto;
+import kr.co.awesomelead.groupware_backend.domain.visit.dto.request.VisitSearchRequestDto;
+import kr.co.awesomelead.groupware_backend.domain.visit.dto.response.MyVisitListResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.dto.response.VisitListResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.visit.entity.Visit;
 import kr.co.awesomelead.groupware_backend.domain.visit.entity.VisitHost;
@@ -337,6 +339,90 @@ public class VisitServiceTest {
                                                 .isEqualTo("s3-key-123");
                                         return true;
                                     }));
+        }
+    }
+
+    @Nested
+    @DisplayName("getMyVisitList 메서드는")
+    class Describe_getMyVisitList {
+
+        @Nested
+        @DisplayName("이름과 전화번호에 해당하는 방문 정보가 없으면")
+        class Context_with_no_visit {
+
+            @Test
+            @DisplayName("VISIT_NOT_FOUND 예외를 던진다.")
+            void it_throws_visit_not_found() {
+                // given
+                VisitSearchRequestDto dto =
+                        new VisitSearchRequestDto("홍길동", "01012345678", "1234");
+                given(
+                                visitRepository
+                                        .findByVisitorNameAndPhoneNumberHashOrderByIdDesc(
+                                                dto.getName(),
+                                                Visit.hashValue(dto.getPhoneNumber())))
+                        .willReturn(List.of());
+
+                // when & then
+                assertThatThrownBy(() -> visitService.getMyVisitList(dto))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage(ErrorCode.VISIT_NOT_FOUND.getMessage());
+            }
+        }
+
+        @Nested
+        @DisplayName("방문 정보는 있지만 비밀번호가 일치하지 않으면")
+        class Context_with_invalid_password {
+
+            @Test
+            @DisplayName("VISITOR_AUTHENTICATION_FAILED 예외를 던진다.")
+            void it_throws_visitor_authentication_failed() {
+                // given
+                VisitSearchRequestDto dto =
+                        new VisitSearchRequestDto("홍길동", "01012345678", "1234");
+                Visit visit = createBaseVisit(VisitStatus.NOT_VISITED, VisitCategory.PRE_ONE_DAY);
+                given(
+                                visitRepository
+                                        .findByVisitorNameAndPhoneNumberHashOrderByIdDesc(
+                                                dto.getName(),
+                                                Visit.hashValue(dto.getPhoneNumber())))
+                        .willReturn(List.of(visit));
+                given(passwordEncoder.matches(dto.getPassword(), ENCODED_PASSWORD))
+                        .willReturn(false);
+
+                // when & then
+                assertThatThrownBy(() -> visitService.getMyVisitList(dto))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessage(ErrorCode.VISITOR_AUTHENTICATION_FAILED.getMessage());
+            }
+        }
+
+        @Nested
+        @DisplayName("방문 정보와 비밀번호가 모두 일치하면")
+        class Context_with_valid_credentials {
+
+            @Test
+            @DisplayName("내 방문 목록을 반환한다.")
+            void it_returns_my_visit_list() {
+                // given
+                VisitSearchRequestDto dto =
+                        new VisitSearchRequestDto("홍길동", "01012345678", "1234");
+                Visit visit = createBaseVisit(VisitStatus.NOT_VISITED, VisitCategory.PRE_ONE_DAY);
+                given(
+                                visitRepository
+                                        .findByVisitorNameAndPhoneNumberHashOrderByIdDesc(
+                                                dto.getName(),
+                                                Visit.hashValue(dto.getPhoneNumber())))
+                        .willReturn(List.of(visit));
+                given(passwordEncoder.matches(dto.getPassword(), ENCODED_PASSWORD))
+                        .willReturn(true);
+
+                // when
+                List<MyVisitListResponseDto> result = visitService.getMyVisitList(dto);
+
+                // then
+                assertThat(result).hasSize(1);
+            }
         }
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #482 

## 📝작업 내용
- `/api/visits/my` 내 방문 목록 조회 시 입력 정보와 일치하는 방문 정보가 없거나 비밀번호가 일치하지 않으면 인증 실패 예외를 반환하도록 수정했습니다.
- `/api/users/list`를 비로그인 상태에서도 접근 가능하도록 허용하여 내방객 작성 시 담당 직원 선택 화면에서 사용할 수 있게 수정했습니다.
- `/api/admin/users/excel` 엑셀 다운로드 응답에 `Access-Control-Expose-Headers: Content-Disposition` 헤더를 추가해 프론트에서 파일명 헤더를 읽을 수 있도록 수정했습니다.

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X