### PR TITLE
fix(485): 직원/내방객 조회 및 권한 표시 개선

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
@@ -143,6 +143,9 @@ public class AdminController {
             @Parameter(description = "상태 필터 (AVAILABLE, SUSPENDED, PENDING 등 다중 선택 가능)")
                     @RequestParam(required = false)
                     List<Status> statuses,
+            @Parameter(description = "개인정보 수정 승인 대기 여부 필터", required = false, example = "true")
+                    @RequestParam(required = false)
+                    Boolean hasPendingMyInfoRequest,
             @ParameterObject @PageableDefault(page = 0, size = 20) Pageable pageable) {
 
         Page<AdminUserSummaryResponseDto> result =
@@ -155,6 +158,7 @@ public class AdminController {
                         role,
                         workLocation,
                         statuses,
+                        hasPendingMyInfoRequest,
                         pageable);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(result));

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/dto/request/AdminUserUpdateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/dto/request/AdminUserUpdateRequestDto.java
@@ -1,5 +1,7 @@
 package kr.co.awesomelead.groupware_backend.domain.admin.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -43,6 +45,15 @@ public class AdminUserUpdateRequestDto {
 
     @Schema(description = "주소2", example = "어썸리드빌딩 5층")
     private String address2;
+
+    @JsonIgnore
+    @Schema(hidden = true)
+    private boolean address2Present;
+
+    public void setAddress2(String address2) {
+        this.address2 = address2;
+        this.address2Present = true;
+    }
 
     @Schema(description = "주민등록번호/외국인등록번호", example = "9001011234567")
     private String registrationNumber;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
@@ -213,6 +213,7 @@ public class AdminService {
             Role role,
             Company workLocation,
             List<Status> statuses,
+            Boolean hasPendingMyInfoRequest,
             Pageable pageable) {
         User admin =
                 userRepository
@@ -237,6 +238,7 @@ public class AdminService {
                         role,
                         workLocation,
                         statuses,
+                        hasPendingMyInfoRequest,
                         pageable)
                 .map(
                         u ->

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
@@ -295,8 +295,9 @@ public class AdminService {
         if (hasText(requestDto.getAddress1())) {
             user.setAddress1(requestDto.getAddress1().trim());
         }
-        if (hasText(requestDto.getAddress2())) {
-            user.setAddress2(requestDto.getAddress2().trim());
+        if (requestDto.isAddress2Present()) {
+            user.setAddress2(
+                    hasText(requestDto.getAddress2()) ? requestDto.getAddress2().trim() : null);
         }
 
         if (hasText(requestDto.getRegistrationNumber())) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/controller/AdminRequestHistoryController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/requesthistory/controller/AdminRequestHistoryController.java
@@ -92,7 +92,7 @@ public class AdminRequestHistoryController {
                                 {
                                   "isSuccess": false,
                                   "code": "NO_AUTHORITY_FOR_CERTIFICATE_REQUEST_REVIEW",
-                                  "message": "제증명 신청 승인/반려 권한이 없습니다.",
+                                  "message": "제증명 발급 관리 권한이 없습니다.",
                                   "result": null
                                 }
                                 """)))
@@ -182,7 +182,7 @@ public class AdminRequestHistoryController {
                                 {
                                   "isSuccess": false,
                                   "code": "NO_AUTHORITY_FOR_CERTIFICATE_REQUEST_REVIEW",
-                                  "message": "제증명 신청 승인/반려 권한이 없습니다.",
+                                  "message": "제증명 발급 관리 권한이 없습니다.",
                                   "result": null
                                 }
                                 """)))
@@ -235,7 +235,7 @@ public class AdminRequestHistoryController {
                                 {
                                   "isSuccess": false,
                                   "code": "NO_AUTHORITY_FOR_CERTIFICATE_REQUEST_REVIEW",
-                                  "message": "제증명 신청 승인/반려 권한이 없습니다.",
+                                  "message": "제증명 발급 관리 권한이 없습니다.",
                                   "result": null
                                 }
                                 """))),
@@ -301,7 +301,7 @@ public class AdminRequestHistoryController {
                                 {
                                   "isSuccess": false,
                                   "code": "NO_AUTHORITY_FOR_CERTIFICATE_REQUEST_REVIEW",
-                                  "message": "제증명 신청 승인/반려 권한이 없습니다.",
+                                  "message": "제증명 발급 관리 권한이 없습니다.",
                                   "result": null
                                 }
                                 """))),

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/enums/Authority.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/enums/Authority.java
@@ -18,7 +18,7 @@ public enum Authority {
     MANAGE_VISITOR("내방객 관리"),
 
     EDIT_EMPLOYEE_INFO("직원 정보 수정"), // 연차, 급여명세서, 근태확인표 발송 권한
-청    MANAGE_CERTIFICATE_REQUEST("제증명 발급 관리"),
+    MANAGE_CERTIFICATE_REQUEST("제증명 발급 관리"),
     MANAGE_APPROVAL_LINE("결재선 설정 관리");
 
     private final String description;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/enums/Authority.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/enums/Authority.java
@@ -18,7 +18,7 @@ public enum Authority {
     MANAGE_VISITOR("내방객 관리"),
 
     EDIT_EMPLOYEE_INFO("직원 정보 수정"), // 연차, 급여명세서, 근태확인표 발송 권한
-    MANAGE_CERTIFICATE_REQUEST("제증명 신청 승인/반려"),
+청    MANAGE_CERTIFICATE_REQUEST("제증명 발급 관리"),
     MANAGE_APPROVAL_LINE("결재선 설정 관리");
 
     private final String description;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/querydsl/UserQueryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/repository/querydsl/UserQueryRepository.java
@@ -1,14 +1,17 @@
 package kr.co.awesomelead.groupware_backend.domain.user.repository.querydsl;
 
+import static kr.co.awesomelead.groupware_backend.domain.user.entity.QMyInfoUpdateRequest.myInfoUpdateRequest;
 import static kr.co.awesomelead.groupware_backend.domain.user.entity.QUser.user;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import kr.co.awesomelead.groupware_backend.domain.department.entity.QDepartment;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.JobType;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.MyInfoUpdateRequestStatus;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
@@ -108,6 +111,7 @@ public class UserQueryRepository {
             Role role,
             Company workLocation,
             List<Status> statuses,
+            Boolean hasPendingMyInfoRequest,
             Pageable pageable) {
         List<User> content =
                 queryFactory
@@ -122,6 +126,7 @@ public class UserQueryRepository {
                                 roleFilter(role),
                                 workLocationFilter(workLocation),
                                 adminStatusFilter(statuses),
+                                pendingMyInfoRequestFilter(hasPendingMyInfoRequest),
                                 excludeMasterAdmin())
                         .orderBy(user.id.desc())
                         .offset(pageable.getOffset())
@@ -143,6 +148,7 @@ public class UserQueryRepository {
                                         roleFilter(role),
                                         workLocationFilter(workLocation),
                                         adminStatusFilter(statuses),
+                                        pendingMyInfoRequestFilter(hasPendingMyInfoRequest),
                                         excludeMasterAdmin())
                                 .fetchOne());
     }
@@ -177,6 +183,22 @@ public class UserQueryRepository {
             return null;
         }
         return user.status.in(statuses);
+    }
+
+    private BooleanExpression pendingMyInfoRequestFilter(Boolean hasPendingMyInfoRequest) {
+        if (hasPendingMyInfoRequest == null) {
+            return null;
+        }
+
+        BooleanExpression existsPendingRequest =
+                JPAExpressions.selectOne()
+                        .from(myInfoUpdateRequest)
+                        .where(
+                                myInfoUpdateRequest.user.eq(user),
+                                myInfoUpdateRequest.status.eq(MyInfoUpdateRequestStatus.PENDING))
+                        .exists();
+
+        return hasPendingMyInfoRequest ? existsPendingRequest : existsPendingRequest.not();
     }
 
     private BooleanExpression keywordFilter(String keyword) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/response/MyVisitListResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/response/MyVisitListResponseDto.java
@@ -2,6 +2,7 @@ package kr.co.awesomelead.groupware_backend.domain.visit.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitPurpose;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitStatus;
 
 import lombok.AllArgsConstructor;
@@ -28,6 +29,9 @@ public class MyVisitListResponseDto {
 
     @Schema(description = "내방객 회사명", example = "어썸리드")
     private String visitorCompany;
+
+    @Schema(description = "방문 목적", example = "MEETING")
+    private VisitPurpose purpose;
 
     @Schema(description = "방문 시작일", example = "2024-07-01")
     private LocalDate startDate;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/mapper/VisitMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/mapper/VisitMapper.java
@@ -111,6 +111,7 @@ public interface VisitMapper {
     List<VisitHostResponseDto> toVisitHostResponseDtoList(List<VisitHost> visitHosts);
 
     @Mapping(target = "visitId", source = "id")
+    @Mapping(target = "purpose", source = "purpose")
     MyVisitListResponseDto toMyVisitListResponseDto(Visit visit);
 
     List<MyVisitListResponseDto> toMyVisitListResponseDtoList(List<Visit> visits);

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
@@ -112,7 +112,7 @@ public enum ErrorCode {
     NO_AUTHORITY_FOR_ROLE_UPDATE(HttpStatus.FORBIDDEN, "사용자 역할 변경 권한이 없습니다."),
     NO_AUTHORITY_FOR_VIEW_PAYSLIP(HttpStatus.FORBIDDEN, "급여명세서 조회 권한이 없습니다."),
     NO_AUTHORITY_FOR_NOTIFICATION(HttpStatus.FORBIDDEN, "해당 알림에 대한 접근 권한이 없습니다."),
-    NO_AUTHORITY_FOR_CERTIFICATE_REQUEST_REVIEW(HttpStatus.FORBIDDEN, "제증명 신청 승인/반려 권한이 없습니다."),
+    NO_AUTHORITY_FOR_CERTIFICATE_REQUEST_REVIEW(HttpStatus.FORBIDDEN, "제증명 발급 관리 권한이 없습니다."),
     NO_AUTHORITY_FOR_EDUCATION_CATEGORY_MANAGE(HttpStatus.FORBIDDEN, "교육 카테고리 관리 권한이 없습니다."),
     NO_AUTHORITY_FOR_APPROVAL_CONFIG(HttpStatus.FORBIDDEN, "결재선 설정 관리 권한이 없습니다."),
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
@@ -453,17 +453,42 @@ class AdminServiceTest {
             when(myInfoUpdateRequestRepository.findDistinctUserIdsByStatus(any()))
                     .thenReturn(List.of());
             when(userQueryRepository.findAllForAdminWithFilters(
-                            null, null, null, null, null, null, (List<Status>) null, null, pageable))
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            (List<Status>) null,
+                            null,
+                            pageable))
                     .thenReturn(Page.empty());
 
             // when
             adminService.getUsers(
-                    adminId, null, null, null, null, null, null, (List<Status>) null, null, pageable);
+                    adminId,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    (List<Status>) null,
+                    null,
+                    pageable);
 
             // then
             verify(userQueryRepository)
                     .findAllForAdminWithFilters(
-                            null, null, null, null, null, null, (List<Status>) null, null, pageable);
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            (List<Status>) null,
+                            null,
+                            pageable);
         }
 
         @Test
@@ -694,11 +719,7 @@ class AdminServiceTest {
         void it_clears_address2_when_blank() {
             // given
             User targetUser =
-                    User.builder()
-                            .id(17L)
-                            .phoneNumber("01011112222")
-                            .address2("어썸리드빌딩 5층")
-                            .build();
+                    User.builder().id(17L).phoneNumber("01011112222").address2("어썸리드빌딩 5층").build();
             targetUser.setPhoneNumberHash(User.hashValue("01011112222"));
             when(userRepository.findById(17L)).thenReturn(Optional.of(targetUser));
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
@@ -385,6 +385,7 @@ class AdminServiceTest {
                             Role.USER,
                             null,
                             null,
+                            null,
                             pageable))
                     .thenReturn(userPage);
             when(myInfoUpdateRequestRepository.findDistinctUserIdsByStatus(
@@ -400,6 +401,7 @@ class AdminServiceTest {
                             11L,
                             JobType.MANAGEMENT,
                             Role.USER,
+                            null,
                             null,
                             null,
                             pageable);
@@ -436,6 +438,7 @@ class AdminServiceTest {
                                             null,
                                             null,
                                             null,
+                                            null,
                                             PageRequest.of(0, 20)))
                     .isInstanceOf(CustomException.class)
                     .extracting("errorCode")
@@ -450,17 +453,17 @@ class AdminServiceTest {
             when(myInfoUpdateRequestRepository.findDistinctUserIdsByStatus(any()))
                     .thenReturn(List.of());
             when(userQueryRepository.findAllForAdminWithFilters(
-                            null, null, null, null, null, null, (List<Status>) null, pageable))
+                            null, null, null, null, null, null, (List<Status>) null, null, pageable))
                     .thenReturn(Page.empty());
 
             // when
             adminService.getUsers(
-                    adminId, null, null, null, null, null, null, (List<Status>) null, pageable);
+                    adminId, null, null, null, null, null, null, (List<Status>) null, null, pageable);
 
             // then
             verify(userQueryRepository)
                     .findAllForAdminWithFilters(
-                            null, null, null, null, null, null, (List<Status>) null, pageable);
+                            null, null, null, null, null, null, (List<Status>) null, null, pageable);
         }
 
         @Test
@@ -471,16 +474,17 @@ class AdminServiceTest {
             when(myInfoUpdateRequestRepository.findDistinctUserIdsByStatus(any()))
                     .thenReturn(List.of());
             when(userQueryRepository.findAllForAdminWithFilters(
-                            null, null, null, null, null, null, List.of(), pageable))
+                            null, null, null, null, null, null, List.of(), null, pageable))
                     .thenReturn(Page.empty());
 
             // when
-            adminService.getUsers(adminId, null, null, null, null, null, null, List.of(), pageable);
+            adminService.getUsers(
+                    adminId, null, null, null, null, null, null, List.of(), null, pageable);
 
             // then
             verify(userQueryRepository)
                     .findAllForAdminWithFilters(
-                            null, null, null, null, null, null, List.of(), pageable);
+                            null, null, null, null, null, null, List.of(), null, pageable);
         }
 
         @Test
@@ -492,16 +496,17 @@ class AdminServiceTest {
             when(myInfoUpdateRequestRepository.findDistinctUserIdsByStatus(any()))
                     .thenReturn(List.of());
             when(userQueryRepository.findAllForAdminWithFilters(
-                            null, null, null, null, null, null, statuses, pageable))
+                            null, null, null, null, null, null, statuses, null, pageable))
                     .thenReturn(Page.empty());
 
             // when
-            adminService.getUsers(adminId, null, null, null, null, null, null, statuses, pageable);
+            adminService.getUsers(
+                    adminId, null, null, null, null, null, null, statuses, null, pageable);
 
             // then
             verify(userQueryRepository)
                     .findAllForAdminWithFilters(
-                            null, null, null, null, null, null, statuses, pageable);
+                            null, null, null, null, null, null, statuses, null, pageable);
         }
 
         @Test
@@ -513,16 +518,38 @@ class AdminServiceTest {
             when(myInfoUpdateRequestRepository.findDistinctUserIdsByStatus(any()))
                     .thenReturn(List.of());
             when(userQueryRepository.findAllForAdminWithFilters(
-                            null, null, null, null, null, null, statuses, pageable))
+                            null, null, null, null, null, null, statuses, null, pageable))
                     .thenReturn(Page.empty());
 
             // when
-            adminService.getUsers(adminId, null, null, null, null, null, null, statuses, pageable);
+            adminService.getUsers(
+                    adminId, null, null, null, null, null, null, statuses, null, pageable);
 
             // then
             verify(userQueryRepository)
                     .findAllForAdminWithFilters(
-                            null, null, null, null, null, null, statuses, pageable);
+                            null, null, null, null, null, null, statuses, null, pageable);
+        }
+
+        @Test
+        @DisplayName("hasPendingMyInfoRequest 필터를 repository에 전달한다")
+        void getUsers_hasPendingMyInfoRequest를_repository에_전달한다() {
+            // given
+            Pageable pageable = PageRequest.of(0, 20);
+            when(myInfoUpdateRequestRepository.findDistinctUserIdsByStatus(any()))
+                    .thenReturn(List.of());
+            when(userQueryRepository.findAllForAdminWithFilters(
+                            null, null, null, null, null, null, null, true, pageable))
+                    .thenReturn(Page.empty());
+
+            // when
+            adminService.getUsers(
+                    adminId, null, null, null, null, null, null, null, true, pageable);
+
+            // then
+            verify(userQueryRepository)
+                    .findAllForAdminWithFilters(
+                            null, null, null, null, null, null, null, true, pageable);
         }
     }
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
@@ -634,6 +634,58 @@ class AdminServiceTest {
         }
 
         @Test
+        @DisplayName("address2를 null로 명시하면 상세주소를 삭제한다")
+        void it_clears_address2_when_explicit_null() {
+            // given
+            User targetUser =
+                    User.builder()
+                            .id(17L)
+                            .phoneNumber("01011112222")
+                            .zipcode("06234")
+                            .address1("서울특별시 강남구 테헤란로 123")
+                            .address2("어썸리드빌딩 5층")
+                            .build();
+            targetUser.setPhoneNumberHash(User.hashValue("01011112222"));
+            when(userRepository.findById(17L)).thenReturn(Optional.of(targetUser));
+
+            AdminUserUpdateRequestDto dto = new AdminUserUpdateRequestDto();
+            dto.setZipcode("06234");
+            dto.setAddress1("서울특별시 강남구 테헤란로 1234");
+            dto.setAddress2(null);
+
+            // when
+            adminService.updateUserInfo(17L, dto, adminId);
+
+            // then
+            assertThat(targetUser.getZipcode()).isEqualTo("06234");
+            assertThat(targetUser.getAddress1()).isEqualTo("서울특별시 강남구 테헤란로 1234");
+            assertThat(targetUser.getAddress2()).isNull();
+        }
+
+        @Test
+        @DisplayName("address2를 빈 문자열로 명시하면 상세주소를 삭제한다")
+        void it_clears_address2_when_blank() {
+            // given
+            User targetUser =
+                    User.builder()
+                            .id(17L)
+                            .phoneNumber("01011112222")
+                            .address2("어썸리드빌딩 5층")
+                            .build();
+            targetUser.setPhoneNumberHash(User.hashValue("01011112222"));
+            when(userRepository.findById(17L)).thenReturn(Optional.of(targetUser));
+
+            AdminUserUpdateRequestDto dto = new AdminUserUpdateRequestDto();
+            dto.setAddress2("");
+
+            // when
+            adminService.updateUserInfo(17L, dto, adminId);
+
+            // then
+            assertThat(targetUser.getAddress2()).isNull();
+        }
+
+        @Test
         @DisplayName("전화번호 인증이 안된 상태로 번호를 바꾸면 PHONE_NOT_VERIFIED 에러를 던진다")
         void it_throws_when_phone_not_verified() {
             // given

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/UserQueryRepositoryTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/UserQueryRepositoryTest.java
@@ -2,9 +2,12 @@ package kr.co.awesomelead.groupware_backend.domain.user;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import kr.co.awesomelead.groupware_backend.domain.user.entity.MyInfoUpdateRequest;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.MyInfoUpdateRequestStatus;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Role;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
+import kr.co.awesomelead.groupware_backend.domain.user.repository.MyInfoUpdateRequestRepository;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.querydsl.UserQueryRepository;
 
@@ -25,6 +28,7 @@ import java.util.List;
 class UserQueryRepositoryTest {
 
     @Autowired private UserRepository userRepository;
+    @Autowired private MyInfoUpdateRequestRepository myInfoUpdateRequestRepository;
     @Autowired private UserQueryRepository userQueryRepository;
 
     @Test
@@ -49,12 +53,56 @@ class UserQueryRepositoryTest {
         // when
         var result =
                 userQueryRepository.findAllForAdminWithFilters(
-                        null, null, null, null, null, null, null, PageRequest.of(0, 20));
+                        null, null, null, null, null, null, null, null, PageRequest.of(0, 20));
 
         // then
         assertThat(result.getContent())
                 .extracting(User::getRole)
                 .containsExactlyInAnyOrder(Role.USER, Role.ADMIN);
+    }
+
+    @Test
+    @DisplayName("findAllForAdminWithFilters 메서드는 개인정보 수정 승인 대기 여부로 필터링한다")
+    void findAllForAdminWithFilters_filters_by_pending_my_info_request() {
+        // given
+        User userWithPendingRequest =
+                userRepository.save(
+                        createUser(
+                                "pending-my-info@example.com",
+                                "수정요청사용자",
+                                "900109-1234567",
+                                "01099990000",
+                                Role.USER));
+        User userWithoutPendingRequest =
+                userRepository.save(
+                        createUser(
+                                "no-pending-my-info@example.com",
+                                "일반사용자",
+                                "900110-1234567",
+                                "01099990001",
+                                Role.USER));
+        myInfoUpdateRequestRepository.save(
+                MyInfoUpdateRequest.builder()
+                        .user(userWithPendingRequest)
+                        .requestedAddress1("서울시 강남구 테헤란로 456")
+                        .status(MyInfoUpdateRequestStatus.PENDING)
+                        .build());
+
+        // when
+        var pendingResult =
+                userQueryRepository.findAllForAdminWithFilters(
+                        null, null, null, null, null, null, null, true, PageRequest.of(0, 20));
+        var noPendingResult =
+                userQueryRepository.findAllForAdminWithFilters(
+                        null, null, null, null, null, null, null, false, PageRequest.of(0, 20));
+
+        // then
+        assertThat(pendingResult.getContent())
+                .extracting(User::getId)
+                .containsExactly(userWithPendingRequest.getId());
+        assertThat(noPendingResult.getContent())
+                .extracting(User::getId)
+                .containsExactly(userWithoutPendingRequest.getId());
     }
 
     @Test

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
@@ -377,6 +377,7 @@ public class VisitServiceTest {
                 // given
                 VisitSearchRequestDto dto = new VisitSearchRequestDto("홍길동", "01012345678", "1234");
                 Visit visit = createBaseVisit(VisitStatus.NOT_VISITED, VisitCategory.PRE_ONE_DAY);
+                visit.setPurpose(VisitPurpose.MEETING);
                 given(
                                 visitRepository.findByVisitorNameAndPhoneNumberHashOrderByIdDesc(
                                         dto.getName(), Visit.hashValue(dto.getPhoneNumber())))
@@ -401,6 +402,7 @@ public class VisitServiceTest {
                 // given
                 VisitSearchRequestDto dto = new VisitSearchRequestDto("홍길동", "01012345678", "1234");
                 Visit visit = createBaseVisit(VisitStatus.NOT_VISITED, VisitCategory.PRE_ONE_DAY);
+                visit.setPurpose(VisitPurpose.MEETING);
                 given(
                                 visitRepository.findByVisitorNameAndPhoneNumberHashOrderByIdDesc(
                                         dto.getName(), Visit.hashValue(dto.getPhoneNumber())))
@@ -413,6 +415,7 @@ public class VisitServiceTest {
 
                 // then
                 assertThat(result).hasSize(1);
+                assertThat(result.get(0).getPurpose()).isEqualTo(VisitPurpose.MEETING);
             }
         }
     }


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #485 

## 📝작업 내용
- `POST /api/visits/my` 내 방문 목록 조회 응답에 `purpose`를 추가했습니다.
- `PATCH /api/admin/users/{userId}` 직원 정보 수정 시 `address2`를 `null` 또는 빈 문자열로 보내면 상세주소가 삭제되도록 수정했습니다.
- `GET /api/admin/users` 직원 목록 조회에 `hasPendingMyInfoRequest` 필터를 추가했습니다.
  - `true`: 개인정보 수정 승인 대기 요청이 있는 직원만 조회
  - `false`: 개인정보 수정 승인 대기 요청이 없는 직원만 조회
- `제증명 신청 승인/반려` 권한 표시 문구를 `제증명 발급 관리`로 수정했습니다.

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [X] 테스트 코드를 작성함
- [X] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X