### PR TITLE
fix(487): 안전보건 교육일지 첨부파일 등록 및 상세 조회 추가

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/controller/SafetyTrainingSessionController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/controller/SafetyTrainingSessionController.java
@@ -1,14 +1,21 @@
 package kr.co.awesomelead.groupware_backend.domain.safetytraining.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Encoding;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Valid;
+import jakarta.validation.Validator;
 
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.request.SafetyTrainingSessionCreateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.request.SafetyTrainingSessionSearchConditionDto;
@@ -22,6 +29,8 @@ import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.response.Sa
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.service.SafetyTrainingSessionService;
 import kr.co.awesomelead.groupware_backend.domain.user.dto.CustomUserDetails;
 import kr.co.awesomelead.groupware_backend.global.common.response.ApiResponse;
+import kr.co.awesomelead.groupware_backend.global.error.CustomException;
+import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -30,6 +39,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -44,6 +54,8 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Set;
 
 @RestController
 @RequiredArgsConstructor
@@ -76,6 +88,8 @@ import java.io.IOException;
 public class SafetyTrainingSessionController {
 
     private final SafetyTrainingSessionService safetyTrainingSessionService;
+    private final ObjectMapper objectMapper;
+    private final Validator validator;
 
     @Operation(
             summary = "안전보건 교육일지 목록 조회",
@@ -128,7 +142,8 @@ public class SafetyTrainingSessionController {
 
     @Operation(
             summary = "안전보건 교육일지 상세 조회",
-            description = "제목, 교육 정보(실시자 이름/직급/부서 포함), 엑셀 파일 URL, 내 수료/미수료 및 서명 가능 여부를 조회합니다.")
+            description =
+                    "제목, 교육 정보(실시자 이름/직급/부서 포함), 첨부파일 목록, 엑셀 파일 URL, 내 수료/미수료 및 서명 가능 여부를 조회합니다.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -784,13 +799,80 @@ public class SafetyTrainingSessionController {
                                 }
                                 """)))
             })
-    @PostMapping
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiResponse<Long>> create(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody SafetyTrainingSessionCreateRequestDto requestDto) {
 
         Long sessionId = safetyTrainingSessionService.create(userDetails.getId(), requestDto);
         return ResponseEntity.ok(ApiResponse.onSuccess(sessionId));
+    }
+
+    @Operation(
+            summary = "안전보건 교육일지 등록",
+            description =
+                    "안전 보건 관리 권한 사용자가 첨부파일을 포함해 교육일지를 등록합니다. 첨부파일은 상세 조회에서 제공되며 엑셀 파일에는 포함되지 않습니다.",
+            requestBody =
+                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                                            schema =
+                                                    @Schema(
+                                                            implementation =
+                                                                    SafetyTrainingSessionCreateMultipartRequestDoc
+                                                                            .class),
+                                            encoding = {
+                                                @Encoding(
+                                                        name = "request",
+                                                        contentType =
+                                                                MediaType.APPLICATION_JSON_VALUE),
+                                                @Encoding(
+                                                        name = "attachments",
+                                                        contentType = "*/*")
+                                            })))
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Long>> createWithAttachments(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(hidden = true)
+            @RequestPart("request") String request,
+            @Parameter(hidden = true)
+            @RequestPart(value = "attachments", required = false) List<MultipartFile> attachments)
+            throws IOException {
+
+        SafetyTrainingSessionCreateRequestDto requestDto = parseCreateRequest(request);
+        Long sessionId =
+                safetyTrainingSessionService.create(
+                        userDetails.getId(), requestDto, attachments);
+        return ResponseEntity.ok(ApiResponse.onSuccess(sessionId));
+    }
+
+    private SafetyTrainingSessionCreateRequestDto parseCreateRequest(String request) {
+        try {
+            SafetyTrainingSessionCreateRequestDto requestDto =
+                    objectMapper.readValue(request, SafetyTrainingSessionCreateRequestDto.class);
+            Set<ConstraintViolation<SafetyTrainingSessionCreateRequestDto>> violations =
+                    validator.validate(requestDto);
+            if (!violations.isEmpty()) {
+                throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+            }
+            return requestDto;
+        } catch (JsonProcessingException e) {
+            throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+        }
+    }
+
+    @Schema(
+            name = "SafetyTrainingSessionCreateMultipartRequestDoc",
+            description = "안전보건 교육일지 첨부파일 포함 등록 multipart 요청")
+    static class SafetyTrainingSessionCreateMultipartRequestDoc {
+
+        @Schema(description = "안전보건 교육일지 등록 요청(JSON 파트)", requiredMode = Schema.RequiredMode.REQUIRED)
+        public SafetyTrainingSessionCreateRequestDto request;
+
+        @ArraySchema(schema = @Schema(type = "string", format = "binary"))
+        public List<String> attachments;
     }
 
     @Operation(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/controller/SafetyTrainingSessionController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/controller/SafetyTrainingSessionController.java
@@ -828,23 +828,19 @@ public class SafetyTrainingSessionController {
                                                         name = "request",
                                                         contentType =
                                                                 MediaType.APPLICATION_JSON_VALUE),
-                                                @Encoding(
-                                                        name = "attachments",
-                                                        contentType = "*/*")
+                                                @Encoding(name = "attachments", contentType = "*/*")
                                             })))
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Long>> createWithAttachments(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
-            @Parameter(hidden = true)
-            @RequestPart("request") String request,
-            @Parameter(hidden = true)
-            @RequestPart(value = "attachments", required = false) List<MultipartFile> attachments)
+            @Parameter(hidden = true) @RequestPart("request") String request,
+            @Parameter(hidden = true) @RequestPart(value = "attachments", required = false)
+                    List<MultipartFile> attachments)
             throws IOException {
 
         SafetyTrainingSessionCreateRequestDto requestDto = parseCreateRequest(request);
         Long sessionId =
-                safetyTrainingSessionService.create(
-                        userDetails.getId(), requestDto, attachments);
+                safetyTrainingSessionService.create(userDetails.getId(), requestDto, attachments);
         return ResponseEntity.ok(ApiResponse.onSuccess(sessionId));
     }
 
@@ -868,7 +864,9 @@ public class SafetyTrainingSessionController {
             description = "안전보건 교육일지 첨부파일 포함 등록 multipart 요청")
     static class SafetyTrainingSessionCreateMultipartRequestDoc {
 
-        @Schema(description = "안전보건 교육일지 등록 요청(JSON 파트)", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(
+                description = "안전보건 교육일지 등록 요청(JSON 파트)",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         public SafetyTrainingSessionCreateRequestDto request;
 
         @ArraySchema(schema = @Schema(type = "string", format = "binary"))

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingSessionDetailResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingSessionDetailResponseDto.java
@@ -84,6 +84,9 @@ public class SafetyTrainingSessionDetailResponseDto {
     @Schema(description = "엑셀 파일 URL(확정본 생성 후)", example = "https://...presigned-url")
     private String reportFileUrl;
 
+    @Schema(description = "교육 첨부파일 목록")
+    private List<AttachmentItem> attachments;
+
     @Schema(description = "내 참석 상태", example = "SIGNED")
     private SafetyTrainingAttendeeStatus myAttendanceStatus;
 
@@ -127,5 +130,26 @@ public class SafetyTrainingSessionDetailResponseDto {
 
         @Schema(description = "작성일시", example = "2026-04-06T10:15:00")
         private LocalDateTime createdAt;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "안전보건 교육 첨부파일")
+    public static class AttachmentItem {
+
+        @Schema(description = "첨부파일 ID", example = "1")
+        private Long attachmentId;
+
+        @Schema(description = "원본 파일명", example = "교육자료.pdf")
+        private String fileName;
+
+        @Schema(description = "파일 URL", example = "https://...presigned-url")
+        private String fileUrl;
+
+        @Schema(description = "콘텐츠 타입", example = "application/pdf")
+        private String contentType;
+
+        @Schema(description = "파일 크기(byte)", example = "102400")
+        private long fileSize;
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/entity/SafetyTrainingSessionAttachment.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/entity/SafetyTrainingSessionAttachment.java
@@ -1,0 +1,45 @@
+package kr.co.awesomelead.groupware_backend.domain.safetytraining.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "safety_training_session_attachments")
+public class SafetyTrainingSessionAttachment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "session_id", nullable = false)
+    private SafetyTrainingSession session;
+
+    @Column(name = "original_file_name", nullable = false, length = 255)
+    private String originalFileName;
+
+    @Column(name = "file_key", nullable = false, length = 500)
+    private String fileKey;
+
+    @Column(name = "content_type", length = 100)
+    private String contentType;
+
+    @Column(name = "file_size", nullable = false)
+    private long fileSize;
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/repository/SafetyTrainingSessionAttachmentRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/repository/SafetyTrainingSessionAttachmentRepository.java
@@ -1,0 +1,15 @@
+package kr.co.awesomelead.groupware_backend.domain.safetytraining.repository;
+
+import kr.co.awesomelead.groupware_backend.domain.safetytraining.entity.SafetyTrainingSessionAttachment;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SafetyTrainingSessionAttachmentRepository
+        extends JpaRepository<SafetyTrainingSessionAttachment, Long> {
+
+    List<SafetyTrainingSessionAttachment> findAllBySessionIdOrderByIdAsc(Long sessionId);
+
+    void deleteBySessionId(Long sessionId);
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
@@ -779,8 +779,8 @@ public class SafetyTrainingSessionService {
         }
     }
 
-    private void saveAttachments(
-            SafetyTrainingSession session, List<MultipartFile> attachmentFiles) throws IOException {
+    private void saveAttachments(SafetyTrainingSession session, List<MultipartFile> attachmentFiles)
+            throws IOException {
         if (attachmentFiles == null || attachmentFiles.isEmpty()) {
             return;
         }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
@@ -14,11 +14,13 @@ import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.response.Sa
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.response.SafetyTrainingSessionReportResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.response.SafetyTrainingSessionSummaryResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.entity.SafetyTrainingSession;
+import kr.co.awesomelead.groupware_backend.domain.safetytraining.entity.SafetyTrainingSessionAttachment;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.entity.SafetyTrainingSessionAttendee;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.enums.SafetyEducationMethod;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.enums.SafetyTrainingAttendeeStatus;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.enums.SafetyTrainingCompletionStatus;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.enums.SafetyTrainingSessionStatus;
+import kr.co.awesomelead.groupware_backend.domain.safetytraining.repository.SafetyTrainingSessionAttachmentRepository;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.repository.SafetyTrainingSessionAttendeeRepository;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.repository.SafetyTrainingSessionRepository;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
@@ -44,6 +46,7 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -63,6 +66,7 @@ public class SafetyTrainingSessionService {
 
     private final SafetyTrainingSessionRepository sessionRepository;
     private final SafetyTrainingSessionAttendeeRepository attendeeRepository;
+    private final SafetyTrainingSessionAttachmentRepository attachmentRepository;
     private final UserRepository userRepository;
     private final ObjectMapper objectMapper;
     private final SafetyTrainingExcelService safetyTrainingExcelService;
@@ -110,6 +114,27 @@ public class SafetyTrainingSessionService {
 
     @Transactional
     public Long create(Long userId, SafetyTrainingSessionCreateRequestDto requestDto) {
+        try {
+            return createInternal(userId, requestDto, Collections.emptyList());
+        } catch (IOException e) {
+            throw new IllegalStateException("안전보건 교육 첨부파일 저장 중 오류가 발생했습니다.", e);
+        }
+    }
+
+    @Transactional(rollbackFor = IOException.class)
+    public Long create(
+            Long userId,
+            SafetyTrainingSessionCreateRequestDto requestDto,
+            List<MultipartFile> attachments)
+            throws IOException {
+        return createInternal(userId, requestDto, attachments);
+    }
+
+    private Long createInternal(
+            Long userId,
+            SafetyTrainingSessionCreateRequestDto requestDto,
+            List<MultipartFile> attachments)
+            throws IOException {
         User actor =
                 userRepository
                         .findById(userId)
@@ -155,6 +180,7 @@ public class SafetyTrainingSessionService {
                         .toList();
 
         attendeeRepository.saveAll(rows);
+        saveAttachments(saved, attachments);
 
         saved.setTargetCount(rows.size());
         saved.setAttendedCount(0);
@@ -253,6 +279,10 @@ public class SafetyTrainingSessionService {
                         : s3Service.getPresignedDownloadUrl(
                                 session.getReportFileKey(),
                                 buildExportFileName(session.getStartAt(), session.getTitle()));
+        List<SafetyTrainingSessionDetailResponseDto.AttachmentItem> attachments =
+                attachmentRepository.findAllBySessionIdOrderByIdAsc(sessionId).stream()
+                        .map(this::toAttachmentItem)
+                        .toList();
 
         SafetyTrainingSessionDetailResponseDto.SessionInfo prevSession =
                 findPrevSessionInfo(actor, session);
@@ -299,6 +329,7 @@ public class SafetyTrainingSessionService {
                 .absentCount(session.getAbsentCount())
                 .absentReasonSummary(session.getAbsentReasonSummary())
                 .reportFileUrl(reportFileUrl)
+                .attachments(attachments)
                 .myAttendanceStatus(myStatus)
                 .mySigned(
                         resolveMySigned(
@@ -728,6 +759,10 @@ public class SafetyTrainingSessionService {
 
         attendeeRepository.deleteBySessionId(sessionId);
         attendeeRepository.flush();
+        List<SafetyTrainingSessionAttachment> attachments =
+                attachmentRepository.findAllBySessionIdOrderByIdAsc(sessionId);
+        attachmentRepository.deleteBySessionId(sessionId);
+        attachmentRepository.flush();
         sessionRepository.delete(session);
 
         if (reportFileKey != null && !reportFileKey.isBlank()) {
@@ -739,6 +774,72 @@ public class SafetyTrainingSessionService {
                 safeDeleteFile(signatureKey);
             }
         }
+        for (SafetyTrainingSessionAttachment attachment : attachments) {
+            safeDeleteFile(attachment.getFileKey());
+        }
+    }
+
+    private void saveAttachments(
+            SafetyTrainingSession session, List<MultipartFile> attachmentFiles) throws IOException {
+        if (attachmentFiles == null || attachmentFiles.isEmpty()) {
+            return;
+        }
+
+        List<String> uploadedKeys = new ArrayList<>();
+        List<SafetyTrainingSessionAttachment> attachments = new ArrayList<>();
+        try {
+            for (MultipartFile file : attachmentFiles) {
+                if (isSkippableAttachment(file)) {
+                    continue;
+                }
+
+                String fileKey = s3Service.uploadFile(file);
+                uploadedKeys.add(fileKey);
+                attachments.add(
+                        SafetyTrainingSessionAttachment.builder()
+                                .session(session)
+                                .originalFileName(resolveOriginalFileName(file))
+                                .fileKey(fileKey)
+                                .contentType(file.getContentType())
+                                .fileSize(file.getSize())
+                                .build());
+            }
+
+            if (!attachments.isEmpty()) {
+                attachmentRepository.saveAll(attachments);
+            }
+        } catch (IOException | RuntimeException e) {
+            uploadedKeys.forEach(this::safeDeleteFile);
+            throw e;
+        }
+    }
+
+    private String resolveOriginalFileName(MultipartFile file) {
+        String originalFileName = file.getOriginalFilename();
+        return originalFileName == null || originalFileName.isBlank()
+                ? "attachment"
+                : originalFileName;
+    }
+
+    private boolean isSkippableAttachment(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            return true;
+        }
+
+        String originalFileName = file.getOriginalFilename();
+        String contentType = file.getContentType();
+        return "blob".equals(originalFileName) && "*/*".equals(contentType);
+    }
+
+    private SafetyTrainingSessionDetailResponseDto.AttachmentItem toAttachmentItem(
+            SafetyTrainingSessionAttachment attachment) {
+        return SafetyTrainingSessionDetailResponseDto.AttachmentItem.builder()
+                .attachmentId(attachment.getId())
+                .fileName(attachment.getOriginalFileName())
+                .fileUrl(s3Service.getPresignedViewUrl(attachment.getFileKey()))
+                .contentType(attachment.getContentType())
+                .fileSize(attachment.getFileSize())
+                .build();
     }
 
     private void validateSafetyWriteAuthority(User user) {

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/SafetyTrainingSessionServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/SafetyTrainingSessionServiceTest.java
@@ -1,9 +1,12 @@
 package kr.co.awesomelead.groupware_backend.domain.safetytraining;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -11,11 +14,20 @@ import static org.mockito.Mockito.when;
 
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
+import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.request.SafetyTrainingSessionCreateRequestDto;
+import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.response.SafetyTrainingSessionDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.entity.SafetyTrainingSession;
+import kr.co.awesomelead.groupware_backend.domain.safetytraining.entity.SafetyTrainingSessionAttachment;
+import kr.co.awesomelead.groupware_backend.domain.safetytraining.entity.SafetyTrainingSessionAttendee;
+import kr.co.awesomelead.groupware_backend.domain.safetytraining.enums.SafetyEducationMethod;
+import kr.co.awesomelead.groupware_backend.domain.safetytraining.enums.SafetyEducationType;
+import kr.co.awesomelead.groupware_backend.domain.safetytraining.enums.SafetyTrainingAttendeeStatus;
+import kr.co.awesomelead.groupware_backend.domain.safetytraining.repository.SafetyTrainingSessionAttachmentRepository;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.repository.SafetyTrainingSessionAttendeeRepository;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.repository.SafetyTrainingSessionRepository;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.service.SafetyTrainingSessionService;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
+import kr.co.awesomelead.groupware_backend.domain.user.enums.Authority;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Position;
 import kr.co.awesomelead.groupware_backend.domain.user.enums.Status;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
@@ -30,8 +42,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -41,6 +56,7 @@ class SafetyTrainingSessionServiceTest {
 
     @Mock private SafetyTrainingSessionRepository sessionRepository;
     @Mock private SafetyTrainingSessionAttendeeRepository attendeeRepository;
+    @Mock private SafetyTrainingSessionAttachmentRepository attachmentRepository;
     @Mock private UserRepository userRepository;
     @Mock private NotificationService notificationService;
     @Mock private com.fasterxml.jackson.databind.ObjectMapper objectMapper;
@@ -63,15 +79,172 @@ class SafetyTrainingSessionServiceTest {
 
     @BeforeEach
     void setUp() {
-        actor = User.builder().id(USER_ID).nameKor("작성자").build();
+        actor =
+                User.builder()
+                        .id(USER_ID)
+                        .nameKor("작성자")
+                        .workLocation(Company.AWESOME)
+                        .position(Position.STAFF)
+                        .build();
+        actor.addAuthority(Authority.MANAGE_SAFETY);
 
         session =
                 SafetyTrainingSession.builder()
                         .id(SESSION_ID)
                         .title("2024년 안전보건교육")
+                        .educationType(SafetyEducationType.REGULAR)
+                        .educationMethodsJson("[\"LECTURE\"]")
+                        .startAt(LocalDateTime.of(2026, 7, 2, 9, 0))
+                        .endAt(LocalDateTime.of(2026, 7, 2, 10, 0))
+                        .place("교육장")
                         .companyScope(Company.AWESOME)
+                        .instructorUser(actor)
+                        .instructorNameSnapshot("작성자")
                         .createdBy(actor)
                         .build();
+    }
+
+    @Nested
+    @DisplayName("create - 안전보건교육 세션 등록")
+    class Create {
+
+        @Test
+        @DisplayName("첨부파일이 있으면 S3 업로드 후 첨부파일 메타데이터를 저장한다")
+        void create_savesAttachments() throws Exception {
+            // given
+            SafetyTrainingSessionCreateRequestDto requestDto = createRequestDto();
+            MockMultipartFile attachment =
+                    new MockMultipartFile(
+                            "attachments",
+                            "교육자료.pdf",
+                            "application/pdf",
+                            "file-content".getBytes());
+
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(actor));
+            when(objectMapper.writeValueAsString(List.of(SafetyEducationMethod.LECTURE)))
+                    .thenReturn("[\"LECTURE\"]");
+            when(sessionRepository.save(any(SafetyTrainingSession.class)))
+                    .thenAnswer(
+                            invocation -> {
+                                SafetyTrainingSession saved = invocation.getArgument(0);
+                                saved.setId(SESSION_ID);
+                                return saved;
+                            });
+            when(userRepository.findAllByCompanyAndStatusExcludingPosition(
+                            Company.AWESOME, Status.AVAILABLE, Position.CEO))
+                    .thenReturn(List.of(actor));
+            when(s3Service.uploadFile(attachment)).thenReturn("safety-training/file-key.pdf");
+
+            // when
+            Long sessionId =
+                    safetyTrainingSessionService.create(USER_ID, requestDto, List.of(attachment));
+
+            // then
+            assertThat(sessionId).isEqualTo(SESSION_ID);
+            verify(attachmentRepository)
+                    .saveAll(
+                            argThat(
+                                    attachments -> {
+                                        SafetyTrainingSessionAttachment savedAttachment =
+                                                attachments.iterator().next();
+                                        assertThat(savedAttachment.getSession().getId())
+                                                .isEqualTo(SESSION_ID);
+                                        assertThat(savedAttachment.getOriginalFileName())
+                                                .isEqualTo("교육자료.pdf");
+                                        assertThat(savedAttachment.getFileKey())
+                                                .isEqualTo("safety-training/file-key.pdf");
+                                        assertThat(savedAttachment.getContentType())
+                                                .isEqualTo("application/pdf");
+                                        assertThat(savedAttachment.getFileSize()).isEqualTo(12);
+                                        return true;
+                                    }));
+        }
+
+        @Test
+        @DisplayName("Swagger가 파일 미첨부 시 보내는 blob placeholder는 첨부파일로 저장하지 않는다")
+        void create_ignoresSwaggerPlaceholderAttachment() throws Exception {
+            // given
+            SafetyTrainingSessionCreateRequestDto requestDto = createRequestDto();
+            MockMultipartFile placeholder =
+                    new MockMultipartFile(
+                            "attachments", "blob", "*/*", "string".getBytes());
+
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(actor));
+            when(objectMapper.writeValueAsString(List.of(SafetyEducationMethod.LECTURE)))
+                    .thenReturn("[\"LECTURE\"]");
+            when(sessionRepository.save(any(SafetyTrainingSession.class)))
+                    .thenAnswer(
+                            invocation -> {
+                                SafetyTrainingSession saved = invocation.getArgument(0);
+                                saved.setId(SESSION_ID);
+                                return saved;
+                            });
+            when(userRepository.findAllByCompanyAndStatusExcludingPosition(
+                            Company.AWESOME, Status.AVAILABLE, Position.CEO))
+                    .thenReturn(List.of(actor));
+
+            // when
+            Long sessionId =
+                    safetyTrainingSessionService.create(USER_ID, requestDto, List.of(placeholder));
+
+            // then
+            assertThat(sessionId).isEqualTo(SESSION_ID);
+            verify(s3Service, never()).uploadFile(placeholder);
+            verify(attachmentRepository, never()).saveAll(anyList());
+        }
+    }
+
+    @Nested
+    @DisplayName("getSessionDetail - 안전보건교육 상세 조회")
+    class GetSessionDetail {
+
+        @Test
+        @DisplayName("교육 첨부파일 목록과 조회 URL을 응답에 포함한다")
+        void getSessionDetail_returnsAttachments() {
+            // given
+            SafetyTrainingSessionAttachment attachment =
+                    SafetyTrainingSessionAttachment.builder()
+                            .id(3L)
+                            .session(session)
+                            .originalFileName("교육자료.pdf")
+                            .fileKey("safety-training/file-key.pdf")
+                            .contentType("application/pdf")
+                            .fileSize(1024L)
+                            .build();
+            SafetyTrainingSessionAttendee attendee =
+                    SafetyTrainingSessionAttendee.builder()
+                            .session(session)
+                            .user(actor)
+                            .status(SafetyTrainingAttendeeStatus.PENDING)
+                            .build();
+
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(actor));
+            when(sessionRepository.findById(SESSION_ID)).thenReturn(Optional.of(session));
+            when(attendeeRepository.findBySessionIdAndUserId(SESSION_ID, USER_ID))
+                    .thenReturn(Optional.of(attendee));
+            when(attachmentRepository.findAllBySessionIdOrderByIdAsc(SESSION_ID))
+                    .thenReturn(List.of(attachment));
+            when(s3Service.getPresignedViewUrl("safety-training/file-key.pdf"))
+                    .thenReturn("https://example.com/file-key.pdf");
+            when(sessionRepository.findFirstByIdGreaterThanOrderByIdAsc(SESSION_ID))
+                    .thenReturn(Optional.empty());
+            when(sessionRepository.findFirstByIdLessThanOrderByIdDesc(SESSION_ID))
+                    .thenReturn(Optional.empty());
+
+            // when
+            SafetyTrainingSessionDetailResponseDto response =
+                    safetyTrainingSessionService.getSessionDetail(SESSION_ID, USER_ID);
+
+            // then
+            assertThat(response.getAttachments()).hasSize(1);
+            SafetyTrainingSessionDetailResponseDto.AttachmentItem attachmentItem =
+                    response.getAttachments().get(0);
+            assertThat(attachmentItem.getAttachmentId()).isEqualTo(3L);
+            assertThat(attachmentItem.getFileName()).isEqualTo("교육자료.pdf");
+            assertThat(attachmentItem.getFileUrl()).isEqualTo("https://example.com/file-key.pdf");
+            assertThat(attachmentItem.getContentType()).isEqualTo("application/pdf");
+            assertThat(attachmentItem.getFileSize()).isEqualTo(1024L);
+        }
     }
 
     @Nested
@@ -197,5 +370,23 @@ class SafetyTrainingSessionServiceTest {
                     .sendSafetyTrainingSessionRemindAlertToAttendees(
                             eq(SESSION_ID), eq("2024년 안전보건교육"), eq(List.of(101L, 102L)));
         }
+    }
+
+    private SafetyTrainingSessionCreateRequestDto createRequestDto() {
+        SafetyTrainingSessionCreateRequestDto requestDto =
+                new SafetyTrainingSessionCreateRequestDto();
+        ReflectionTestUtils.setField(requestDto, "title", "2026년 안전보건교육");
+        ReflectionTestUtils.setField(requestDto, "educationType", SafetyEducationType.REGULAR);
+        ReflectionTestUtils.setField(
+                requestDto, "educationMethods", List.of(SafetyEducationMethod.LECTURE));
+        ReflectionTestUtils.setField(
+                requestDto, "startAt", LocalDateTime.of(2026, 7, 2, 9, 0));
+        ReflectionTestUtils.setField(
+                requestDto, "endAt", LocalDateTime.of(2026, 7, 2, 10, 0));
+        ReflectionTestUtils.setField(requestDto, "educationContent", "교육 내용");
+        ReflectionTestUtils.setField(requestDto, "place", "교육장");
+        ReflectionTestUtils.setField(requestDto, "instructorUserId", USER_ID);
+        ReflectionTestUtils.setField(requestDto, "companyScope", Company.AWESOME);
+        return requestDto;
     }
 }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/SafetyTrainingSessionServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/SafetyTrainingSessionServiceTest.java
@@ -166,8 +166,7 @@ class SafetyTrainingSessionServiceTest {
             // given
             SafetyTrainingSessionCreateRequestDto requestDto = createRequestDto();
             MockMultipartFile placeholder =
-                    new MockMultipartFile(
-                            "attachments", "blob", "*/*", "string".getBytes());
+                    new MockMultipartFile("attachments", "blob", "*/*", "string".getBytes());
 
             when(userRepository.findById(USER_ID)).thenReturn(Optional.of(actor));
             when(objectMapper.writeValueAsString(List.of(SafetyEducationMethod.LECTURE)))
@@ -379,10 +378,8 @@ class SafetyTrainingSessionServiceTest {
         ReflectionTestUtils.setField(requestDto, "educationType", SafetyEducationType.REGULAR);
         ReflectionTestUtils.setField(
                 requestDto, "educationMethods", List.of(SafetyEducationMethod.LECTURE));
-        ReflectionTestUtils.setField(
-                requestDto, "startAt", LocalDateTime.of(2026, 7, 2, 9, 0));
-        ReflectionTestUtils.setField(
-                requestDto, "endAt", LocalDateTime.of(2026, 7, 2, 10, 0));
+        ReflectionTestUtils.setField(requestDto, "startAt", LocalDateTime.of(2026, 7, 2, 9, 0));
+        ReflectionTestUtils.setField(requestDto, "endAt", LocalDateTime.of(2026, 7, 2, 10, 0));
         ReflectionTestUtils.setField(requestDto, "educationContent", "교육 내용");
         ReflectionTestUtils.setField(requestDto, "place", "교육장");
         ReflectionTestUtils.setField(requestDto, "instructorUserId", USER_ID);


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #487 

## 📝작업 내용
- 안전보건 교육일지 등록 시 첨부파일을 함께 업로드할 수 있도록 multipart 등록 API를 추가함.
- 첨부파일 정보를 저장하기 위한 `SafetyTrainingSessionAttachment` 엔티티와 Repository를 추가함.
- 안전보건 교육일지 상세 조회 응답에 첨부파일 목록을 추가하여 근로자가 서명 전 자료를 확인할 수 있도록 함.
- 교육일지 삭제 시 첨부파일 DB 데이터와 S3 파일도 함께 정리되도록 처리함.
- 첨부파일이 없는 요청도 정상 처리되도록 하고, Swagger의 파일 미선택 placeholder가 저장되지 않도록 방지함.
- 첨부파일은 엑셀 생성 결과에는 포함하지 않음.

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X