### PR TITLE
fix(487): 안전보건 교육일지 수정 시 첨부파일 선택 삭제 및 추가

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/controller/SafetyTrainingSessionController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/controller/SafetyTrainingSessionController.java
@@ -465,16 +465,13 @@ public class SafetyTrainingSessionController {
                                                         name = "request",
                                                         contentType =
                                                                 MediaType.APPLICATION_JSON_VALUE),
-                                                @Encoding(
-                                                        name = "attachments",
-                                                        contentType = "*/*")
+                                                @Encoding(name = "attachments", contentType = "*/*")
                                             })))
     @PatchMapping(value = "/{sessionId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Long>> updateWithAttachments(
             @PathVariable Long sessionId,
             @Parameter(hidden = true) @RequestPart("request") String request,
-            @Parameter(hidden = true)
-                    @RequestPart(value = "attachments", required = false)
+            @Parameter(hidden = true) @RequestPart(value = "attachments", required = false)
                     List<MultipartFile> attachments,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
             throws IOException {
@@ -482,10 +479,7 @@ public class SafetyTrainingSessionController {
         SafetyTrainingSessionUpdateRequestDto requestDto = parseUpdateRequest(request);
         Long updatedId =
                 safetyTrainingSessionService.update(
-                        sessionId,
-                        userDetails.getId(),
-                        requestDto,
-                        attachments);
+                        sessionId, userDetails.getId(), requestDto, attachments);
         return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
     }
 
@@ -944,7 +938,9 @@ public class SafetyTrainingSessionController {
             description = "안전보건 교육일지 첨부파일 포함 수정 multipart 요청")
     static class SafetyTrainingSessionUpdateMultipartRequestDoc {
 
-        @Schema(description = "안전보건 교육일지 수정 요청(JSON 파트)", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(
+                description = "안전보건 교육일지 수정 요청(JSON 파트)",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         public SafetyTrainingSessionUpdateRequestDto request;
 
         @ArraySchema(schema = @Schema(type = "string", format = "binary"))

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/controller/SafetyTrainingSessionController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/controller/SafetyTrainingSessionController.java
@@ -428,13 +428,64 @@ public class SafetyTrainingSessionController {
                         responseCode = "404",
                         description = "교육일지/사용자 없음")
             })
-    @PatchMapping("/{sessionId}")
+    @PatchMapping(value = "/{sessionId}", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiResponse<Long>> update(
             @PathVariable Long sessionId,
             @Valid @RequestBody SafetyTrainingSessionUpdateRequestDto requestDto,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long updatedId =
                 safetyTrainingSessionService.update(sessionId, userDetails.getId(), requestDto);
+        return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
+    }
+
+    @Operation(
+            summary = "안전보건 교육일지 수정",
+            description =
+                    """
+                    관리 권한(MANAGE_SAFETY) 사용자가 첨부파일을 포함해 교육일지를 수정합니다.
+                    OPEN 상태 + 서명 완료자 0명인 경우에만 수정 가능합니다.
+
+                    - `request.deleteAttachmentIds`로 기존 첨부파일을 삭제합니다.
+                    - `attachments`로 새 첨부파일을 추가합니다.
+                    - 둘 다 없으면 기존 첨부파일을 유지합니다.
+                    """,
+            requestBody =
+                    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            required = true,
+                            content =
+                                    @Content(
+                                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                                            schema =
+                                                    @Schema(
+                                                            implementation =
+                                                                    SafetyTrainingSessionUpdateMultipartRequestDoc
+                                                                            .class),
+                                            encoding = {
+                                                @Encoding(
+                                                        name = "request",
+                                                        contentType =
+                                                                MediaType.APPLICATION_JSON_VALUE),
+                                                @Encoding(
+                                                        name = "attachments",
+                                                        contentType = "*/*")
+                                            })))
+    @PatchMapping(value = "/{sessionId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Long>> updateWithAttachments(
+            @PathVariable Long sessionId,
+            @Parameter(hidden = true) @RequestPart("request") String request,
+            @Parameter(hidden = true)
+                    @RequestPart(value = "attachments", required = false)
+                    List<MultipartFile> attachments,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails)
+            throws IOException {
+
+        SafetyTrainingSessionUpdateRequestDto requestDto = parseUpdateRequest(request);
+        Long updatedId =
+                safetyTrainingSessionService.update(
+                        sessionId,
+                        userDetails.getId(),
+                        requestDto,
+                        attachments);
         return ResponseEntity.ok(ApiResponse.onSuccess(updatedId));
     }
 
@@ -859,6 +910,21 @@ public class SafetyTrainingSessionController {
         }
     }
 
+    private SafetyTrainingSessionUpdateRequestDto parseUpdateRequest(String request) {
+        try {
+            SafetyTrainingSessionUpdateRequestDto requestDto =
+                    objectMapper.readValue(request, SafetyTrainingSessionUpdateRequestDto.class);
+            Set<ConstraintViolation<SafetyTrainingSessionUpdateRequestDto>> violations =
+                    validator.validate(requestDto);
+            if (!violations.isEmpty()) {
+                throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+            }
+            return requestDto;
+        } catch (JsonProcessingException e) {
+            throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+        }
+    }
+
     @Schema(
             name = "SafetyTrainingSessionCreateMultipartRequestDoc",
             description = "안전보건 교육일지 첨부파일 포함 등록 multipart 요청")
@@ -868,6 +934,18 @@ public class SafetyTrainingSessionController {
                 description = "안전보건 교육일지 등록 요청(JSON 파트)",
                 requiredMode = Schema.RequiredMode.REQUIRED)
         public SafetyTrainingSessionCreateRequestDto request;
+
+        @ArraySchema(schema = @Schema(type = "string", format = "binary"))
+        public List<String> attachments;
+    }
+
+    @Schema(
+            name = "SafetyTrainingSessionUpdateMultipartRequestDoc",
+            description = "안전보건 교육일지 첨부파일 포함 수정 multipart 요청")
+    static class SafetyTrainingSessionUpdateMultipartRequestDoc {
+
+        @Schema(description = "안전보건 교육일지 수정 요청(JSON 파트)", requiredMode = Schema.RequiredMode.REQUIRED)
+        public SafetyTrainingSessionUpdateRequestDto request;
 
         @ArraySchema(schema = @Schema(type = "string", format = "binary"))
         public List<String> attachments;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/request/SafetyTrainingSessionUpdateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/request/SafetyTrainingSessionUpdateRequestDto.java
@@ -86,4 +86,7 @@ public class SafetyTrainingSessionUpdateRequestDto {
             example = "AWESOME",
             allowableValues = {"AWESOME", "MARUI"})
     private Company companyScope;
+
+    @Schema(description = "삭제할 첨부파일 ID 목록(선택)", example = "[1, 2]")
+    private List<Long> deleteAttachmentIds;
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
@@ -840,8 +840,7 @@ public class SafetyTrainingSessionService {
         }
     }
 
-    private void deleteAttachments(
-            SafetyTrainingSession session, List<Long> deleteAttachmentIds) {
+    private void deleteAttachments(SafetyTrainingSession session, List<Long> deleteAttachmentIds) {
         if (deleteAttachmentIds == null || deleteAttachmentIds.isEmpty()) {
             return;
         }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
@@ -583,6 +583,29 @@ public class SafetyTrainingSessionService {
     @Transactional
     public Long update(
             Long sessionId, Long userId, SafetyTrainingSessionUpdateRequestDto requestDto) {
+        try {
+            return updateInternal(sessionId, userId, requestDto, null);
+        } catch (IOException e) {
+            throw new IllegalStateException("안전보건 교육 첨부파일 저장 중 오류가 발생했습니다.", e);
+        }
+    }
+
+    @Transactional(rollbackFor = IOException.class)
+    public Long update(
+            Long sessionId,
+            Long userId,
+            SafetyTrainingSessionUpdateRequestDto requestDto,
+            List<MultipartFile> attachments)
+            throws IOException {
+        return updateInternal(sessionId, userId, requestDto, attachments);
+    }
+
+    private Long updateInternal(
+            Long sessionId,
+            Long userId,
+            SafetyTrainingSessionUpdateRequestDto requestDto,
+            List<MultipartFile> attachments)
+            throws IOException {
         User actor =
                 userRepository
                         .findById(userId)
@@ -644,6 +667,9 @@ public class SafetyTrainingSessionService {
         session.setAttendedCount(0);
         session.setAbsentCount(0);
         session.setAbsentReasonSummary(null);
+
+        deleteAttachments(session, requestDto.getDeleteAttachmentIds());
+        saveAttachments(session, attachments);
 
         return session.getId();
     }
@@ -811,6 +837,32 @@ public class SafetyTrainingSessionService {
         } catch (IOException | RuntimeException e) {
             uploadedKeys.forEach(this::safeDeleteFile);
             throw e;
+        }
+    }
+
+    private void deleteAttachments(
+            SafetyTrainingSession session, List<Long> deleteAttachmentIds) {
+        if (deleteAttachmentIds == null || deleteAttachmentIds.isEmpty()) {
+            return;
+        }
+
+        for (Long attachmentId : new java.util.LinkedHashSet<>(deleteAttachmentIds)) {
+            SafetyTrainingSessionAttachment attachment =
+                    attachmentRepository
+                            .findById(attachmentId)
+                            .orElseThrow(
+                                    () ->
+                                            new CustomException(
+                                                    ErrorCode
+                                                            .SAFETY_TRAINING_ATTACHMENT_NOT_FOUND));
+
+            if (attachment.getSession() == null
+                    || !attachment.getSession().getId().equals(session.getId())) {
+                throw new CustomException(ErrorCode.SAFETY_TRAINING_ATTACHMENT_NOT_FOUND);
+            }
+
+            attachmentRepository.delete(attachment);
+            safeDeleteFile(attachment.getFileKey());
         }
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
@@ -123,6 +123,7 @@ public enum ErrorCode {
     DEPARTMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 부서를 찾을 수 없습니다."),
     EDU_REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 교육 게시물을 찾을 수 없습니다."),
     EDU_ATTACHMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 교육 첨부파일을 찾을 수 없습니다."),
+    SAFETY_TRAINING_ATTACHMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 안전보건 교육일지 첨부파일을 찾을 수 없습니다."),
     NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 공지사항을 찾을 수 없습니다."),
     NOTICE_ATTACHMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 공지사항 첨부파일을 찾을 수 없습니다."),
     REQUEST_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 제증명 발급 신청 내역을 찾을 수 없습니다."),

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/SafetyTrainingSessionServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/SafetyTrainingSessionServiceTest.java
@@ -215,10 +215,7 @@ class SafetyTrainingSessionServiceTest {
                             .build();
             MockMultipartFile newAttachment =
                     new MockMultipartFile(
-                            "attachments",
-                            "새자료.pdf",
-                            "application/pdf",
-                            "new-file".getBytes());
+                            "attachments", "새자료.pdf", "application/pdf", "new-file".getBytes());
 
             when(userRepository.findById(USER_ID)).thenReturn(Optional.of(actor));
             when(sessionRepository.findById(SESSION_ID)).thenReturn(Optional.of(session));
@@ -458,10 +455,8 @@ class SafetyTrainingSessionServiceTest {
         ReflectionTestUtils.setField(requestDto, "educationType", SafetyEducationType.REGULAR);
         ReflectionTestUtils.setField(
                 requestDto, "educationMethods", List.of(SafetyEducationMethod.LECTURE));
-        ReflectionTestUtils.setField(
-                requestDto, "startAt", LocalDateTime.of(2026, 7, 2, 9, 0));
-        ReflectionTestUtils.setField(
-                requestDto, "endAt", LocalDateTime.of(2026, 7, 2, 10, 0));
+        ReflectionTestUtils.setField(requestDto, "startAt", LocalDateTime.of(2026, 7, 2, 9, 0));
+        ReflectionTestUtils.setField(requestDto, "endAt", LocalDateTime.of(2026, 7, 2, 10, 0));
         ReflectionTestUtils.setField(requestDto, "educationContent", "교육 내용 수정");
         ReflectionTestUtils.setField(requestDto, "place", "교육장");
         ReflectionTestUtils.setField(requestDto, "instructorUserId", USER_ID);

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/SafetyTrainingSessionServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/SafetyTrainingSessionServiceTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.request.SafetyTrainingSessionCreateRequestDto;
+import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.request.SafetyTrainingSessionUpdateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.response.SafetyTrainingSessionDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.entity.SafetyTrainingSession;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.entity.SafetyTrainingSessionAttachment;
@@ -190,6 +191,69 @@ class SafetyTrainingSessionServiceTest {
             assertThat(sessionId).isEqualTo(SESSION_ID);
             verify(s3Service, never()).uploadFile(placeholder);
             verify(attachmentRepository, never()).saveAll(anyList());
+        }
+    }
+
+    @Nested
+    @DisplayName("update - 안전보건교육 세션 수정")
+    class Update {
+
+        @Test
+        @DisplayName("deleteAttachmentIds로 기존 첨부파일을 삭제하고 새 첨부파일을 추가한다")
+        void update_deletesSelectedAttachmentsAndAddsNewAttachments() throws Exception {
+            // given
+            SafetyTrainingSessionUpdateRequestDto requestDto = updateRequestDto();
+            ReflectionTestUtils.setField(requestDto, "deleteAttachmentIds", List.of(1L));
+            SafetyTrainingSessionAttachment oldAttachment =
+                    SafetyTrainingSessionAttachment.builder()
+                            .id(1L)
+                            .session(session)
+                            .originalFileName("기존자료.pdf")
+                            .fileKey("safety-training/old-file.pdf")
+                            .contentType("application/pdf")
+                            .fileSize(100L)
+                            .build();
+            MockMultipartFile newAttachment =
+                    new MockMultipartFile(
+                            "attachments",
+                            "새자료.pdf",
+                            "application/pdf",
+                            "new-file".getBytes());
+
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(actor));
+            when(sessionRepository.findById(SESSION_ID)).thenReturn(Optional.of(session));
+            when(attendeeRepository.countBySessionIdAndStatus(
+                            SESSION_ID, SafetyTrainingAttendeeStatus.SIGNED))
+                    .thenReturn(0L);
+            when(objectMapper.writeValueAsString(List.of(SafetyEducationMethod.LECTURE)))
+                    .thenReturn("[\"LECTURE\"]");
+            when(userRepository.findAllByCompanyAndStatusExcludingPosition(
+                            Company.AWESOME, Status.AVAILABLE, Position.CEO))
+                    .thenReturn(List.of(actor));
+            when(attachmentRepository.findById(1L)).thenReturn(Optional.of(oldAttachment));
+            when(s3Service.uploadFile(newAttachment)).thenReturn("safety-training/new-file.pdf");
+
+            // when
+            Long updatedId =
+                    safetyTrainingSessionService.update(
+                            SESSION_ID, USER_ID, requestDto, List.of(newAttachment));
+
+            // then
+            assertThat(updatedId).isEqualTo(SESSION_ID);
+            verify(attachmentRepository).delete(oldAttachment);
+            verify(s3Service).deleteFile("safety-training/old-file.pdf");
+            verify(attachmentRepository)
+                    .saveAll(
+                            argThat(
+                                    attachments -> {
+                                        SafetyTrainingSessionAttachment savedAttachment =
+                                                attachments.iterator().next();
+                                        assertThat(savedAttachment.getOriginalFileName())
+                                                .isEqualTo("새자료.pdf");
+                                        assertThat(savedAttachment.getFileKey())
+                                                .isEqualTo("safety-training/new-file.pdf");
+                                        return true;
+                                    }));
         }
     }
 
@@ -381,6 +445,24 @@ class SafetyTrainingSessionServiceTest {
         ReflectionTestUtils.setField(requestDto, "startAt", LocalDateTime.of(2026, 7, 2, 9, 0));
         ReflectionTestUtils.setField(requestDto, "endAt", LocalDateTime.of(2026, 7, 2, 10, 0));
         ReflectionTestUtils.setField(requestDto, "educationContent", "교육 내용");
+        ReflectionTestUtils.setField(requestDto, "place", "교육장");
+        ReflectionTestUtils.setField(requestDto, "instructorUserId", USER_ID);
+        ReflectionTestUtils.setField(requestDto, "companyScope", Company.AWESOME);
+        return requestDto;
+    }
+
+    private SafetyTrainingSessionUpdateRequestDto updateRequestDto() {
+        SafetyTrainingSessionUpdateRequestDto requestDto =
+                new SafetyTrainingSessionUpdateRequestDto();
+        ReflectionTestUtils.setField(requestDto, "title", "2026년 안전보건교육 수정");
+        ReflectionTestUtils.setField(requestDto, "educationType", SafetyEducationType.REGULAR);
+        ReflectionTestUtils.setField(
+                requestDto, "educationMethods", List.of(SafetyEducationMethod.LECTURE));
+        ReflectionTestUtils.setField(
+                requestDto, "startAt", LocalDateTime.of(2026, 7, 2, 9, 0));
+        ReflectionTestUtils.setField(
+                requestDto, "endAt", LocalDateTime.of(2026, 7, 2, 10, 0));
+        ReflectionTestUtils.setField(requestDto, "educationContent", "교육 내용 수정");
         ReflectionTestUtils.setField(requestDto, "place", "교육장");
         ReflectionTestUtils.setField(requestDto, "instructorUserId", USER_ID);
         ReflectionTestUtils.setField(requestDto, "companyScope", Company.AWESOME);


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #487 

## 📝작업 내용
- 안전보건 교육일지 수정 시 첨부파일 선택 삭제 및 추가합니다.

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X