### PR TITLE
fix(490): 안전보건 교육일지 제목 검색을 부분일치로 변경

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/controller/SafetyTrainingSessionController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/controller/SafetyTrainingSessionController.java
@@ -96,7 +96,7 @@ public class SafetyTrainingSessionController {
             description =
                     "일반 사용자는 본인 회사 데이터를 조회할 수 있으며, MANAGE_SAFETY 권한 사용자는 전체 회사/상태 조회가 가능합니다. 각 교육일지"
                             + " 항목에 현재 로그인 사용자의 서명 완료 여부(mySigned)를 포함합니다."
-                            + " titleKeyword 파라미터로 제목 검색이 가능하며, MySQL FULLTEXT ngram 인덱스를 사용합니다.")
+                            + " titleKeyword 파라미터로 제목 부분일치 검색이 가능합니다.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/request/SafetyTrainingSessionSearchConditionDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/request/SafetyTrainingSessionSearchConditionDto.java
@@ -21,7 +21,7 @@ import java.time.LocalDateTime;
 @Schema(description = "안전보건 교육일지 목록 조회 필터")
 public class SafetyTrainingSessionSearchConditionDto {
 
-    @Schema(description = "제목 검색어 (MySQL FULLTEXT ngram 기반 검색)", example = "정기 안전보건")
+    @Schema(description = "제목 검색어 (부분일치 검색)", example = "정기 안전보건")
     private String titleKeyword;
 
     @Schema(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/repository/SafetyTrainingSessionRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/repository/SafetyTrainingSessionRepository.java
@@ -26,7 +26,7 @@ public interface SafetyTrainingSessionRepository
               AND (:status IS NULL OR s.status = :status)
               AND (:startAtFrom IS NULL OR s.startAt >= :startAtFrom)
               AND (:startAtTo IS NULL OR s.startAt <= :startAtTo)
-              AND (:titleKeyword IS NULL OR function('match_against', s.title, :titleKeyword) > 0)
+              AND (:titleKeyword IS NULL OR LOWER(s.title) LIKE LOWER(CONCAT('%', :titleKeyword, '%')))
             """)
     Page<SafetyTrainingSession> findAllByFilters(
             @Param("companyScope") Company companyScope,

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/config/MysqlFulltextIndexInitializer.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/config/MysqlFulltextIndexInitializer.java
@@ -30,10 +30,6 @@ public class MysqlFulltextIndexInitializer implements ApplicationRunner {
         }
 
         createFulltextIndexIfAbsent(
-                "safety_training_sessions",
-                "ft_sts_title",
-                "ALTER TABLE safety_training_sessions ADD FULLTEXT INDEX ft_sts_title (title)");
-        createFulltextIndexIfAbsent(
                 "users",
                 "ft_users_name_kor",
                 "ALTER TABLE users ADD FULLTEXT INDEX ft_users_name_kor (name_kor)");


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #490 

## 📝작업 내용
- 안전보건 교육일지 목록 조회의 `titleKeyword` 검색 조건을 FULLTEXT `MATCH AGAINST`에서 부분일치 검색으로 변경했습니다.
- `titleKeyword=제`처럼 한 글자 검색어도 제목에 포함되어 있으면 조회되도록 수정했습니다.
- Swagger/DTO의 검색 설명에서 FULLTEXT/ngram 문구를 제거하고 부분일치 검색 설명으로 변경했습니다.
- 더 이상 사용하지 않는 안전보건 교육일지 제목 FULLTEXT 인덱스 자동 생성 로직을 제거했습니다.

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X