### PR TITLE
fix(492): 상세주소 빈값 처리 일관화

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/dto/request/UserApprovalRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/dto/request/UserApprovalRequestDto.java
@@ -1,5 +1,7 @@
 package kr.co.awesomelead.groupware_backend.domain.admin.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -42,8 +44,17 @@ public class UserApprovalRequestDto {
     @Schema(description = "주소1", example = "서울특별시 강남구 테헤란로 123")
     private String address1;
 
-    @Schema(description = "주소2", example = "어썸리드빌딩 5층")
+    @Schema(description = "주소2 (null 또는 빈 문자열로 보내면 삭제)", example = "어썸리드빌딩 5층")
     private String address2;
+
+    @JsonIgnore
+    @Schema(hidden = true)
+    private boolean address2Present;
+
+    public void setAddress2(String address2) {
+        this.address2 = address2;
+        this.address2Present = true;
+    }
 
     @Schema(description = "주민등록번호/외국인등록번호", example = "9001011234567")
     private String registrationNumber;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
@@ -479,7 +479,7 @@ public class AdminService {
         if (request.getRequestedAddress1() != null) {
             targetUser.setAddress1(request.getRequestedAddress1());
         }
-        if (request.getRequestedAddress2() != null) {
+        if (request.isRequestedAddress2Present()) {
             targetUser.setAddress2(request.getRequestedAddress2());
         }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
@@ -98,8 +98,9 @@ public class AdminService {
         if (hasText(requestDto.getAddress1())) {
             user.setAddress1(requestDto.getAddress1().trim());
         }
-        if (hasText(requestDto.getAddress2())) {
-            user.setAddress2(requestDto.getAddress2().trim());
+        if (requestDto.isAddress2Present()) {
+            user.setAddress2(
+                    hasText(requestDto.getAddress2()) ? requestDto.getAddress2().trim() : null);
         }
 
         if (hasText(requestDto.getRegistrationNumber())) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/auth/service/AuthService.java
@@ -124,6 +124,7 @@ public class AuthService {
         // Mapper에서 처리 안 되는 필드만 설정
         user.setNameKor(joinDto.getNameKor().trim());
         user.setNameEng(joinDto.getNameEng().trim());
+        user.setAddress2(normalizeOptionalText(joinDto.getAddress2()));
         user.setPassword(bCryptPasswordEncoder.encode(joinDto.getPassword()));
 
         // 7. DB에 저장
@@ -150,6 +151,10 @@ public class AuthService {
         if (userRepository.existsByPhoneNumberHash(User.hashValue(phoneNumber))) {
             throw new CustomException(ErrorCode.DUPLICATE_PHONE_NUMBER);
         }
+    }
+
+    private String normalizeOptionalText(String value) {
+        return value != null && !value.isBlank() ? value.trim() : null;
     }
 
     private void validateEmailNotDuplicated(String email) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/controller/UserController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/controller/UserController.java
@@ -293,7 +293,8 @@ public class UserController {
             summary = "내 정보 수정",
             description =
                     "내 정보 수정 요청을 생성합니다. 요청은 관리자 승인 후 반영됩니다. "
-                            + "수정 가능 필드: 영문 이름, 전화번호, 우편번호, 주소1, 주소2")
+                            + "수정 가능 필드: 영문 이름, 전화번호, 우편번호, 주소1, 주소2. "
+                            + "address2는 null 또는 빈 문자열로 보내면 삭제 요청으로 처리됩니다.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/dto/response/UpdateMyInfoRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/dto/response/UpdateMyInfoRequestDto.java
@@ -1,5 +1,7 @@
 package kr.co.awesomelead.groupware_backend.domain.user.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import jakarta.validation.constraints.Pattern;
@@ -29,7 +31,16 @@ public class UpdateMyInfoRequestDto {
     @Size(max = 255, message = "주소1은 최대 255자까지 입력 가능합니다.")
     private String address1;
 
-    @Schema(description = "주소2", example = "어썸리드빌딩 5층")
+    @Schema(description = "주소2 (null 또는 빈 문자열로 보내면 삭제 요청)", example = "어썸리드빌딩 5층")
     @Size(max = 255, message = "주소2는 최대 255자까지 입력 가능합니다.")
     private String address2;
+
+    @JsonIgnore
+    @Schema(hidden = true)
+    private boolean address2Present;
+
+    public void setAddress2(String address2) {
+        this.address2 = address2;
+        this.address2Present = true;
+    }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/entity/MyInfoUpdateRequest.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/entity/MyInfoUpdateRequest.java
@@ -64,6 +64,9 @@ public class MyInfoUpdateRequest extends BaseTimeEntity {
     @Convert(converter = Encryptor.class)
     private String requestedAddress2;
 
+    @Builder.Default
+    private boolean requestedAddress2Present = false;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     @Builder.Default

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/entity/MyInfoUpdateRequest.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/entity/MyInfoUpdateRequest.java
@@ -64,8 +64,7 @@ public class MyInfoUpdateRequest extends BaseTimeEntity {
     @Convert(converter = Encryptor.class)
     private String requestedAddress2;
 
-    @Builder.Default
-    private boolean requestedAddress2Present = false;
+    @Builder.Default private boolean requestedAddress2Present = false;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserService.java
@@ -34,6 +34,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -77,6 +78,7 @@ public class UserService {
         String requestedZipcode = null;
         String requestedAddress1 = null;
         String requestedAddress2 = null;
+        boolean requestedAddress2Present = false;
 
         if (hasText(requestDto.getNameEng())) {
             requestedNameEng = requestDto.getNameEng().trim();
@@ -112,9 +114,11 @@ public class UserService {
                 requestedAddress1 = null;
             }
         }
-        if (hasText(requestDto.getAddress2())) {
-            requestedAddress2 = requestDto.getAddress2().trim();
-            if (requestedAddress2.equals(user.getAddress2())) {
+        if (requestDto.isAddress2Present()) {
+            requestedAddress2 =
+                    hasText(requestDto.getAddress2()) ? requestDto.getAddress2().trim() : null;
+            requestedAddress2Present = !Objects.equals(requestedAddress2, user.getAddress2());
+            if (!requestedAddress2Present) {
                 requestedAddress2 = null;
             }
         }
@@ -123,7 +127,7 @@ public class UserService {
                 && requestedPhoneNumber == null
                 && requestedZipcode == null
                 && requestedAddress1 == null
-                && requestedAddress2 == null) {
+                && !requestedAddress2Present) {
             throw new CustomException(ErrorCode.MY_INFO_UPDATE_NO_CHANGES);
         }
 
@@ -136,6 +140,7 @@ public class UserService {
                         .requestedZipcode(requestedZipcode)
                         .requestedAddress1(requestedAddress1)
                         .requestedAddress2(requestedAddress2)
+                        .requestedAddress2Present(requestedAddress2Present)
                         .status(MyInfoUpdateRequestStatus.PENDING)
                         .build();
         MyInfoUpdateRequest saved = myInfoUpdateRequestRepository.save(request);

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
@@ -1101,8 +1101,7 @@ class AdminServiceTest {
         @DisplayName("관리자가 address2 삭제 요청을 승인하면 상세주소가 삭제된다")
         void approveMyInfoUpdate_clearsAddress2() {
             // given
-            User targetUser =
-                    User.builder().id(userId).address2("어썸리드빌딩 5층").build();
+            User targetUser = User.builder().id(userId).address2("어썸리드빌딩 5층").build();
             MyInfoUpdateRequest request =
                     MyInfoUpdateRequest.builder()
                             .id(10L)

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
@@ -1054,6 +1054,33 @@ class AdminServiceTest {
         }
 
         @Test
+        @DisplayName("관리자가 address2 삭제 요청을 승인하면 상세주소가 삭제된다")
+        void approveMyInfoUpdate_clearsAddress2() {
+            // given
+            User targetUser =
+                    User.builder().id(userId).address2("어썸리드빌딩 5층").build();
+            MyInfoUpdateRequest request =
+                    MyInfoUpdateRequest.builder()
+                            .id(10L)
+                            .user(targetUser)
+                            .requestedAddress2(null)
+                            .requestedAddress2Present(true)
+                            .status(MyInfoUpdateRequestStatus.PENDING)
+                            .build();
+
+            when(myInfoUpdateRequestRepository.findById(10L)).thenReturn(Optional.of(request));
+
+            // when
+            adminService.approveMyInfoUpdate(10L, adminId);
+
+            // then
+            assertThat(targetUser.getAddress2()).isNull();
+            assertThat(request.getStatus()).isEqualTo(MyInfoUpdateRequestStatus.APPROVED);
+            verify(userRepository).save(targetUser);
+            verify(myInfoUpdateRequestRepository).save(request);
+        }
+
+        @Test
         @DisplayName("관리자가 반려하면 요청 상태가 REJECTED로 바뀐다")
         void rejectMyInfoUpdate_success() {
             // given

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
@@ -120,6 +120,50 @@ class AdminServiceTest {
             }
 
             @Test
+            @DisplayName("address2를 null로 명시하면 상세주소를 삭제한다")
+            void it_clears_address2_when_explicit_null() {
+                // given
+                Department department =
+                        Department.builder().id(1L).name(DepartmentName.SALES_DEPT).build();
+                User pendingUser = new User();
+                pendingUser.setId(userId);
+                pendingUser.setStatus(Status.PENDING);
+                pendingUser.setAddress2("어썸리드빌딩 5층");
+                requestDto.setAddress2(null);
+
+                when(userRepository.findById(userId)).thenReturn(Optional.of(pendingUser));
+                when(departmentRepository.findByName(any())).thenReturn(Optional.of(department));
+
+                // when
+                adminService.approveUserRegistration(userId, requestDto, adminId);
+
+                // then
+                assertThat(pendingUser.getAddress2()).isNull();
+            }
+
+            @Test
+            @DisplayName("address2를 빈 문자열로 명시하면 상세주소를 삭제한다")
+            void it_clears_address2_when_blank() {
+                // given
+                Department department =
+                        Department.builder().id(1L).name(DepartmentName.SALES_DEPT).build();
+                User pendingUser = new User();
+                pendingUser.setId(userId);
+                pendingUser.setStatus(Status.PENDING);
+                pendingUser.setAddress2("어썸리드빌딩 5층");
+                requestDto.setAddress2("");
+
+                when(userRepository.findById(userId)).thenReturn(Optional.of(pendingUser));
+                when(departmentRepository.findByName(any())).thenReturn(Optional.of(department));
+
+                // when
+                adminService.approveUserRegistration(userId, requestDto, adminId);
+
+                // then
+                assertThat(pendingUser.getAddress2()).isNull();
+            }
+
+            @Test
             @DisplayName("MASTER_ADMIN으로 승인하면 모든 권한을 부여한다")
             void it_grants_all_authorities_to_master_admin() {
                 // given

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/auth/AuthServiceTest.java
@@ -250,6 +250,62 @@ class AuthServiceTest {
                 .sendAlertToAdminsRequiringApproval(any(), any(), any(), any(Map.class), any());
     }
 
+    @Test
+    @DisplayName("회원가입 시 address2가 null이면 null로 저장한다")
+    void signup_Address2Null_SavesNull() {
+        // given
+        SignupRequestDto signupDto = createSignupRequestDto();
+        signupDto.setAddress2(null);
+        User mappedUser = createMappedSignupUser(signupDto);
+        User savedUser = createSavedSignupUser(signupDto, 1L);
+        savedUser.setAddress2(null);
+
+        when(emailAuthService.isEmailVerified(signupDto.getEmail())).thenReturn(true);
+        when(phoneAuthService.isPhoneVerified(signupDto.getPhoneNumber())).thenReturn(true);
+        when(userRepository.existsByEmail(signupDto.getEmail())).thenReturn(false);
+        when(userRepository.existsByRegistrationNumber(signupDto.getRegistrationNumber()))
+                .thenReturn(false);
+        when(userMapper.toEntity(signupDto)).thenReturn(mappedUser);
+        when(bCryptPasswordEncoder.encode(signupDto.getPassword())).thenReturn("encodedPassword");
+        when(userRepository.save(any(User.class))).thenReturn(savedUser);
+
+        // when
+        authService.signup(signupDto);
+
+        // then
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        assertThat(captor.getValue().getAddress2()).isNull();
+    }
+
+    @Test
+    @DisplayName("회원가입 시 address2가 빈 문자열이면 null로 저장한다")
+    void signup_Address2Blank_SavesNull() {
+        // given
+        SignupRequestDto signupDto = createSignupRequestDto();
+        signupDto.setAddress2("");
+        User mappedUser = createMappedSignupUser(signupDto);
+        User savedUser = createSavedSignupUser(signupDto, 1L);
+        savedUser.setAddress2(null);
+
+        when(emailAuthService.isEmailVerified(signupDto.getEmail())).thenReturn(true);
+        when(phoneAuthService.isPhoneVerified(signupDto.getPhoneNumber())).thenReturn(true);
+        when(userRepository.existsByEmail(signupDto.getEmail())).thenReturn(false);
+        when(userRepository.existsByRegistrationNumber(signupDto.getRegistrationNumber()))
+                .thenReturn(false);
+        when(userMapper.toEntity(signupDto)).thenReturn(mappedUser);
+        when(bCryptPasswordEncoder.encode(signupDto.getPassword())).thenReturn("encodedPassword");
+        when(userRepository.save(any(User.class))).thenReturn(savedUser);
+
+        // when
+        authService.signup(signupDto);
+
+        // then
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        assertThat(captor.getValue().getAddress2()).isNull();
+    }
+
     @Nested
     @DisplayName("회원가입 이메일 인증번호 발송")
     class SendSignupEmailAuthCodeTest {
@@ -2553,5 +2609,62 @@ class AuthServiceTest {
                                             && jpql.contains("n.userId")
                                             && jpql.contains(":userId"));
         }
+    }
+
+    private SignupRequestDto createSignupRequestDto() {
+        SignupRequestDto signupDto = new SignupRequestDto();
+        signupDto.setEmail("address2-test@example.com");
+        signupDto.setPassword("password123!");
+        signupDto.setPasswordConfirm("password123!");
+        signupDto.setNameKor("김어썸");
+        signupDto.setNameEng("Awesome Kim");
+        signupDto.setNationality("대한민국");
+        signupDto.setZipcode("06234");
+        signupDto.setAddress1("서울특별시 강남구 테헤란로 123");
+        signupDto.setAddress2("어썸리드빌딩 5층");
+        signupDto.setRegistrationNumber("9501011234567");
+        signupDto.setPhoneNumber("01012345678");
+        signupDto.setCompany(Company.AWESOME);
+        return signupDto;
+    }
+
+    private User createMappedSignupUser(SignupRequestDto signupDto) {
+        User user =
+                User.builder()
+                        .email(signupDto.getEmail())
+                        .nameKor(signupDto.getNameKor())
+                        .nameEng(signupDto.getNameEng())
+                        .nationality(signupDto.getNationality())
+                        .zipcode(signupDto.getZipcode())
+                        .address1(signupDto.getAddress1())
+                        .address2(signupDto.getAddress2())
+                        .registrationNumber(signupDto.getRegistrationNumber())
+                        .phoneNumber(signupDto.getPhoneNumber())
+                        .workLocation(Company.AWESOME)
+                        .role(Role.USER)
+                        .status(Status.PENDING)
+                        .build();
+        user.onPrePersist();
+        return user;
+    }
+
+    private User createSavedSignupUser(SignupRequestDto signupDto, Long id) {
+        return User.builder()
+                .id(id)
+                .email(signupDto.getEmail())
+                .nameKor(signupDto.getNameKor())
+                .nameEng(signupDto.getNameEng())
+                .nationality(signupDto.getNationality())
+                .zipcode(signupDto.getZipcode())
+                .address1(signupDto.getAddress1())
+                .address2(signupDto.getAddress2())
+                .registrationNumber(signupDto.getRegistrationNumber())
+                .phoneNumber(signupDto.getPhoneNumber())
+                .password("encodedPassword")
+                .workLocation(Company.AWESOME)
+                .role(Role.USER)
+                .status(Status.PENDING)
+                .phoneNumberHash(User.hashValue(signupDto.getPhoneNumber()))
+                .build();
     }
 }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/user/service/UserServiceTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -260,6 +261,72 @@ class UserServiceTest {
             verify(myInfoUpdateRequestRepository).save(any(MyInfoUpdateRequest.class));
             verify(notificationService)
                     .sendAlertToAdminsRequiringApproval(any(), any(), any(), any(Map.class), any());
+        }
+
+        @Test
+        @DisplayName("성공: address2를 null로 명시하면 상세주소 삭제 요청을 생성한다")
+        void updateMyInfo_Address2ExplicitNull_CreatesClearRequest() {
+            // given
+            User testUser = createTestUser();
+            testUser.setAddress2("어썸리드빌딩 5층");
+            requestDto.setAddress2(null);
+
+            given(userRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.of(testUser));
+            given(
+                            myInfoUpdateRequestRepository.existsByUserIdAndStatus(
+                                    testUser.getId(), MyInfoUpdateRequestStatus.PENDING))
+                    .willReturn(false);
+            given(myInfoUpdateRequestRepository.save(any(MyInfoUpdateRequest.class)))
+                    .willAnswer(
+                            invocation -> {
+                                MyInfoUpdateRequest request = invocation.getArgument(0);
+                                request.setId(99L);
+                                return request;
+                            });
+
+            // when
+            MyInfoResponseDto response = userService.updateMyInfo(userDetails, requestDto);
+
+            // then
+            assertThat(response).isNotNull();
+            ArgumentCaptor<MyInfoUpdateRequest> captor =
+                    ArgumentCaptor.forClass(MyInfoUpdateRequest.class);
+            verify(myInfoUpdateRequestRepository).save(captor.capture());
+            assertThat(captor.getValue().isRequestedAddress2Present()).isTrue();
+            assertThat(captor.getValue().getRequestedAddress2()).isNull();
+        }
+
+        @Test
+        @DisplayName("성공: address2를 빈 문자열로 명시하면 상세주소 삭제 요청을 생성한다")
+        void updateMyInfo_Address2Blank_CreatesClearRequest() {
+            // given
+            User testUser = createTestUser();
+            testUser.setAddress2("어썸리드빌딩 5층");
+            requestDto.setAddress2("");
+
+            given(userRepository.findByEmail(TEST_EMAIL)).willReturn(Optional.of(testUser));
+            given(
+                            myInfoUpdateRequestRepository.existsByUserIdAndStatus(
+                                    testUser.getId(), MyInfoUpdateRequestStatus.PENDING))
+                    .willReturn(false);
+            given(myInfoUpdateRequestRepository.save(any(MyInfoUpdateRequest.class)))
+                    .willAnswer(
+                            invocation -> {
+                                MyInfoUpdateRequest request = invocation.getArgument(0);
+                                request.setId(99L);
+                                return request;
+                            });
+
+            // when
+            MyInfoResponseDto response = userService.updateMyInfo(userDetails, requestDto);
+
+            // then
+            assertThat(response).isNotNull();
+            ArgumentCaptor<MyInfoUpdateRequest> captor =
+                    ArgumentCaptor.forClass(MyInfoUpdateRequest.class);
+            verify(myInfoUpdateRequestRepository).save(captor.capture());
+            assertThat(captor.getValue().isRequestedAddress2Present()).isTrue();
+            assertThat(captor.getValue().getRequestedAddress2()).isNull();
         }
 
         @Test


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #492 

## 📝작업 내용
- 회원가입 시 `address2`가 `null` 또는 빈 문자열로 전달되면 `null`로 저장되도록 수정했습니다.
- 회원가입 승인 API에서 `address2`를 `null` 또는 빈 문자열로 명시하면 상세주소가 삭제되도록 수정했습니다.
- 내 정보 수정 API에서 `address2`를 `null` 또는 빈 문자열로 명시하면 상세주소 삭제 요청으로 처리되도록 수정했습니다.
- `address2` 필드가 요청에 포함되지 않은 경우에는 기존 값을 유지하도록 처리했습니다.

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X