### PR TITLE
fix(497): 권한 컬럼 길이 확장

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/entity/User.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/user/entity/User.java
@@ -183,7 +183,7 @@ public class User {
     @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(name = "user_authorities", joinColumns = @JoinColumn(name = "user_id"))
     @Enumerated(EnumType.STRING)
-    @Column(name = "authority")
+    @Column(name = "authority", length = 50)
     private Set<Authority> authorities = new HashSet<>();
 
     @PrePersist


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #497 

## 📝작업 내용
- `user_authorities.authority` 컬럼 매핑 길이를 50자로 명시했습니다.
- 긴 권한 enum 값을 저장할 때 `Data truncated for column 'authority'` 오류가 발생하지 않도록 수정했습니다.

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X