### PR TITLE
fix(497): 첨부파일 다운로드 URL에 파일명 헤더 적용

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
@@ -407,7 +407,9 @@ public class AnnualLeaveService {
                 .title(resolveDispatchMonthTitle(history))
                 .originalFileName(history.getOriginalFileName())
                 .sheetName(normalizeSheetName(history.getSheetName()))
-                .fileUrl(s3Service.getPresignedViewUrl(history.getFileKey()))
+                .fileUrl(
+                        s3Service.getPresignedDownloadUrl(
+                                history.getFileKey(), history.getOriginalFileName()))
                 .company(history.getCompany())
                 .build();
     }
@@ -505,7 +507,9 @@ public class AnnualLeaveService {
                 .senderName(resolveSenderName(history))
                 .senderPosition(resolveSenderPosition(history))
                 .createdAt(history.getCreatedAt())
-                .fileUrl(s3Service.getPresignedViewUrl(history.getFileKey()))
+                .fileUrl(
+                        s3Service.getPresignedDownloadUrl(
+                                history.getFileKey(), history.getOriginalFileName()))
                 .title(resolveDispatchMonthTitle(history))
                 .company(history.getCompany())
                 .build();

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/mapper/EduMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/mapper/EduMapper.java
@@ -81,7 +81,9 @@ public interface EduMapper {
 
     @Mapping(
             target = "viewUrl",
-            expression = "java(s3Service.getPresignedViewUrl(attachment.getS3Key()))")
+            expression =
+                    "java(s3Service.getPresignedDownloadUrl(attachment.getS3Key(),"
+                            + " attachment.getOriginalFileName()))")
     EduReportDetailDto.AttachmentResponse toAttachmentDto(
             EduAttachment attachment, @Context S3Service s3Service);
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/mapper/NoticeMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/mapper/NoticeMapper.java
@@ -47,7 +47,9 @@ public interface NoticeMapper {
 
     @Mapping(
             target = "viewUrl",
-            expression = "java(s3Service.getPresignedViewUrl(attachment.getS3Key()))")
+            expression =
+                    "java(s3Service.getPresignedDownloadUrl(attachment.getS3Key(),"
+                            + " attachment.getOriginalFileName()))")
     NoticeDetailDto.AttachmentResponse toAttachmentResponse(
             NoticeAttachment attachment, @Context S3Service s3Service);
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/mapper/PayslipMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/payslip/mapper/PayslipMapper.java
@@ -44,7 +44,9 @@ public interface PayslipMapper {
     @Mapping(target = "payslipTitle", expression = "java(buildPayslipTitle(payslip))")
     @Mapping(
             target = "presignedUrl",
-            expression = "java(s3Service.getPresignedViewUrl(payslip.getFileKey()))")
+            expression =
+                    "java(s3Service.getPresignedDownloadUrl(payslip.getFileKey(),"
+                            + " payslip.getOriginalFileName()))")
     AdminPayslipDetailDto toAdminPayslipDetailDto(Payslip payslip, @Context S3Service s3Service);
 
     @Mapping(target = "payslipId", source = "payslip.id")
@@ -55,7 +57,9 @@ public interface PayslipMapper {
 
     @Mapping(
             target = "presignedUrl",
-            expression = "java(s3Service.getPresignedViewUrl(payslip.getFileKey()))")
+            expression =
+                    "java(s3Service.getPresignedDownloadUrl(payslip.getFileKey(),"
+                            + " payslip.getOriginalFileName()))")
     @Mapping(target = "payslipId", source = "payslip.id")
     @Mapping(target = "payslipTitle", expression = "java(buildPayslipTitle(payslip))")
     EmployeePayslipDetailDto toEmployeePayslipDetailDto(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
@@ -887,7 +887,9 @@ public class SafetyTrainingSessionService {
         return SafetyTrainingSessionDetailResponseDto.AttachmentItem.builder()
                 .attachmentId(attachment.getId())
                 .fileName(attachment.getOriginalFileName())
-                .fileUrl(s3Service.getPresignedViewUrl(attachment.getFileKey()))
+                .fileUrl(
+                        s3Service.getPresignedDownloadUrl(
+                                attachment.getFileKey(), attachment.getOriginalFileName()))
                 .contentType(attachment.getContentType())
                 .fileSize(attachment.getFileSize())
                 .build();

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
@@ -327,14 +327,17 @@ public class AnnualLeaveServiceTest {
                             .build();
             given(annualLeaveDispatchHistoryRepository.findAllByCompanyOrderByCreatedAtDesc(null))
                     .willReturn(List.of(first, second, third));
-            given(s3Service.getPresignedDownloadUrl(
-                            "annual-leave/2026-06-first.xlsx", "2026_연차현황.xlsx"))
+            given(
+                            s3Service.getPresignedDownloadUrl(
+                                    "annual-leave/2026-06-first.xlsx", "2026_연차현황.xlsx"))
                     .willReturn("https://example.com/annual-leave-2026-06-first");
-            given(s3Service.getPresignedDownloadUrl(
-                            "annual-leave/2026-06-second.xlsx", "2026_연차현황_수정본.xlsx"))
+            given(
+                            s3Service.getPresignedDownloadUrl(
+                                    "annual-leave/2026-06-second.xlsx", "2026_연차현황_수정본.xlsx"))
                     .willReturn("https://example.com/annual-leave-2026-06-second");
-            given(s3Service.getPresignedDownloadUrl(
-                            "annual-leave/2026-07-first.xlsx", "2026_연차현황_7월.xlsx"))
+            given(
+                            s3Service.getPresignedDownloadUrl(
+                                    "annual-leave/2026-07-first.xlsx", "2026_연차현황_7월.xlsx"))
                     .willReturn("https://example.com/annual-leave-2026-07-first");
 
             // when
@@ -627,8 +630,9 @@ public class AnnualLeaveServiceTest {
 
             given(annualLeaveDispatchHistoryRepository.findById(10L))
                     .willReturn(Optional.of(history));
-            given(s3Service.getPresignedDownloadUrl(
-                            "annual-leave/2026-06-first.xlsx", "2026_연차현황.xlsx"))
+            given(
+                            s3Service.getPresignedDownloadUrl(
+                                    "annual-leave/2026-06-first.xlsx", "2026_연차현황.xlsx"))
                     .willReturn("https://example.com/annual-leave-2026-06-first");
 
             // when

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
@@ -327,11 +327,14 @@ public class AnnualLeaveServiceTest {
                             .build();
             given(annualLeaveDispatchHistoryRepository.findAllByCompanyOrderByCreatedAtDesc(null))
                     .willReturn(List.of(first, second, third));
-            given(s3Service.getPresignedViewUrl("annual-leave/2026-06-first.xlsx"))
+            given(s3Service.getPresignedDownloadUrl(
+                            "annual-leave/2026-06-first.xlsx", "2026_연차현황.xlsx"))
                     .willReturn("https://example.com/annual-leave-2026-06-first");
-            given(s3Service.getPresignedViewUrl("annual-leave/2026-06-second.xlsx"))
+            given(s3Service.getPresignedDownloadUrl(
+                            "annual-leave/2026-06-second.xlsx", "2026_연차현황_수정본.xlsx"))
                     .willReturn("https://example.com/annual-leave-2026-06-second");
-            given(s3Service.getPresignedViewUrl("annual-leave/2026-07-first.xlsx"))
+            given(s3Service.getPresignedDownloadUrl(
+                            "annual-leave/2026-07-first.xlsx", "2026_연차현황_7월.xlsx"))
                     .willReturn("https://example.com/annual-leave-2026-07-first");
 
             // when
@@ -624,7 +627,8 @@ public class AnnualLeaveServiceTest {
 
             given(annualLeaveDispatchHistoryRepository.findById(10L))
                     .willReturn(Optional.of(history));
-            given(s3Service.getPresignedViewUrl("annual-leave/2026-06-first.xlsx"))
+            given(s3Service.getPresignedDownloadUrl(
+                            "annual-leave/2026-06-first.xlsx", "2026_연차현황.xlsx"))
                     .willReturn("https://example.com/annual-leave-2026-06-first");
 
             // when

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipMapperTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/payslip/PayslipMapperTest.java
@@ -84,7 +84,7 @@ class PayslipMapperTest {
                         .build();
 
         S3Service s3Service = mock(S3Service.class);
-        when(s3Service.getPresignedViewUrl("payslip-7"))
+        when(s3Service.getPresignedDownloadUrl("payslip-7", originalFileName))
                 .thenReturn("https://example.com/payslip-7");
 
         AdminPayslipDetailDto response = payslipMapper.toAdminPayslipDetailDto(payslip, s3Service);

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/SafetyTrainingSessionServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/SafetyTrainingSessionServiceTest.java
@@ -284,8 +284,7 @@ class SafetyTrainingSessionServiceTest {
                     .thenReturn(Optional.of(attendee));
             when(attachmentRepository.findAllBySessionIdOrderByIdAsc(SESSION_ID))
                     .thenReturn(List.of(attachment));
-            when(s3Service.getPresignedDownloadUrl(
-                            "safety-training/file-key.pdf", "교육자료.pdf"))
+            when(s3Service.getPresignedDownloadUrl("safety-training/file-key.pdf", "교육자료.pdf"))
                     .thenReturn("https://example.com/file-key.pdf");
             when(sessionRepository.findFirstByIdGreaterThanOrderByIdAsc(SESSION_ID))
                     .thenReturn(Optional.empty());

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/SafetyTrainingSessionServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/SafetyTrainingSessionServiceTest.java
@@ -284,7 +284,8 @@ class SafetyTrainingSessionServiceTest {
                     .thenReturn(Optional.of(attendee));
             when(attachmentRepository.findAllBySessionIdOrderByIdAsc(SESSION_ID))
                     .thenReturn(List.of(attachment));
-            when(s3Service.getPresignedViewUrl("safety-training/file-key.pdf"))
+            when(s3Service.getPresignedDownloadUrl(
+                            "safety-training/file-key.pdf", "교육자료.pdf"))
                     .thenReturn("https://example.com/file-key.pdf");
             when(sessionRepository.findFirstByIdGreaterThanOrderByIdAsc(SESSION_ID))
                     .thenReturn(Optional.empty());


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #497 

## 📝작업 내용
- 공지 첨부파일 URL을 다운로드용 presigned URL로 변경
- 교육 첨부파일 URL을 다운로드용 presigned URL로 변경
- 연차 발송 파일 URL을 다운로드용 presigned URL로 변경
- 급여명세서 파일 URL을 다운로드용 presigned URL로 변경
- 안전보건 교육일지 첨부파일 URL을 다운로드용 presigned URL로 변경

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X