### PR TITLE
fix(501): 파일 단일 업로드 응답 형식 변경

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/infra/s3/controller/S3Controller.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/infra/s3/controller/S3Controller.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import kr.co.awesomelead.groupware_backend.global.common.response.ApiResponse;
 import kr.co.awesomelead.groupware_backend.global.error.CustomException;
 import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
+import kr.co.awesomelead.groupware_backend.global.infra.s3.dto.response.FileUploadResponseDto;
 import kr.co.awesomelead.groupware_backend.global.infra.s3.service.S3Service;
 
 import lombok.RequiredArgsConstructor;
@@ -29,15 +30,15 @@ public class S3Controller {
 
     private final S3Service s3Service;
 
-    @Operation(summary = "파일 단일 업로드", description = "파일을 S3에 업로드하고 접근 URL을 반환합니다.")
+    @Operation(summary = "파일 단일 업로드", description = "파일을 S3에 업로드하고 파일 키, 원본 파일명, 접근 URL을 반환합니다.")
     @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<String>> uploadFile(@RequestPart("file") MultipartFile file)
+    public ResponseEntity<ApiResponse<FileUploadResponseDto>> uploadFile(
+            @RequestPart("file") MultipartFile file)
             throws IOException {
 
-        // S3에 저장 후 URL 반환
-        String fileUrl = s3Service.uploadFile(file);
+        FileUploadResponseDto response = s3Service.uploadEditorFile(file);
 
-        return ResponseEntity.ok(ApiResponse.onSuccess(fileUrl));
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
     @Operation(summary = "파일 단일 삭제", description = "파일 키(fileKey)를 입력하여 S3 파일을 삭제합니다.")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/infra/s3/controller/S3Controller.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/infra/s3/controller/S3Controller.java
@@ -33,8 +33,7 @@ public class S3Controller {
     @Operation(summary = "파일 단일 업로드", description = "파일을 S3에 업로드하고 파일 키, 원본 파일명, 접근 URL을 반환합니다.")
     @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<FileUploadResponseDto>> uploadFile(
-            @RequestPart("file") MultipartFile file)
-            throws IOException {
+            @RequestPart("file") MultipartFile file) throws IOException {
 
         FileUploadResponseDto response = s3Service.uploadEditorFile(file);
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/infra/s3/dto/response/FileUploadResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/infra/s3/dto/response/FileUploadResponseDto.java
@@ -22,6 +22,7 @@ public class FileUploadResponseDto {
 
     @Schema(
             description = "에디터에 삽입할 이미지 URL",
-            example = "https://cdn.awesomelead.co.kr/editor/2026/07/uuid-dummy1.png")
+            example =
+                    "https://bucket.s3.ap-northeast-2.amazonaws.com/editor/2026/07/uuid-dummy1.png?X-Amz-Signature=...")
     private String imageUrl;
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/infra/s3/dto/response/FileUploadResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/infra/s3/dto/response/FileUploadResponseDto.java
@@ -1,0 +1,27 @@
+package kr.co.awesomelead.groupware_backend.global.infra.s3.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "파일 단일 업로드 응답")
+public class FileUploadResponseDto {
+
+    @Schema(description = "S3 파일 키", example = "editor/2026/07/uuid-dummy1.png")
+    private String fileKey;
+
+    @Schema(description = "원본 파일명", example = "dummy1.png")
+    private String fileName;
+
+    @Schema(
+            description = "에디터에 삽입할 이미지 URL",
+            example = "https://cdn.awesomelead.co.kr/editor/2026/07/uuid-dummy1.png")
+    private String imageUrl;
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/infra/s3/service/S3Service.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/infra/s3/service/S3Service.java
@@ -1,5 +1,7 @@
 package kr.co.awesomelead.groupware_backend.global.infra.s3.service;
 
+import kr.co.awesomelead.groupware_backend.global.infra.s3.dto.response.FileUploadResponseDto;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -19,6 +21,8 @@ import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.UUID;
 
 @Slf4j
@@ -34,6 +38,9 @@ public class S3Service {
 
     @Value("${spring.cloud.aws.region.static}")
     private String region;
+
+    @Value("${spring.cloud.aws.s3.cdn-url:https://cdn.awesomelead.co.kr}")
+    private String cdnUrl;
 
     public String getPresignedViewUrl(String fileKey) {
         return generatePresignedUrl(fileKey, Duration.ofMinutes(30)); // 30분짜리 권한
@@ -108,6 +115,22 @@ public class S3Service {
         return fileName;
     }
 
+    public FileUploadResponseDto uploadEditorFile(MultipartFile file) throws IOException {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("파일이 비어있습니다.");
+        }
+
+        String originalFileName = file.getOriginalFilename();
+        String fileKey = generateEditorFileKey(originalFileName);
+        upload(file, fileKey);
+
+        return FileUploadResponseDto.builder()
+                .fileKey(fileKey)
+                .fileName(originalFileName)
+                .imageUrl(getCdnFileUrl(fileKey))
+                .build();
+    }
+
     public String uploadBytes(byte[] fileData, String originalFileName, String contentType) {
         if (fileData == null || fileData.length == 0) {
             throw new IllegalArgumentException("파일 데이터가 비어있습니다.");
@@ -146,8 +169,39 @@ public class S3Service {
                 + (originalFileName != null ? originalFileName : "file");
     }
 
+    private String generateEditorFileKey(String originalFileName) {
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        String fileName = originalFileName != null ? originalFileName : "file";
+        return String.format(
+                "editor/%d/%02d/%s-%s",
+                today.getYear(), today.getMonthValue(), UUID.randomUUID(), fileName);
+    }
+
+    private void upload(MultipartFile file, String fileKey) throws IOException {
+        PutObjectRequest putObjectRequest =
+                PutObjectRequest.builder()
+                        .bucket(bucketName)
+                        .key(fileKey)
+                        .contentType(file.getContentType())
+                        .contentDisposition("inline")
+                        .build();
+
+        RequestBody requestBody =
+                RequestBody.fromInputStream(file.getInputStream(), file.getSize());
+        s3Client.putObject(putObjectRequest, requestBody);
+    }
+
     public String getFileUrl(String fileName) {
         return String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, fileName);
+    }
+
+    public String getCdnFileUrl(String fileKey) {
+        if (fileKey == null || fileKey.isBlank()) {
+            return null;
+        }
+
+        String baseUrl = cdnUrl.endsWith("/") ? cdnUrl.substring(0, cdnUrl.length() - 1) : cdnUrl;
+        return baseUrl + "/" + fileKey;
     }
 
     public byte[] downloadFile(String fileKey) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/infra/s3/service/S3Service.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/infra/s3/service/S3Service.java
@@ -39,9 +39,6 @@ public class S3Service {
     @Value("${spring.cloud.aws.region.static}")
     private String region;
 
-    @Value("${spring.cloud.aws.s3.cdn-url:https://cdn.awesomelead.co.kr}")
-    private String cdnUrl;
-
     public String getPresignedViewUrl(String fileKey) {
         return generatePresignedUrl(fileKey, Duration.ofMinutes(30)); // 30분짜리 권한
     }
@@ -127,7 +124,7 @@ public class S3Service {
         return FileUploadResponseDto.builder()
                 .fileKey(fileKey)
                 .fileName(originalFileName)
-                .imageUrl(getCdnFileUrl(fileKey))
+                .imageUrl(getPresignedViewUrl(fileKey))
                 .build();
     }
 
@@ -193,15 +190,6 @@ public class S3Service {
 
     public String getFileUrl(String fileName) {
         return String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, fileName);
-    }
-
-    public String getCdnFileUrl(String fileKey) {
-        if (fileKey == null || fileKey.isBlank()) {
-            return null;
-        }
-
-        String baseUrl = cdnUrl.endsWith("/") ? cdnUrl.substring(0, cdnUrl.length() - 1) : cdnUrl;
-        return baseUrl + "/" + fileKey;
     }
 
     public byte[] downloadFile(String fileKey) {


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #501 

## 📝작업 내용
- `/api/files/upload` 응답 타입을 기존 문자열에서 `FileUploadResponseDto` 객체로 변경했습니다.
- 업로드 응답에 S3 관리용 `fileKey`, 원본 파일명 `fileName`, Quill 에디터 삽입용 `imageUrl`을 포함하도록 수정했습니다.
- S3 private 버킷 파일도 접근할 수 있도록 `imageUrl`은 presigned view URL로 반환하도록 수정했습니다.
- 에디터 업로드 파일은 `editor/yyyy/MM/{uuid}-{fileName}` 형식의 S3 key로 저장되도록 추가했습니다.

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [X] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X