### PR TITLE
fix(503): 연차 엑셀 시트명과 기준월 검증 강화

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/dto/response/AnnualLeaveResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/dto/response/AnnualLeaveResponseDto.java
@@ -18,5 +18,6 @@ public class AnnualLeaveResponseDto {
     private Double carriedOver; // 이월 월차
     private Double used; // 사용
     private Double remain; // 잔여일
+    private String remark; // 비고
     private LocalDate updateDate; // 수정일
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/entity/AnnualLeave.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/entity/AnnualLeave.java
@@ -35,6 +35,7 @@ public class AnnualLeave {
     private Double carriedOver; // 이월 월차
     private Double used; // 사용
     private Double remain; // 잔여일
+    private String remark; // 비고
     private LocalDate updateDate; // 수정일
 
     @OneToOne(fetch = FetchType.LAZY)

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
@@ -48,6 +48,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -55,6 +57,9 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AnnualLeaveService {
+
+    private static final Pattern SHEET_NAME_DAY_PATTERN = Pattern.compile("\\d+\\s*일");
+    private static final Pattern SHEET_NAME_MONTH_PATTERN = Pattern.compile("(?<!\\d)(1[0-2]|[1-9])\\s*월");
 
     private final AnnualLeaveRepository annualLeaveRepository;
     private final AnnualLeaveDispatchHistoryRepository annualLeaveDispatchHistoryRepository;
@@ -69,23 +74,21 @@ public class AnnualLeaveService {
         User currentUser = validateAnnualLeaveEditAuthority(userId);
         String normalizedSheetName = normalizeSheetName(sheetName);
 
-        // S3 업로드를 트랜잭션 전에 수행 (네트워크 I/O를 DB 커넥션 점유 시간에서 분리)
-        String fileKey = uploadAnnualLeaveSourceFile(file);
+        LocalDate baseDate = parseAnnualLeaveBaseDate(file, normalizedSheetName);
+        validateSheetMonthMatchesBaseDate(normalizedSheetName, baseDate);
 
-        ProcessResult processResult = processAnnualLeaveFile(file, normalizedSheetName, company);
-        validateSheetMonthMatchesBaseDate(normalizedSheetName, processResult.baseDate());
-
-        if (processResult.baseDate() != null) {
-            LocalDate start = processResult.baseDate().withDayOfMonth(1);
-            LocalDate end =
-                    processResult
-                            .baseDate()
-                            .withDayOfMonth(processResult.baseDate().lengthOfMonth());
+        if (baseDate != null) {
+            LocalDate start = baseDate.withDayOfMonth(1);
+            LocalDate end = baseDate.withDayOfMonth(baseDate.lengthOfMonth());
             if (annualLeaveDispatchHistoryRepository.existsByCompanyAndBaseDateBetween(
                     company, start, end)) {
                 throw new CustomException(ErrorCode.DUPLICATE_ANNUAL_LEAVE_DISPATCH);
             }
         }
+
+        // S3 업로드를 트랜잭션 전에 수행 (네트워크 I/O를 DB 커넥션 점유 시간에서 분리)
+        String fileKey = uploadAnnualLeaveSourceFile(file);
+        ProcessResult processResult = processAnnualLeaveFile(file, normalizedSheetName, company);
 
         saveDispatchHistory(
                 currentUser,
@@ -114,23 +117,20 @@ public class AnnualLeaveService {
         validateSheetMonthMatchesBaseDate(normalizedSheetName, newBaseDate);
         validateDispatchMonthMatchesBaseDate(history, newBaseDate);
 
-        // S3 업로드를 DB 작업 전에 수행 (트랜잭션 내 네트워크 I/O 제거)
-        String oldFileKey = history.getFileKey();
-        String newFileKey = uploadAnnualLeaveSourceFile(file);
-
-        ProcessResult processResult = processAnnualLeaveFile(file, normalizedSheetName, company);
-
-        if (processResult.baseDate() != null) {
-            LocalDate start = processResult.baseDate().withDayOfMonth(1);
-            LocalDate end =
-                    processResult
-                            .baseDate()
-                            .withDayOfMonth(processResult.baseDate().lengthOfMonth());
+        if (newBaseDate != null) {
+            LocalDate start = newBaseDate.withDayOfMonth(1);
+            LocalDate end = newBaseDate.withDayOfMonth(newBaseDate.lengthOfMonth());
             if (annualLeaveDispatchHistoryRepository.existsByIdNotAndCompanyAndBaseDateBetween(
                     dispatchId, company, start, end)) {
                 throw new CustomException(ErrorCode.DUPLICATE_ANNUAL_LEAVE_DISPATCH);
             }
         }
+
+        // S3 업로드를 DB 작업 전에 수행 (트랜잭션 내 네트워크 I/O 제거)
+        String oldFileKey = history.getFileKey();
+        String newFileKey = uploadAnnualLeaveSourceFile(file);
+
+        ProcessResult processResult = processAnnualLeaveFile(file, normalizedSheetName, company);
 
         history.updateDispatch(
                 currentUser,
@@ -614,33 +614,27 @@ public class AnnualLeaveService {
         if (sheetName == null || sheetName.isBlank()) {
             return null;
         }
-        String numericStr = sheetName.replaceAll("[^0-9]", "");
-        if (numericStr.isEmpty()) {
-            return null;
+
+        YearMonth yearMonth = parseStrictYearMonthFromSheetName(sheetName);
+        if (yearMonth != null) {
+            return yearMonth.getMonthValue();
         }
-        try {
-            int month = Integer.parseInt(numericStr);
-            if (month >= 1 && month <= 12) {
-                return month;
-            }
-        } catch (NumberFormatException ignored) {
+
+        Matcher matcher = SHEET_NAME_MONTH_PATTERN.matcher(sheetName);
+        if (matcher.find()) {
+            return Integer.parseInt(matcher.group(1));
         }
         return null;
     }
 
     private void validateSheetMonthMatchesBaseDate(String sheetName, LocalDate baseDate) {
-        try {
-            String numericStr = sheetName.replaceAll("[^0-9]", "");
-            if (!numericStr.isEmpty()) {
-                int sheetMonth = Integer.parseInt(numericStr);
-                if (sheetMonth >= 1 && sheetMonth <= 12 && sheetMonth != baseDate.getMonthValue()) {
-                    throw new CustomException(ErrorCode.ANNUAL_LEAVE_MONTH_MISMATCH);
-                }
-            }
-        } catch (CustomException e) {
-            throw e;
-        } catch (NumberFormatException e) {
-            // 숫자 파싱 불가 시트명은 검증 통과
+        if (sheetName != null && SHEET_NAME_DAY_PATTERN.matcher(sheetName).find()) {
+            throw new CustomException(ErrorCode.ANNUAL_LEAVE_INVALID_SHEET_NAME);
+        }
+
+        Integer sheetMonth = parseMonthFromSheetName(sheetName);
+        if (sheetMonth != null && sheetMonth != baseDate.getMonthValue()) {
+            throw new CustomException(ErrorCode.ANNUAL_LEAVE_MONTH_MISMATCH);
         }
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
@@ -277,6 +277,7 @@ public class AnnualLeaveService {
         Double carried = getCellValueAsDouble(row.getCell(7));
         Double used = getCellValueAsDouble(row.getCell(8));
         Double remain = getCellValueAsDouble(row.getCell(9));
+        String remark = getCellValueAsString(row.getCell(10)).trim();
 
         // 기존 정보가 있으면 업데이트, 없으면 신규 생성
         AnnualLeave annualLeave =
@@ -297,6 +298,7 @@ public class AnnualLeaveService {
         annualLeave.setCarriedOver(carried);
         annualLeave.setUsed(used);
         annualLeave.setRemain(remain);
+        annualLeave.setRemark(remark);
         annualLeave.setUpdateDate(updateDate); // Date 타입 호환
 
         annualLeaveRepository.save(annualLeave);

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
@@ -59,7 +59,8 @@ import java.util.stream.Collectors;
 public class AnnualLeaveService {
 
     private static final Pattern SHEET_NAME_DAY_PATTERN = Pattern.compile("\\d+\\s*일");
-    private static final Pattern SHEET_NAME_MONTH_PATTERN = Pattern.compile("(?<!\\d)(1[0-2]|[1-9])\\s*월");
+    private static final Pattern SHEET_NAME_MONTH_PATTERN =
+            Pattern.compile("(?<!\\d)(1[0-2]|[1-9])\\s*월");
 
     private final AnnualLeaveRepository annualLeaveRepository;
     private final AnnualLeaveDispatchHistoryRepository annualLeaveDispatchHistoryRepository;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
@@ -110,12 +110,15 @@ public class AnnualLeaveService {
                                                 ErrorCode.ANNUAL_LEAVE_DISPATCH_HISTORY_NOT_FOUND));
         String normalizedSheetName = normalizeSheetName(sheetName);
 
+        LocalDate newBaseDate = parseAnnualLeaveBaseDate(file, normalizedSheetName);
+        validateSheetMonthMatchesBaseDate(normalizedSheetName, newBaseDate);
+        validateDispatchMonthMatchesBaseDate(history, newBaseDate);
+
         // S3 업로드를 DB 작업 전에 수행 (트랜잭션 내 네트워크 I/O 제거)
         String oldFileKey = history.getFileKey();
         String newFileKey = uploadAnnualLeaveSourceFile(file);
 
         ProcessResult processResult = processAnnualLeaveFile(file, normalizedSheetName, company);
-        validateSheetMonthMatchesBaseDate(normalizedSheetName, processResult.baseDate());
 
         if (processResult.baseDate() != null) {
             LocalDate start = processResult.baseDate().withDayOfMonth(1);
@@ -321,6 +324,21 @@ public class AnnualLeaveService {
         } catch (Exception e) {
             log.error("기준일 파싱 실패, 오늘 날짜로 대체합니다.");
             throw new CustomException(ErrorCode.INVALID_BASE_DATE_FORMAT);
+        }
+    }
+
+    private LocalDate parseAnnualLeaveBaseDate(MultipartFile file, String normalizedSheetName) {
+        try (InputStream is = file.getInputStream();
+                Workbook workbook = WorkbookFactory.create(is)) {
+            Sheet sheet = workbook.getSheet(normalizedSheetName);
+            if (sheet == null) {
+                throw new CustomException(ErrorCode.ANNUAL_LEAVE_SHEET_NOT_FOUND);
+            }
+            return parseBaseDate(sheet);
+        } catch (CustomException e) {
+            throw e;
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.FILE_UPLOAD_ERROR);
         }
     }
 
@@ -623,6 +641,34 @@ public class AnnualLeaveService {
             throw e;
         } catch (NumberFormatException e) {
             // 숫자 파싱 불가 시트명은 검증 통과
+        }
+    }
+
+    private void validateDispatchMonthMatchesBaseDate(
+            AnnualLeaveDispatchHistory history, LocalDate baseDate) {
+        if (baseDate == null) {
+            return;
+        }
+
+        YearMonth newYearMonth = YearMonth.from(baseDate);
+        if (history.getBaseDate() != null) {
+            if (!YearMonth.from(history.getBaseDate()).equals(newYearMonth)) {
+                throw new CustomException(ErrorCode.ANNUAL_LEAVE_DISPATCH_MONTH_MISMATCH);
+            }
+            return;
+        }
+
+        YearMonth historyYearMonth = parseStrictYearMonthFromSheetName(history.getSheetName());
+        if (historyYearMonth != null) {
+            if (!historyYearMonth.equals(newYearMonth)) {
+                throw new CustomException(ErrorCode.ANNUAL_LEAVE_DISPATCH_MONTH_MISMATCH);
+            }
+            return;
+        }
+
+        Integer historyMonth = parseMonthFromSheetName(history.getSheetName());
+        if (historyMonth != null && historyMonth != baseDate.getMonthValue()) {
+            throw new CustomException(ErrorCode.ANNUAL_LEAVE_DISPATCH_MONTH_MISMATCH);
         }
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
@@ -205,7 +205,7 @@ public class AnnualLeaveService {
 
             Sheet sheet = workbook.getSheet(normalizedSheetName);
             if (sheet == null) {
-                sheet = workbook.getSheetAt(0);
+                throw new CustomException(ErrorCode.ANNUAL_LEAVE_SHEET_NOT_FOUND);
             }
 
             // 기준일 파싱 (5행 J열(Index 9)에서 기준일 추출)

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
@@ -81,6 +81,8 @@ public enum ErrorCode {
             HttpStatus.BAD_REQUEST, "결석자가 있을 경우 교육 미참석 사유 입력은 필수입니다."),
     ANNUAL_LEAVE_SHEET_NOT_FOUND(HttpStatus.BAD_REQUEST, "입력한 시트명을 엑셀 파일에서 찾을 수 없습니다."),
     ANNUAL_LEAVE_MONTH_MISMATCH(HttpStatus.BAD_REQUEST, "시트명의 월 정보와 엑셀 기준일의 월 정보가 일치하지 않습니다."),
+    ANNUAL_LEAVE_DISPATCH_MONTH_MISMATCH(
+            HttpStatus.BAD_REQUEST, "수정하려는 연차 발송 월과 엑셀 기준일의 월이 일치하지 않습니다."),
     ANNUAL_LEAVE_COMPANY_MISMATCH(
             HttpStatus.BAD_REQUEST, "업로드 요청한 회사 정보와 엑셀 데이터 내 직원의 소속 회사가 일치하지 않습니다."),
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
@@ -79,6 +79,7 @@ public enum ErrorCode {
             HttpStatus.BAD_REQUEST, "서명 완료자가 존재하여 교육을 수정할 수 없습니다."),
     SAFETY_TRAINING_ABSENT_REASON_REQUIRED(
             HttpStatus.BAD_REQUEST, "결석자가 있을 경우 교육 미참석 사유 입력은 필수입니다."),
+    ANNUAL_LEAVE_SHEET_NOT_FOUND(HttpStatus.BAD_REQUEST, "입력한 시트명을 엑셀 파일에서 찾을 수 없습니다."),
     ANNUAL_LEAVE_MONTH_MISMATCH(HttpStatus.BAD_REQUEST, "시트명의 월 정보와 엑셀 기준일의 월 정보가 일치하지 않습니다."),
     ANNUAL_LEAVE_COMPANY_MISMATCH(
             HttpStatus.BAD_REQUEST, "업로드 요청한 회사 정보와 엑셀 데이터 내 직원의 소속 회사가 일치하지 않습니다."),

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
@@ -80,8 +80,7 @@ public enum ErrorCode {
     SAFETY_TRAINING_ABSENT_REASON_REQUIRED(
             HttpStatus.BAD_REQUEST, "결석자가 있을 경우 교육 미참석 사유 입력은 필수입니다."),
     ANNUAL_LEAVE_SHEET_NOT_FOUND(HttpStatus.BAD_REQUEST, "입력한 시트명을 엑셀 파일에서 찾을 수 없습니다."),
-    ANNUAL_LEAVE_INVALID_SHEET_NAME(
-            HttpStatus.BAD_REQUEST, "시트명에는 월 외의 날짜 숫자를 포함할 수 없습니다."),
+    ANNUAL_LEAVE_INVALID_SHEET_NAME(HttpStatus.BAD_REQUEST, "시트명에는 월 외의 날짜 숫자를 포함할 수 없습니다."),
     ANNUAL_LEAVE_MONTH_MISMATCH(HttpStatus.BAD_REQUEST, "시트명의 월 정보와 엑셀 기준일의 월 정보가 일치하지 않습니다."),
     ANNUAL_LEAVE_DISPATCH_MONTH_MISMATCH(
             HttpStatus.BAD_REQUEST, "수정하려는 연차 발송 월과 엑셀 기준일의 월이 일치하지 않습니다."),

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
@@ -80,6 +80,8 @@ public enum ErrorCode {
     SAFETY_TRAINING_ABSENT_REASON_REQUIRED(
             HttpStatus.BAD_REQUEST, "결석자가 있을 경우 교육 미참석 사유 입력은 필수입니다."),
     ANNUAL_LEAVE_SHEET_NOT_FOUND(HttpStatus.BAD_REQUEST, "입력한 시트명을 엑셀 파일에서 찾을 수 없습니다."),
+    ANNUAL_LEAVE_INVALID_SHEET_NAME(
+            HttpStatus.BAD_REQUEST, "시트명에는 월 외의 날짜 숫자를 포함할 수 없습니다."),
     ANNUAL_LEAVE_MONTH_MISMATCH(HttpStatus.BAD_REQUEST, "시트명의 월 정보와 엑셀 기준일의 월 정보가 일치하지 않습니다."),
     ANNUAL_LEAVE_DISPATCH_MONTH_MISMATCH(
             HttpStatus.BAD_REQUEST, "수정하려는 연차 발송 월과 엑셀 기준일의 월이 일치하지 않습니다."),

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
@@ -170,7 +170,6 @@ public class AnnualLeaveServiceTest {
                 User admin = createMockUser(Authority.MANAGE_ANNUAL_LEAVE);
                 given(userRepository.findById(loginUserId)).willReturn(Optional.of(admin));
                 MultipartFile mockFile = createMockExcelFile();
-                given(s3Service.uploadFile(mockFile)).willReturn("annual-leave/history.xlsx");
 
                 // when & then
                 assertThatThrownBy(
@@ -885,6 +884,25 @@ public class AnnualLeaveServiceTest {
         }
 
         @Nested
+        @DisplayName("ANNUAL_LEAVE_INVALID_SHEET_NAME 상수가")
+        class Context_ANNUAL_LEAVE_INVALID_SHEET_NAME {
+
+            @Test
+            @DisplayName("정의되어 있어야 하고 HttpStatus.BAD_REQUEST와 지정된 메시지를 가진다")
+            void it_has_correct_status_and_message() {
+                // given & when
+                kr.co.awesomelead.groupware_backend.global.error.ErrorCode code =
+                        kr.co.awesomelead.groupware_backend.global.error.ErrorCode.valueOf(
+                                "ANNUAL_LEAVE_INVALID_SHEET_NAME");
+
+                // then
+                assertThat(code.getHttpStatus())
+                        .isEqualTo(org.springframework.http.HttpStatus.BAD_REQUEST);
+                assertThat(code.getMessage()).isEqualTo("시트명에는 월 외의 날짜 숫자를 포함할 수 없습니다.");
+            }
+        }
+
+        @Nested
         @DisplayName("ANNUAL_LEAVE_DISPATCH_MONTH_MISMATCH 상수가")
         class Context_ANNUAL_LEAVE_DISPATCH_MONTH_MISMATCH {
 
@@ -972,7 +990,6 @@ public class AnnualLeaveServiceTest {
                         .willReturn(true);
 
                 MultipartFile mockFile = createMockExcelFile();
-                given(s3Service.uploadFile(mockFile)).willReturn("annual-leave/history.xlsx");
 
                 // when & then
                 assertThatThrownBy(
@@ -1044,7 +1061,6 @@ public class AnnualLeaveServiceTest {
                 given(userRepository.findById(loginUserId)).willReturn(Optional.of(admin));
 
                 MultipartFile mockFile = createMockExcelFileWithSheetName("5월");
-                given(s3Service.uploadFile(mockFile)).willReturn("annual-leave/history.xlsx");
 
                 // when & then
                 assertThatThrownBy(
@@ -1053,6 +1069,55 @@ public class AnnualLeaveServiceTest {
                                                 mockFile, "5월", loginUserId, Company.AWESOME))
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining("시트명의 월 정보와 엑셀 기준일의 월 정보가 일치하지 않습니다.");
+            }
+        }
+
+        @Nested
+        @DisplayName("시트명이 yyyy-MM 형식이고 기준일 월과 불일치하면")
+        class Context_with_year_month_sheet_name_mismatch {
+
+            @Test
+            @DisplayName("ANNUAL_LEAVE_MONTH_MISMATCH 예외를 던진다")
+            void uploadAnnualLeaveFile_throwsWhenYearMonthSheetNameMismatch() throws IOException {
+                // given
+                User admin = createMockUser(Authority.MANAGE_ANNUAL_LEAVE);
+                given(userRepository.findById(loginUserId)).willReturn(Optional.of(admin));
+
+                MultipartFile mockFile = createMockExcelFileWithSheetName("2026-06");
+
+                // when & then
+                assertThatThrownBy(
+                                () ->
+                                        annualLeaveService.uploadAnnualLeaveFile(
+                                                mockFile, "2026-06", loginUserId, Company.AWESOME))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessageContaining("시트명의 월 정보와 엑셀 기준일의 월 정보가 일치하지 않습니다.");
+            }
+        }
+
+        @Nested
+        @DisplayName("시트명에 월 외의 일자 숫자가 포함되면")
+        class Context_with_day_in_sheet_name {
+
+            @Test
+            @DisplayName("ANNUAL_LEAVE_INVALID_SHEET_NAME 예외를 던진다")
+            void uploadAnnualLeaveFile_throwsWhenSheetNameContainsDay() throws IOException {
+                // given
+                User admin = createMockUser(Authority.MANAGE_ANNUAL_LEAVE);
+                given(userRepository.findById(loginUserId)).willReturn(Optional.of(admin));
+
+                MultipartFile mockFile = createMockExcelFileWithSheetName("8월 1일 연차현황");
+
+                // when & then
+                assertThatThrownBy(
+                                () ->
+                                        annualLeaveService.uploadAnnualLeaveFile(
+                                                mockFile,
+                                                "8월 1일 연차현황",
+                                                loginUserId,
+                                                Company.AWESOME))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessageContaining("시트명에는 월 외의 날짜 숫자를 포함할 수 없습니다.");
             }
         }
     }
@@ -1200,7 +1265,6 @@ public class AnnualLeaveServiceTest {
                         .willReturn(true);
 
                 MultipartFile mockFile = createMockExcelFile();
-                given(s3Service.uploadFile(mockFile)).willReturn("annual-leave/history.xlsx");
 
                 // when & then
                 assertThatThrownBy(
@@ -1421,7 +1485,6 @@ public class AnnualLeaveServiceTest {
                         .willReturn(true);
 
                 MultipartFile mockFile = createMockExcelFile();
-                given(s3Service.uploadFile(mockFile)).willReturn("annual-leave/history.xlsx");
 
                 // when & then
                 assertThatThrownBy(

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
@@ -917,8 +917,7 @@ public class AnnualLeaveServiceTest {
                 // then
                 assertThat(code.getHttpStatus())
                         .isEqualTo(org.springframework.http.HttpStatus.BAD_REQUEST);
-                assertThat(code.getMessage())
-                        .isEqualTo("수정하려는 연차 발송 월과 엑셀 기준일의 월이 일치하지 않습니다.");
+                assertThat(code.getMessage()).isEqualTo("수정하려는 연차 발송 월과 엑셀 기준일의 월이 일치하지 않습니다.");
             }
         }
 
@@ -1685,7 +1684,8 @@ public class AnnualLeaveServiceTest {
     private MultipartFile createMockExcelFileWithSheetName(String sheetName) throws IOException {
         ClassPathResource resource = new ClassPathResource("excel/annual_leave_test.xlsx");
         try (org.apache.poi.ss.usermodel.Workbook workbook =
-                        org.apache.poi.ss.usermodel.WorkbookFactory.create(resource.getInputStream());
+                        org.apache.poi.ss.usermodel.WorkbookFactory.create(
+                                resource.getInputStream());
                 ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
             workbook.setSheetName(0, sheetName);
             workbook.write(outputStream);
@@ -1700,7 +1700,8 @@ public class AnnualLeaveServiceTest {
     private MultipartFile createMockExcelFileWithRemark(String remark) throws IOException {
         ClassPathResource resource = new ClassPathResource("excel/annual_leave_test.xlsx");
         try (org.apache.poi.ss.usermodel.Workbook workbook =
-                        org.apache.poi.ss.usermodel.WorkbookFactory.create(resource.getInputStream());
+                        org.apache.poi.ss.usermodel.WorkbookFactory.create(
+                                resource.getInputStream());
                 ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
             workbook.getSheet("8월").getRow(7).getCell(10).setCellValue(remark);
             workbook.write(outputStream);

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
@@ -40,6 +40,7 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -151,6 +152,32 @@ public class AnnualLeaveServiceTest {
                         .isInstanceOf(CustomException.class)
                         .hasMessageContaining(
                                 "유효하지 않은 기준일자 형식입니다. (yyyy-MM-dd)"); // ErrorCode 메시지에 따라 수정
+            }
+        }
+
+        @Nested
+        @DisplayName("엑셀 파일에 입력한 시트명이 없으면")
+        class Context_with_missing_sheet {
+
+            @Test
+            @DisplayName("ANNUAL_LEAVE_SHEET_NOT_FOUND 예외를 던진다")
+            void it_throws_when_sheet_not_found() throws IOException {
+                // given
+                User admin = createMockUser(Authority.MANAGE_ANNUAL_LEAVE);
+                given(userRepository.findById(loginUserId)).willReturn(Optional.of(admin));
+                MultipartFile mockFile = createMockExcelFile();
+                given(s3Service.uploadFile(mockFile)).willReturn("annual-leave/history.xlsx");
+
+                // when & then
+                assertThatThrownBy(
+                                () ->
+                                        annualLeaveService.uploadAnnualLeaveFile(
+                                                mockFile,
+                                                "6월 1일 연차 기준현황",
+                                                loginUserId,
+                                                Company.AWESOME))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessageContaining("입력한 시트명을 엑셀 파일에서 찾을 수 없습니다.");
             }
         }
 
@@ -833,6 +860,25 @@ public class AnnualLeaveServiceTest {
         }
 
         @Nested
+        @DisplayName("ANNUAL_LEAVE_SHEET_NOT_FOUND 상수가")
+        class Context_ANNUAL_LEAVE_SHEET_NOT_FOUND {
+
+            @Test
+            @DisplayName("정의되어 있어야 하고 HttpStatus.BAD_REQUEST와 지정된 메시지를 가진다")
+            void it_has_correct_status_and_message() {
+                // given & when
+                kr.co.awesomelead.groupware_backend.global.error.ErrorCode code =
+                        kr.co.awesomelead.groupware_backend.global.error.ErrorCode.valueOf(
+                                "ANNUAL_LEAVE_SHEET_NOT_FOUND");
+
+                // then
+                assertThat(code.getHttpStatus())
+                        .isEqualTo(org.springframework.http.HttpStatus.BAD_REQUEST);
+                assertThat(code.getMessage()).isEqualTo("입력한 시트명을 엑셀 파일에서 찾을 수 없습니다.");
+            }
+        }
+
+        @Nested
         @DisplayName("ANNUAL_LEAVE_MONTH_MISMATCH 상수가")
         class Context_ANNUAL_LEAVE_MONTH_MISMATCH {
 
@@ -877,7 +923,7 @@ public class AnnualLeaveServiceTest {
     class Describe_uploadAnnualLeaveFile_duplicateCheck {
 
         private final Long loginUserId = 1L;
-        private final String sheetName = "2026-06";
+        private final String sheetName = "8월";
 
         @Nested
         @DisplayName("같은 월에 이미 발송 이력이 존재하면")
@@ -941,7 +987,7 @@ public class AnnualLeaveServiceTest {
                 given(userRepository.findByNameAndJoinDate(anyString(), any()))
                         .willReturn(Optional.of(targetUser));
                 given(annualLeaveRepository.findByUser(targetUser)).willReturn(Optional.empty());
-                given(s3Service.uploadFile(mockFile)).willReturn("annual-leave/2026-06.xlsx");
+                given(s3Service.uploadFile(mockFile)).willReturn("annual-leave/2026-08.xlsx");
 
                 // when
                 ExcelUploadResponseDto response =
@@ -971,7 +1017,8 @@ public class AnnualLeaveServiceTest {
                 User admin = createMockUser(Authority.MANAGE_ANNUAL_LEAVE);
                 given(userRepository.findById(loginUserId)).willReturn(Optional.of(admin));
 
-                MultipartFile mockFile = createMockExcelFile();
+                MultipartFile mockFile = createMockExcelFileWithSheetName("5월");
+                given(s3Service.uploadFile(mockFile)).willReturn("annual-leave/history.xlsx");
 
                 // when & then
                 assertThatThrownBy(
@@ -1047,7 +1094,7 @@ public class AnnualLeaveServiceTest {
 
         private final Long adminId = 1L;
         private final Long dispatchId = 10L;
-        private final String sheetName = "2026-06";
+        private final String sheetName = "8월";
 
         @Nested
         @DisplayName("자기 자신을 제외한 같은 월에 이미 발송 이력이 존재하면")
@@ -1139,7 +1186,7 @@ public class AnnualLeaveServiceTest {
                 given(userRepository.findByNameAndJoinDate(anyString(), any()))
                         .willReturn(Optional.of(targetUser));
                 given(annualLeaveRepository.findByUser(targetUser)).willReturn(Optional.empty());
-                given(s3Service.uploadFile(mockFile)).willReturn("annual-leave/2026-06.xlsx");
+                given(s3Service.uploadFile(mockFile)).willReturn("annual-leave/2026-08.xlsx");
 
                 // when
                 ExcelUploadResponseDto result =
@@ -1278,7 +1325,7 @@ public class AnnualLeaveServiceTest {
     class Describe_uploadAnnualLeaveFile_company_duplicate_check {
 
         private final Long loginUserId = 1L;
-        private final String sheetName = "2026-06";
+        private final String sheetName = "8월";
 
         @Nested
         @DisplayName("같은 Company + 같은 월에 이미 이력이 존재하면")
@@ -1343,7 +1390,7 @@ public class AnnualLeaveServiceTest {
                 given(userRepository.findByNameAndJoinDate(anyString(), any()))
                         .willReturn(Optional.of(targetUser));
                 given(annualLeaveRepository.findByUser(targetUser)).willReturn(Optional.empty());
-                given(s3Service.uploadFile(mockFile)).willReturn("annual-leave/2026-06.xlsx");
+                given(s3Service.uploadFile(mockFile)).willReturn("annual-leave/2026-08.xlsx");
 
                 // when
                 ExcelUploadResponseDto response =
@@ -1497,5 +1544,20 @@ public class AnnualLeaveServiceTest {
                 "wrong_annual_leave_test.xlsx",
                 "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
                 resource.getInputStream());
+    }
+
+    private MultipartFile createMockExcelFileWithSheetName(String sheetName) throws IOException {
+        ClassPathResource resource = new ClassPathResource("excel/annual_leave_test.xlsx");
+        try (org.apache.poi.ss.usermodel.Workbook workbook =
+                        org.apache.poi.ss.usermodel.WorkbookFactory.create(resource.getInputStream());
+                ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            workbook.setSheetName(0, sheetName);
+            workbook.write(outputStream);
+            return new MockMultipartFile(
+                    "file",
+                    "annual_leave_test.xlsx",
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    outputStream.toByteArray());
+        }
     }
 }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
@@ -451,8 +451,10 @@ public class AnnualLeaveServiceTest {
                             .id(dispatchId)
                             .uploadedBy(admin)
                             .originalFileName("old.xlsx")
-                            .sheetName("7월")
+                            .sheetName("8월")
                             .fileKey("annual-leave/old.xlsx")
+                            .baseDate(LocalDate.of(2026, 8, 1))
+                            .company(Company.AWESOME)
                             .build();
             given(annualLeaveDispatchHistoryRepository.findById(dispatchId))
                     .willReturn(Optional.of(history));
@@ -883,6 +885,26 @@ public class AnnualLeaveServiceTest {
         }
 
         @Nested
+        @DisplayName("ANNUAL_LEAVE_DISPATCH_MONTH_MISMATCH 상수가")
+        class Context_ANNUAL_LEAVE_DISPATCH_MONTH_MISMATCH {
+
+            @Test
+            @DisplayName("정의되어 있어야 하고 HttpStatus.BAD_REQUEST와 지정된 메시지를 가진다")
+            void it_has_correct_status_and_message() {
+                // given & when
+                kr.co.awesomelead.groupware_backend.global.error.ErrorCode code =
+                        kr.co.awesomelead.groupware_backend.global.error.ErrorCode.valueOf(
+                                "ANNUAL_LEAVE_DISPATCH_MONTH_MISMATCH");
+
+                // then
+                assertThat(code.getHttpStatus())
+                        .isEqualTo(org.springframework.http.HttpStatus.BAD_REQUEST);
+                assertThat(code.getMessage())
+                        .isEqualTo("수정하려는 연차 발송 월과 엑셀 기준일의 월이 일치하지 않습니다.");
+            }
+        }
+
+        @Nested
         @DisplayName("ANNUAL_LEAVE_MONTH_MISMATCH 상수가")
         class Context_ANNUAL_LEAVE_MONTH_MISMATCH {
 
@@ -1101,6 +1123,49 @@ public class AnnualLeaveServiceTest {
         private final String sheetName = "8월";
 
         @Nested
+        @DisplayName("수정 대상 월과 엑셀 기준월이 다르면")
+        class Context_when_dispatch_month_mismatch {
+
+            @Test
+            @DisplayName("ANNUAL_LEAVE_DISPATCH_MONTH_MISMATCH 예외를 던진다")
+            void updateAnnualLeaveDispatchForAdmin_throwsWhenDispatchMonthMismatch()
+                    throws IOException {
+                // given
+                User admin = createMockUser(Authority.MANAGE_ANNUAL_LEAVE);
+                given(userRepository.findById(adminId)).willReturn(Optional.of(admin));
+
+                AnnualLeaveDispatchHistory history =
+                        AnnualLeaveDispatchHistory.builder()
+                                .id(dispatchId)
+                                .uploadedBy(admin)
+                                .originalFileName("old.xlsx")
+                                .sheetName("6월")
+                                .fileKey("annual-leave/old.xlsx")
+                                .baseDate(LocalDate.of(2026, 6, 1))
+                                .company(Company.AWESOME)
+                                .build();
+                given(annualLeaveDispatchHistoryRepository.findById(dispatchId))
+                        .willReturn(Optional.of(history));
+
+                MultipartFile mockFile = createMockExcelFile();
+
+                // when & then
+                assertThatThrownBy(
+                                () ->
+                                        annualLeaveService.updateAnnualLeaveDispatchForAdmin(
+                                                adminId,
+                                                dispatchId,
+                                                mockFile,
+                                                sheetName,
+                                                Company.AWESOME))
+                        .isInstanceOf(CustomException.class)
+                        .hasMessageContaining("수정하려는 연차 발송 월과 엑셀 기준일의 월이 일치하지 않습니다.");
+                org.mockito.Mockito.verify(s3Service, org.mockito.Mockito.never())
+                        .uploadFile(mockFile);
+            }
+        }
+
+        @Nested
         @DisplayName("자기 자신을 제외한 같은 월에 이미 발송 이력이 존재하면")
         class Context_when_duplicate_exists_excluding_self {
 
@@ -1117,8 +1182,10 @@ public class AnnualLeaveServiceTest {
                                 .id(dispatchId)
                                 .uploadedBy(admin)
                                 .originalFileName("old.xlsx")
-                                .sheetName("2026-05")
+                                .sheetName("8월")
                                 .fileKey("annual-leave/old.xlsx")
+                                .baseDate(LocalDate.of(2026, 8, 1))
+                                .company(Company.AWESOME)
                                 .build();
                 given(annualLeaveDispatchHistoryRepository.findById(dispatchId))
                         .willReturn(Optional.of(history));
@@ -1166,8 +1233,10 @@ public class AnnualLeaveServiceTest {
                                 .id(dispatchId)
                                 .uploadedBy(admin)
                                 .originalFileName("old.xlsx")
-                                .sheetName("2026-05")
+                                .sheetName("8월")
                                 .fileKey("annual-leave/old.xlsx")
+                                .baseDate(LocalDate.of(2026, 8, 1))
+                                .company(Company.AWESOME)
                                 .build();
                 given(annualLeaveDispatchHistoryRepository.findById(dispatchId))
                         .willReturn(Optional.of(history));

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -102,7 +103,7 @@ public class AnnualLeaveServiceTest {
                 User admin = createMockUser(Authority.MANAGE_ANNUAL_LEAVE); // 연차 관리 권한 추가
                 given(userRepository.findById(loginUserId)).willReturn(Optional.of(admin));
 
-                MultipartFile mockFile = createMockExcelFile();
+                MultipartFile mockFile = createMockExcelFileWithRemark("비고 테스트");
 
                 User targetUser =
                         User.builder()
@@ -122,7 +123,10 @@ public class AnnualLeaveServiceTest {
                 // then
                 assertThat(response.getSuccessCount()).isGreaterThan(0);
                 assertThat(response.getFailureCount()).isEqualTo(0);
-                verify(annualLeaveRepository, atLeastOnce()).save(any());
+                ArgumentCaptor<AnnualLeave> annualLeaveCaptor =
+                        ArgumentCaptor.forClass(AnnualLeave.class);
+                verify(annualLeaveRepository, atLeastOnce()).save(annualLeaveCaptor.capture());
+                assertThat(annualLeaveCaptor.getValue().getRemark()).isEqualTo("비고 테스트");
                 verify(notificationService, atLeastOnce())
                         .sendAnnualLeaveAlertToUser(any(), anyString());
                 verify(annualLeaveDispatchHistoryRepository, atLeastOnce()).save(any());
@@ -1552,6 +1556,21 @@ public class AnnualLeaveServiceTest {
                         org.apache.poi.ss.usermodel.WorkbookFactory.create(resource.getInputStream());
                 ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
             workbook.setSheetName(0, sheetName);
+            workbook.write(outputStream);
+            return new MockMultipartFile(
+                    "file",
+                    "annual_leave_test.xlsx",
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    outputStream.toByteArray());
+        }
+    }
+
+    private MultipartFile createMockExcelFileWithRemark(String remark) throws IOException {
+        ClassPathResource resource = new ClassPathResource("excel/annual_leave_test.xlsx");
+        try (org.apache.poi.ss.usermodel.Workbook workbook =
+                        org.apache.poi.ss.usermodel.WorkbookFactory.create(resource.getInputStream());
+                ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            workbook.getSheet("8월").getRow(7).getCell(10).setCellValue(remark);
             workbook.write(outputStream);
             return new MockMultipartFile(
                     "file",


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #503 

## 📝작업 내용
- 연차 엑셀 업로드 시 입력한 시트명이 엑셀 파일에 없으면 첫 번째 시트를 읽지 않고 에러를 반환하도록 수정했습니다.
- 연차 발송/수정 전 시트명 월과 엑셀 기준일 월을 먼저 검증하도록 처리 순서를 개선했습니다.
- 연차 수정 시 기존 발송 이력의 기준월과 새로 업로드한 엑셀 기준월이 다르면 별도 에러를 반환하도록 추가했습니다.
- “6월 1일”처럼 월 외 날짜 숫자가 포함된 시트명을 허용하지 않도록 검증을 강화했습니다.
- 연차 조회 응답에 엑셀 K열의 비고 값을 `remark` 필드로 내려주도록 추가했습니다.
- 관련 서비스 테스트를 추가/수정했습니다.

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X