### PR TITLE
fix(505): 운영 관리 API 응답 및 파일 처리 개선

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/dto/response/AdminAnnualLeaveDispatchItemResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/dto/response/AdminAnnualLeaveDispatchItemResponseDto.java
@@ -7,6 +7,8 @@ import kr.co.awesomelead.groupware_backend.domain.department.enums.Company;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Builder
 @Schema(description = "관리자용 연차 발송 목록 아이템")
@@ -29,4 +31,13 @@ public class AdminAnnualLeaveDispatchItemResponseDto {
 
     @Schema(description = "소속 회사", example = "AWESOME")
     private Company company;
+
+    @Schema(description = "업로드 시각", example = "2026-05-31T15:29:04")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "발송자 이름", example = "김관리")
+    private String senderName;
+
+    @Schema(description = "발송자 직급", example = "과장")
+    private String senderPosition;
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
@@ -432,6 +432,9 @@ public class AnnualLeaveService {
                         s3Service.getPresignedDownloadUrl(
                                 history.getFileKey(), history.getOriginalFileName()))
                 .company(history.getCompany())
+                .createdAt(history.getCreatedAt())
+                .senderName(resolveSenderName(history))
+                .senderPosition(resolveSenderPosition(history))
                 .build();
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/AdminEducationCategoryController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/controller/AdminEducationCategoryController.java
@@ -14,6 +14,7 @@ import kr.co.awesomelead.groupware_backend.domain.education.dto.request.Educatio
 import kr.co.awesomelead.groupware_backend.domain.education.dto.request.EducationCategoryReorderRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.education.dto.request.EducationCategoryUpdateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.education.dto.response.AdminEducationCategoryNodeDto;
+import kr.co.awesomelead.groupware_backend.domain.education.dto.response.AdminEducationCategoryResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.education.enums.EducationCategoryType;
 import kr.co.awesomelead.groupware_backend.domain.education.service.AdminEducationCategoryService;
 import kr.co.awesomelead.groupware_backend.domain.user.dto.CustomUserDetails;
@@ -53,6 +54,23 @@ public class AdminEducationCategoryController {
         return ResponseEntity.ok(
                 ApiResponse.onSuccess(
                         adminEducationCategoryService.getCategoryTree(userDetails.getId(), type)));
+    }
+
+    @Operation(
+            summary = "관리자용 비활성 교육 카테고리 목록 조회",
+            description = "유형(PSM/SAFETY)에 해당하는 비활성 카테고리 목록을 조회합니다.")
+    @GetMapping("/inactive")
+    public ResponseEntity<ApiResponse<List<AdminEducationCategoryResponseDto>>>
+            getInactiveCategories(
+                    @Parameter(hidden = true) @AuthenticationPrincipal
+                            CustomUserDetails userDetails,
+                    @Parameter(description = "카테고리 유형", example = "SAFETY", required = true)
+                            @RequestParam
+                            EducationCategoryType type) {
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(
+                        adminEducationCategoryService.getInactiveCategories(
+                                userDetails.getId(), type)));
     }
 
     @Operation(summary = "교육 카테고리 생성", description = "관리자가 교육 카테고리를 생성합니다.")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/AdminEducationCategoryResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/dto/response/AdminEducationCategoryResponseDto.java
@@ -1,0 +1,42 @@
+package kr.co.awesomelead.groupware_backend.domain.education.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import kr.co.awesomelead.groupware_backend.domain.education.enums.EducationCategoryType;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class AdminEducationCategoryResponseDto {
+
+    @Schema(description = "카테고리 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "카테고리 코드", example = "SAFETY_RESOURCE")
+    private String code;
+
+    @Schema(description = "카테고리명", example = "안전보건 자료")
+    private String name;
+
+    @Schema(description = "카테고리 유형", example = "SAFETY")
+    private EducationCategoryType categoryType;
+
+    @Schema(description = "부모 카테고리 ID", example = "10")
+    private Long parentId;
+
+    @Schema(description = "부모 카테고리명", example = "안전보건")
+    private String parentName;
+
+    @Schema(description = "카테고리 깊이", example = "1")
+    private int depth;
+
+    @Schema(description = "정렬 순서", example = "1")
+    private int sortOrder;
+
+    @Schema(description = "활성 여부", example = "false")
+    private boolean active;
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EducationCategoryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/repository/EducationCategoryRepository.java
@@ -17,6 +17,9 @@ public interface EducationCategoryRepository extends JpaRepository<EducationCate
     List<EducationCategory> findAllByCategoryTypeAndActiveTrueOrderByDepthAscSortOrderAscIdAsc(
             EducationCategoryType categoryType);
 
+    List<EducationCategory> findAllByCategoryTypeAndActiveFalseOrderByDepthAscSortOrderAscIdAsc(
+            EducationCategoryType categoryType);
+
     List<EducationCategory> findAllByCategoryTypeOrderByDepthAscSortOrderAscIdAsc(
             EducationCategoryType categoryType);
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/AdminEducationCategoryService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/AdminEducationCategoryService.java
@@ -4,6 +4,7 @@ import kr.co.awesomelead.groupware_backend.domain.education.dto.request.Educatio
 import kr.co.awesomelead.groupware_backend.domain.education.dto.request.EducationCategoryReorderRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.education.dto.request.EducationCategoryUpdateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.education.dto.response.AdminEducationCategoryNodeDto;
+import kr.co.awesomelead.groupware_backend.domain.education.dto.response.AdminEducationCategoryResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.education.entity.EducationCategory;
 import kr.co.awesomelead.groupware_backend.domain.education.enums.EducationCategoryType;
 import kr.co.awesomelead.groupware_backend.domain.education.repository.EducationCategoryRepository;
@@ -72,6 +73,17 @@ public class AdminEducationCategoryService {
         }
 
         return roots;
+    }
+
+    @Transactional(readOnly = true)
+    public List<AdminEducationCategoryResponseDto> getInactiveCategories(
+            Long adminId, EducationCategoryType type) {
+        validateCategoryManageAuthority(adminId);
+
+        return educationCategoryRepository
+                .findAllByCategoryTypeAndActiveFalseOrderByDepthAscSortOrderAscIdAsc(type).stream()
+                .map(this::toCategoryResponseDto)
+                .toList();
     }
 
     @Transactional
@@ -223,5 +235,20 @@ public class AdminEducationCategoryService {
         if (admin.getRole() != Role.ADMIN && admin.getRole() != Role.MASTER_ADMIN) {
             throw new CustomException(ErrorCode.NO_AUTHORITY_FOR_EDUCATION_CATEGORY_MANAGE);
         }
+    }
+
+    private AdminEducationCategoryResponseDto toCategoryResponseDto(EducationCategory category) {
+        EducationCategory parent = category.getParent();
+        return AdminEducationCategoryResponseDto.builder()
+                .id(category.getId())
+                .code(category.getCode())
+                .name(category.getName())
+                .categoryType(category.getCategoryType())
+                .parentId(parent != null ? parent.getId() : null)
+                .parentName(parent != null ? parent.getName() : null)
+                .depth(category.getDepth())
+                .sortOrder(category.getSortOrder())
+                .active(category.isActive())
+                .build();
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/AdminEducationCategoryService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/education/service/AdminEducationCategoryService.java
@@ -81,7 +81,8 @@ public class AdminEducationCategoryService {
         validateCategoryManageAuthority(adminId);
 
         return educationCategoryRepository
-                .findAllByCategoryTypeAndActiveFalseOrderByDepthAscSortOrderAscIdAsc(type).stream()
+                .findAllByCategoryTypeAndActiveFalseOrderByDepthAscSortOrderAscIdAsc(type)
+                .stream()
                 .map(this::toCategoryResponseDto)
                 .toList();
     }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/mapper/NoticeMapper.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/notice/mapper/NoticeMapper.java
@@ -47,9 +47,7 @@ public interface NoticeMapper {
 
     @Mapping(
             target = "viewUrl",
-            expression =
-                    "java(s3Service.getPresignedDownloadUrl(attachment.getS3Key(),"
-                            + " attachment.getOriginalFileName()))")
+            expression = "java(s3Service.getProxyViewUrl(attachment.getS3Key()))")
     NoticeDetailDto.AttachmentResponse toAttachmentResponse(
             NoticeAttachment attachment, @Context S3Service s3Service);
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/controller/SafetyTrainingSessionController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/controller/SafetyTrainingSessionController.java
@@ -21,12 +21,12 @@ import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.request.Saf
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.request.SafetyTrainingSessionSearchConditionDto;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.request.SafetyTrainingSessionStatusUpdateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.request.SafetyTrainingSessionUpdateRequestDto;
-import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.response.SafetyTrainingPreviewResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.response.SafetyTrainingSessionAttendeesResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.response.SafetyTrainingSessionDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.response.SafetyTrainingSessionReportResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.response.SafetyTrainingSessionSummaryResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.service.SafetyTrainingSessionService;
+import kr.co.awesomelead.groupware_backend.domain.safetytraining.service.SafetyTrainingSessionService.ExcelDownload;
 import kr.co.awesomelead.groupware_backend.domain.user.dto.CustomUserDetails;
 import kr.co.awesomelead.groupware_backend.global.common.response.ApiResponse;
 import kr.co.awesomelead.groupware_backend.global.error.CustomException;
@@ -54,6 +54,8 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.List;
 import java.util.Set;
 
@@ -86,6 +88,8 @@ import java.util.Set;
               - `AWESOME`(어썸리드), `MARUI`(한국마루이)
             """)
 public class SafetyTrainingSessionController {
+    private static final String EXCEL_CONTENT_TYPE =
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
 
     private final SafetyTrainingSessionService safetyTrainingSessionService;
     private final ObjectMapper objectMapper;
@@ -255,8 +259,8 @@ public class SafetyTrainingSessionController {
                         description = "생성 성공",
                         content =
                                 @Content(
-                                        mediaType = "application/json",
-                                        schema = @Schema(implementation = ApiResponse.class))),
+                                        mediaType =
+                                                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")),
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
                         responseCode = "403",
                         description = "관리 권한 없음",
@@ -279,14 +283,13 @@ public class SafetyTrainingSessionController {
                         description = "교육일지/사용자 없음")
             })
     @PostMapping("/{sessionId}/report")
-    public ResponseEntity<ApiResponse<SafetyTrainingSessionReportResponseDto>>
-            generateSessionReport(
+    public ResponseEntity<byte[]> generateSessionReport(
                     @PathVariable Long sessionId,
                     @Parameter(hidden = true) @AuthenticationPrincipal
                             CustomUserDetails userDetails) {
-        SafetyTrainingSessionReportResponseDto result =
+        ExcelDownload result =
                 safetyTrainingSessionService.generateSessionReport(sessionId, userDetails.getId());
-        return ResponseEntity.ok(ApiResponse.onSuccess(result));
+        return excelDownloadResponse(result);
     }
 
     @Operation(
@@ -733,13 +736,21 @@ public class SafetyTrainingSessionController {
                               "companyScope": "AWESOME"
                             }
                             """))))
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "미리보기 엑셀 생성 성공",
+                content =
+                        @Content(
+                                mediaType =
+                                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
+    })
     @PostMapping("/preview")
-    public ResponseEntity<ApiResponse<SafetyTrainingPreviewResponseDto>> preview(
+    public ResponseEntity<byte[]> preview(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody SafetyTrainingSessionCreateRequestDto requestDto) {
-        return ResponseEntity.ok(
-                ApiResponse.onSuccess(
-                        safetyTrainingSessionService.preview(userDetails.getId(), requestDto)));
+        ExcelDownload result = safetyTrainingSessionService.preview(userDetails.getId(), requestDto);
+        return excelDownloadResponse(result);
     }
 
     @Operation(
@@ -1002,5 +1013,19 @@ public class SafetyTrainingSessionController {
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         safetyTrainingSessionService.remindSession(sessionId, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onNoContent());
+    }
+
+    private ResponseEntity<byte[]> excelDownloadResponse(ExcelDownload download) {
+        String encodedFilename;
+        try {
+            encodedFilename = URLEncoder.encode(download.fileName(), "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            encodedFilename = download.fileName();
+        }
+        return ResponseEntity.ok()
+                .header("Content-Disposition", "attachment; filename*=UTF-8''" + encodedFilename)
+                .header("Access-Control-Expose-Headers", "Content-Disposition")
+                .header("Content-Type", EXCEL_CONTENT_TYPE)
+                .body(download.bytes());
     }
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/controller/SafetyTrainingSessionController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/controller/SafetyTrainingSessionController.java
@@ -284,9 +284,8 @@ public class SafetyTrainingSessionController {
             })
     @PostMapping("/{sessionId}/report")
     public ResponseEntity<byte[]> generateSessionReport(
-                    @PathVariable Long sessionId,
-                    @Parameter(hidden = true) @AuthenticationPrincipal
-                            CustomUserDetails userDetails) {
+            @PathVariable Long sessionId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         ExcelDownload result =
                 safetyTrainingSessionService.generateSessionReport(sessionId, userDetails.getId());
         return excelDownloadResponse(result);
@@ -749,7 +748,8 @@ public class SafetyTrainingSessionController {
     public ResponseEntity<byte[]> preview(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody SafetyTrainingSessionCreateRequestDto requestDto) {
-        ExcelDownload result = safetyTrainingSessionService.preview(userDetails.getId(), requestDto);
+        ExcelDownload result =
+                safetyTrainingSessionService.preview(userDetails.getId(), requestDto);
         return excelDownloadResponse(result);
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingPreviewResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingPreviewResponseDto.java
@@ -13,7 +13,7 @@ public class SafetyTrainingPreviewResponseDto {
     @Schema(description = "미리보기 파일 URL", example = "https://...presigned-url")
     private String previewFileUrl;
 
-    @Schema(description = "미리보기 다운로드 파일명", example = "20260324_정기_안전보건교육.xls")
+    @Schema(description = "미리보기 다운로드 파일명", example = "20260324_정기_안전보건교육.xlsx")
     private String previewFileName;
 
     @Schema(description = "교육 대상 인원 수", example = "49")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingSessionReportResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/dto/response/SafetyTrainingSessionReportResponseDto.java
@@ -16,6 +16,6 @@ public class SafetyTrainingSessionReportResponseDto {
     @Schema(description = "엑셀 파일 URL", example = "https://...presigned-url")
     private String reportFileUrl;
 
-    @Schema(description = "엑셀 파일명", example = "20260324_정기_안전보건교육.xls")
+    @Schema(description = "엑셀 파일명", example = "20260324_정기_안전보건교육.xlsx")
     private String reportFileName;
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
@@ -8,7 +8,6 @@ import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.request.Saf
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.request.SafetyTrainingSessionSearchConditionDto;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.request.SafetyTrainingSessionStatusUpdateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.request.SafetyTrainingSessionUpdateRequestDto;
-import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.response.SafetyTrainingPreviewResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.response.SafetyTrainingSessionAttendeesResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.response.SafetyTrainingSessionDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.safetytraining.dto.response.SafetyTrainingSessionReportResponseDto;
@@ -62,7 +61,7 @@ public class SafetyTrainingSessionService {
             DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH시 mm분");
     private static final DateTimeFormatter FILE_DATE_FORMATTER =
             DateTimeFormatter.ofPattern("yyyyMMdd");
-    private static final String EXCEL_FILE_EXTENSION = ".xls";
+    private static final String EXCEL_FILE_EXTENSION = ".xlsx";
 
     private final SafetyTrainingSessionRepository sessionRepository;
     private final SafetyTrainingSessionAttendeeRepository attendeeRepository;
@@ -73,8 +72,10 @@ public class SafetyTrainingSessionService {
     private final S3Service s3Service;
     private final NotificationService notificationService;
 
+    public record ExcelDownload(String fileName, byte[] bytes) {}
+
     @Transactional(readOnly = true)
-    public SafetyTrainingPreviewResponseDto preview(
+    public ExcelDownload preview(
             Long userId, SafetyTrainingSessionCreateRequestDto requestDto) {
         User actor =
                 userRepository
@@ -91,25 +92,10 @@ public class SafetyTrainingSessionService {
         byte[] excelBytes =
                 safetyTrainingExcelService.buildPreviewExcel(
                         requestDto, educationDateText, attendees, instructor.getNameKor());
-
-        String previewFileKey =
-                s3Service.uploadBytes(
-                        excelBytes,
-                        "safety-training-preview-"
-                                + System.currentTimeMillis()
-                                + EXCEL_FILE_EXTENSION,
-                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
         String previewFileName =
                 buildExportFileName(requestDto.getStartAt(), requestDto.getTitle());
-        String previewUrl = s3Service.getPresignedDownloadUrl(previewFileKey, previewFileName);
 
-        return SafetyTrainingPreviewResponseDto.builder()
-                .previewFileUrl(previewUrl)
-                .previewFileName(previewFileName)
-                .targetCount(attendees.size())
-                .attendedCount(0)
-                .absentCount(0)
-                .build();
+        return new ExcelDownload(previewFileName, excelBytes);
     }
 
     @Transactional
@@ -425,7 +411,7 @@ public class SafetyTrainingSessionService {
     }
 
     @Transactional
-    public SafetyTrainingSessionReportResponseDto generateSessionReport(
+    public ExcelDownload generateSessionReport(
             Long sessionId, Long userId) {
         User actor =
                 userRepository
@@ -467,32 +453,8 @@ public class SafetyTrainingSessionService {
                         attendees,
                         signatureImagesByUserId);
 
-        String previousReportKey = session.getReportFileKey();
-        String newReportKey =
-                s3Service.uploadBytes(
-                        reportExcel,
-                        "safety-training-report-"
-                                + session.getId()
-                                + "-"
-                                + System.currentTimeMillis()
-                                + EXCEL_FILE_EXTENSION,
-                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-        session.setReportFileKey(newReportKey);
-
-        if (previousReportKey != null && !previousReportKey.equals(newReportKey)) {
-            try {
-                s3Service.deleteFile(previousReportKey);
-            } catch (Exception ignored) {
-                // 이전 보고서 정리 실패는 현재 요청을 실패시키지 않음
-            }
-        }
-
         String reportFileName = buildExportFileName(session.getStartAt(), session.getTitle());
-        return SafetyTrainingSessionReportResponseDto.builder()
-                .sessionId(session.getId())
-                .reportFileUrl(s3Service.getPresignedDownloadUrl(newReportKey, reportFileName))
-                .reportFileName(reportFileName)
-                .build();
+        return new ExcelDownload(reportFileName, reportExcel);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/safetytraining/service/SafetyTrainingSessionService.java
@@ -75,8 +75,7 @@ public class SafetyTrainingSessionService {
     public record ExcelDownload(String fileName, byte[] bytes) {}
 
     @Transactional(readOnly = true)
-    public ExcelDownload preview(
-            Long userId, SafetyTrainingSessionCreateRequestDto requestDto) {
+    public ExcelDownload preview(Long userId, SafetyTrainingSessionCreateRequestDto requestDto) {
         User actor =
                 userRepository
                         .findById(userId)
@@ -411,8 +410,7 @@ public class SafetyTrainingSessionService {
     }
 
     @Transactional
-    public ExcelDownload generateSessionReport(
-            Long sessionId, Long userId) {
+    public ExcelDownload generateSessionReport(Long sessionId, Long userId) {
         User actor =
                 userRepository
                         .findById(userId)

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/response/VisitListResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/visit/dto/response/VisitListResponseDto.java
@@ -2,6 +2,7 @@ package kr.co.awesomelead.groupware_backend.domain.visit.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitCategory;
 import kr.co.awesomelead.groupware_backend.domain.visit.enums.VisitStatus;
 
 import lombok.AllArgsConstructor;
@@ -37,4 +38,7 @@ public class VisitListResponseDto {
 
     @Schema(description = "방문 상태", example = "방문 중")
     private VisitStatus status;
+
+    @Schema(description = "방문 유형", example = "PRE_ONE_DAY")
+    private VisitCategory visitCategory;
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/infra/s3/controller/S3Controller.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/infra/s3/controller/S3Controller.java
@@ -7,6 +7,7 @@ import kr.co.awesomelead.groupware_backend.global.error.CustomException;
 import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
 import kr.co.awesomelead.groupware_backend.global.infra.s3.dto.response.FileUploadResponseDto;
 import kr.co.awesomelead.groupware_backend.global.infra.s3.service.S3Service;
+import kr.co.awesomelead.groupware_backend.global.infra.s3.service.S3Service.S3File;
 
 import lombok.RequiredArgsConstructor;
 
@@ -14,6 +15,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -35,9 +37,33 @@ public class S3Controller {
     public ResponseEntity<ApiResponse<FileUploadResponseDto>> uploadFile(
             @RequestPart("file") MultipartFile file) throws IOException {
 
-        FileUploadResponseDto response = s3Service.uploadEditorFile(file);
+        FileUploadResponseDto uploaded = s3Service.uploadEditorFile(file);
+        FileUploadResponseDto response =
+                FileUploadResponseDto.builder()
+                        .fileKey(uploaded.getFileKey())
+                        .fileName(uploaded.getFileName())
+                        .imageUrl(s3Service.getProxyViewUrl(uploaded.getFileKey()))
+                        .build();
 
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "파일 보기", description = "S3 파일 키(fileKey)를 입력하여 파일 바이트를 바로 조회합니다.")
+    @GetMapping("/view")
+    public ResponseEntity<byte[]> viewFile(@RequestParam("fileKey") String fileKey) {
+        if (!StringUtils.hasText(fileKey)) {
+            throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+        }
+
+        S3File file = s3Service.downloadFileWithMetadata(fileKey.trim());
+        String contentType =
+                StringUtils.hasText(file.contentType())
+                        ? file.contentType()
+                        : MediaType.APPLICATION_OCTET_STREAM_VALUE;
+        return ResponseEntity.ok()
+                .header("Content-Type", contentType)
+                .header("Cache-Control", "private, max-age=300")
+                .body(file.bytes());
     }
 
     @Operation(summary = "파일 단일 삭제", description = "파일 키(fileKey)를 입력하여 S3 파일을 삭제합니다.")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/infra/s3/service/S3Service.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/infra/s3/service/S3Service.java
@@ -12,6 +12,7 @@ import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
@@ -39,6 +40,8 @@ public class S3Service {
     @Value("${spring.cloud.aws.region.static}")
     private String region;
 
+    public record S3File(String contentType, byte[] bytes) {}
+
     public String getPresignedViewUrl(String fileKey) {
         return generatePresignedUrl(fileKey, Duration.ofMinutes(30)); // 30분짜리 권한
     }
@@ -48,6 +51,14 @@ public class S3Service {
                 fileKey,
                 Duration.ofMinutes(30),
                 buildAttachmentContentDisposition(downloadFileName));
+    }
+
+    public String getProxyViewUrl(String fileKey) {
+        if (fileKey == null || fileKey.isBlank()) {
+            return null;
+        }
+        return "/api/files/view?fileKey="
+                + URLEncoder.encode(fileKey, StandardCharsets.UTF_8).replace("+", "%20");
     }
 
     public String generatePresignedUrl(String fileKey, Duration duration) {
@@ -124,7 +135,7 @@ public class S3Service {
         return FileUploadResponseDto.builder()
                 .fileKey(fileKey)
                 .fileName(originalFileName)
-                .imageUrl(getPresignedViewUrl(fileKey))
+                .imageUrl(getProxyViewUrl(fileKey))
                 .build();
     }
 
@@ -196,6 +207,18 @@ public class S3Service {
         try {
             return s3Client.getObjectAsBytes(builder -> builder.bucket(bucketName).key(fileKey))
                     .asByteArray();
+        } catch (Exception e) {
+            log.error("S3 파일 다운로드 실패: {}", e.getMessage());
+            throw new RuntimeException("파일 다운로드 중 오류가 발생했습니다.");
+        }
+    }
+
+    public S3File downloadFileWithMetadata(String fileKey) {
+        try {
+            var responseBytes =
+                    s3Client.getObjectAsBytes(builder -> builder.bucket(bucketName).key(fileKey));
+            GetObjectResponse response = responseBytes.response();
+            return new S3File(response.contentType(), responseBytes.asByteArray());
         } catch (Exception e) {
             log.error("S3 파일 다운로드 실패: {}", e.getMessage());
             throw new RuntimeException("파일 다운로드 중 오류가 발생했습니다.");

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
@@ -323,6 +323,7 @@ public class AnnualLeaveServiceTest {
             // given
             Long adminId = 1L;
             User admin = createMockUser(Authority.MANAGE_ANNUAL_LEAVE);
+            admin.setPosition(Position.MANAGER);
             given(userRepository.findById(adminId)).willReturn(Optional.of(admin));
 
             AnnualLeaveDispatchHistory first =
@@ -333,6 +334,7 @@ public class AnnualLeaveServiceTest {
                             .sheetName("2026-06")
                             .fileKey("annual-leave/2026-06-first.xlsx")
                             .baseDate(LocalDate.of(2026, 6, 1))
+                            .createdAt(LocalDateTime.of(2026, 6, 1, 9, 0))
                             .company(Company.AWESOME)
                             .build();
             AnnualLeaveDispatchHistory second =
@@ -343,6 +345,7 @@ public class AnnualLeaveServiceTest {
                             .sheetName("2026-06")
                             .fileKey("annual-leave/2026-06-second.xlsx")
                             .baseDate(LocalDate.of(2026, 6, 1))
+                            .createdAt(LocalDateTime.of(2026, 6, 2, 9, 0))
                             .company(Company.AWESOME)
                             .build();
             AnnualLeaveDispatchHistory third =
@@ -353,6 +356,7 @@ public class AnnualLeaveServiceTest {
                             .sheetName("2026-07")
                             .fileKey("annual-leave/2026-07-first.xlsx")
                             .baseDate(LocalDate.of(2026, 7, 1))
+                            .createdAt(LocalDateTime.of(2026, 7, 1, 9, 0))
                             .company(Company.AWESOME)
                             .build();
             given(annualLeaveDispatchHistoryRepository.findAllByCompanyOrderByCreatedAtDesc(null))
@@ -385,6 +389,10 @@ public class AnnualLeaveServiceTest {
                     .isEqualTo("2026_연차현황.xlsx");
             assertThat(result.get(0).getItems().get(0).getSheetName()).isEqualTo("2026-06");
             assertThat(result.get(0).getItems().get(0).getCompany()).isEqualTo(Company.AWESOME);
+            assertThat(result.get(0).getItems().get(0).getCreatedAt())
+                    .isEqualTo(LocalDateTime.of(2026, 6, 1, 9, 0));
+            assertThat(result.get(0).getItems().get(0).getSenderName()).isEqualTo("테스트 업로더");
+            assertThat(result.get(0).getItems().get(0).getSenderPosition()).isEqualTo("과장");
             assertThat(result.get(0).getItems().get(1).getTitle()).isEqualTo("6월");
             assertThat(result.get(0).getItems().get(1).getOriginalFileName())
                     .isEqualTo("2026_연차현황_수정본.xlsx");

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/AdminEducationCategoryServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/edu/AdminEducationCategoryServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import kr.co.awesomelead.groupware_backend.domain.education.dto.response.AdminEducationCategoryNodeDto;
+import kr.co.awesomelead.groupware_backend.domain.education.dto.response.AdminEducationCategoryResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.education.entity.EducationCategory;
 import kr.co.awesomelead.groupware_backend.domain.education.enums.EducationCategoryType;
 import kr.co.awesomelead.groupware_backend.domain.education.repository.EducationCategoryRepository;
@@ -86,5 +87,53 @@ class AdminEducationCategoryServiceTest {
                         "errorCode", ErrorCode.NO_AUTHORITY_FOR_EDUCATION_CATEGORY_MANAGE);
 
         verify(userRepository).findById(userId);
+    }
+
+    @Test
+    void 관리자_조회는_비활성_카테고리_목록을_반환한다() {
+        Long adminId = 1L;
+        User admin = User.builder().id(adminId).role(Role.ADMIN).build();
+        EducationCategory parent =
+                EducationCategory.builder()
+                        .id(10L)
+                        .code("SAFETY")
+                        .name("안전보건")
+                        .categoryType(EducationCategoryType.SAFETY)
+                        .depth(0)
+                        .sortOrder(1)
+                        .active(true)
+                        .build();
+        EducationCategory inactiveCategory =
+                EducationCategory.builder()
+                        .id(11L)
+                        .code("SAFETY_RESOURCE")
+                        .name("안전보건 자료")
+                        .categoryType(EducationCategoryType.SAFETY)
+                        .parent(parent)
+                        .depth(1)
+                        .sortOrder(2)
+                        .active(false)
+                        .build();
+
+        when(userRepository.findById(adminId)).thenReturn(Optional.of(admin));
+        when(educationCategoryRepository
+                        .findAllByCategoryTypeAndActiveFalseOrderByDepthAscSortOrderAscIdAsc(
+                                EducationCategoryType.SAFETY))
+                .thenReturn(List.of(inactiveCategory));
+
+        List<AdminEducationCategoryResponseDto> result =
+                adminEducationCategoryService.getInactiveCategories(
+                        adminId, EducationCategoryType.SAFETY);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(11L);
+        assertThat(result.get(0).getCode()).isEqualTo("SAFETY_RESOURCE");
+        assertThat(result.get(0).getName()).isEqualTo("안전보건 자료");
+        assertThat(result.get(0).getCategoryType()).isEqualTo(EducationCategoryType.SAFETY);
+        assertThat(result.get(0).getParentId()).isEqualTo(10L);
+        assertThat(result.get(0).getParentName()).isEqualTo("안전보건");
+        assertThat(result.get(0).getDepth()).isEqualTo(1);
+        assertThat(result.get(0).getSortOrder()).isEqualTo(2);
+        assertThat(result.get(0).isActive()).isFalse();
     }
 }

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/visit/VisitServiceTest.java
@@ -1178,6 +1178,23 @@ public class VisitServiceTest {
         }
 
         @Test
+        @DisplayName("관리자 목록 응답에 방문 유형을 포함한다.")
+        void it_returns_visit_category() {
+            // given
+            Visit visit = createBaseVisit(VisitStatus.PENDING, VisitCategory.PRE_LONG_TERM);
+            given(visitQueryRepository.findVisitsForAdmin(null, null, null, null, pageable))
+                    .willReturn(new PageImpl<>(List.of(visit)));
+
+            // when
+            Page<VisitListResponseDto> result =
+                    visitService.getVisitsForAdmin(ADMIN_ID, null, null, null, null, pageable);
+
+            // then
+            assertThat(result.getContent().get(0).getVisitCategory())
+                    .isEqualTo(VisitCategory.PRE_LONG_TERM);
+        }
+
+        @Test
         @DisplayName("날짜 범위 없이 호출하면 null로 저장소를 호출한다.")
         void it_calls_repository_with_null_dates_when_not_provided() {
             // given


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #505 

## 📝작업 내용
- 관리자 내방객 목록 조회 응답에 방문 유형 `visitCategory`를 추가했습니다.
- 관리자 연차 발송 목록 조회 응답에 `createdAt`, `senderName`, `senderPosition`을 추가했습니다.
- 안전보건 교육 엑셀 미리보기/보고서 생성 API가 xlsx 파일 바이트를 직접 반환하도록 수정했습니다.
- 공지 파일 조회 URL을 S3 presigned URL에서 백엔드 프록시 URL(`/api/files/view`) 방식으로 변경했습니다.
- 비활성 교육 카테고리 목록 조회 API를 추가했습니다.

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [ ] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X