### PR TITLE
feat(507): 관리자 직원 이메일 변경 API 추가

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
@@ -12,8 +12,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 import jakarta.validation.Valid;
 
-import kr.co.awesomelead.groupware_backend.domain.admin.dto.request.AdminUserUpdateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.admin.dto.request.AdminUserEmailUpdateRequestDto;
+import kr.co.awesomelead.groupware_backend.domain.admin.dto.request.AdminUserUpdateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.admin.dto.request.MyInfoUpdateRejectRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.admin.dto.request.UserApprovalRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.admin.dto.response.AdminPendingMyInfoDetailResponseDto;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/controller/AdminController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
 import kr.co.awesomelead.groupware_backend.domain.admin.dto.request.AdminUserUpdateRequestDto;
+import kr.co.awesomelead.groupware_backend.domain.admin.dto.request.AdminUserEmailUpdateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.admin.dto.request.MyInfoUpdateRejectRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.admin.dto.request.UserApprovalRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.admin.dto.response.AdminPendingMyInfoDetailResponseDto;
@@ -349,6 +350,112 @@ public class AdminController {
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         adminService.updateUserInfo(userId, requestDto, userDetails.getId());
         return ResponseEntity.ok(ApiResponse.onSuccess("직원 정보가 성공적으로 수정되었습니다."));
+    }
+
+    @Operation(
+            summary = "직원 이메일 변경",
+            description =
+                    "관리자가 직원의 로그인 이메일을 변경합니다. 이메일 변경 시 해당 직원의 기존 로그인 세션은 만료되며,"
+                            + " 변경된 이메일로 다시 로그인해야 합니다.")
+    @ApiResponses(
+            value = {
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "이메일 변경 성공",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
+                                        {
+                                          "isSuccess": true,
+                                          "code": "COMMON200",
+                                          "message": "요청에 성공했습니다.",
+                                          "result": "직원 이메일이 성공적으로 변경되었습니다."
+                                        }
+                                        """))),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "400",
+                        description = "잘못된 이메일 형식",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
+                                        {
+                                          "isSuccess": false,
+                                          "code": "COMMON400",
+                                          "message": "입력값이 유효하지 않습니다.",
+                                          "result": {
+                                            "email": "유효한 이메일 형식이 아닙니다."
+                                          }
+                                        }
+                                        """))),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "403",
+                        description = "권한 없음",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
+                                        {
+                                          "isSuccess": false,
+                                          "code": "NO_AUTHORITY_FOR_EMPLOYEE_MANAGEMENT",
+                                          "message": "직원 관리 권한이 없습니다.",
+                                          "result": null
+                                        }
+                                        """))),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "404",
+                        description = "사용자 없음",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
+                                        {
+                                          "isSuccess": false,
+                                          "code": "USER_NOT_FOUND",
+                                          "message": "해당 사용자를 찾을 수 없습니다.",
+                                          "result": null
+                                        }
+                                        """))),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "409",
+                        description = "이메일 중복",
+                        content =
+                                @Content(
+                                        mediaType = "application/json",
+                                        examples =
+                                                @ExampleObject(
+                                                        value =
+                                                                """
+                                        {
+                                          "isSuccess": false,
+                                          "code": "DUPLICATE_LOGIN_ID",
+                                          "message": "이미 사용 중인 이메일입니다.",
+                                          "result": null
+                                        }
+                                        """)))
+            })
+    @PatchMapping("/users/{userId}/email")
+    public ResponseEntity<ApiResponse<String>> updateUserEmail(
+            @Parameter(description = "이메일을 변경할 사용자 ID", required = true, example = "17")
+                    @PathVariable
+                    Long userId,
+            @Valid @RequestBody AdminUserEmailUpdateRequestDto requestDto,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        adminService.updateUserEmail(userId, requestDto, userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.onSuccess("직원 이메일이 성공적으로 변경되었습니다."));
     }
 
     @Operation(summary = "회원가입 승인 대기 목록 조회", description = "승인 대기(PENDING) 사용자 목록을 조회합니다.")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/dto/request/AdminUserEmailUpdateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/dto/request/AdminUserEmailUpdateRequestDto.java
@@ -1,0 +1,23 @@
+package kr.co.awesomelead.groupware_backend.domain.admin.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Schema(description = "관리자 직원 이메일 변경 요청")
+public class AdminUserEmailUpdateRequestDto {
+
+    @Schema(
+            description = "변경할 이메일",
+            example = "new-email@example.com",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "유효한 이메일 형식이 아닙니다.")
+    private String email;
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
@@ -1,7 +1,7 @@
 package kr.co.awesomelead.groupware_backend.domain.admin.service;
 
-import kr.co.awesomelead.groupware_backend.domain.admin.dto.request.AdminUserUpdateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.admin.dto.request.AdminUserEmailUpdateRequestDto;
+import kr.co.awesomelead.groupware_backend.domain.admin.dto.request.AdminUserUpdateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.admin.dto.request.UserApprovalRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.admin.dto.response.AdminPendingMyInfoDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.admin.dto.response.AdminUserDetailResponseDto;

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/admin/service/AdminService.java
@@ -1,6 +1,7 @@
 package kr.co.awesomelead.groupware_backend.domain.admin.service;
 
 import kr.co.awesomelead.groupware_backend.domain.admin.dto.request.AdminUserUpdateRequestDto;
+import kr.co.awesomelead.groupware_backend.domain.admin.dto.request.AdminUserEmailUpdateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.admin.dto.request.UserApprovalRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.admin.dto.response.AdminPendingMyInfoDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.admin.dto.response.AdminUserDetailResponseDto;
@@ -350,6 +351,35 @@ public class AdminService {
             refreshTokenService.deleteRefreshTokenByEmail(user.getEmail());
         }
 
+        userRepository.save(user);
+    }
+
+    @Transactional
+    public void updateUserEmail(
+            Long userId, AdminUserEmailUpdateRequestDto requestDto, Long adminId) {
+        User admin =
+                userRepository
+                        .findById(adminId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        validateEmployeeManagementAuthority(admin);
+
+        User user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        String newEmail = requestDto.getEmail().trim();
+        String currentEmail = user.getEmail();
+        if (newEmail.equals(currentEmail)) {
+            return;
+        }
+
+        if (userRepository.existsByEmail(newEmail)) {
+            throw new CustomException(ErrorCode.DUPLICATE_LOGIN_ID);
+        }
+
+        refreshTokenService.deleteRefreshTokenByEmail(currentEmail);
+        user.setEmail(newEmail);
         userRepository.save(user);
     }
 

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
@@ -6,8 +6,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import kr.co.awesomelead.groupware_backend.domain.admin.dto.request.AdminUserUpdateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.admin.dto.request.AdminUserEmailUpdateRequestDto;
+import kr.co.awesomelead.groupware_backend.domain.admin.dto.request.AdminUserUpdateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.admin.dto.request.UserApprovalRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.admin.dto.response.AdminPendingMyInfoDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.admin.dto.response.AdminUserDetailResponseDto;

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/admin/AdminServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import kr.co.awesomelead.groupware_backend.domain.admin.dto.request.AdminUserUpdateRequestDto;
+import kr.co.awesomelead.groupware_backend.domain.admin.dto.request.AdminUserEmailUpdateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.admin.dto.request.UserApprovalRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.admin.dto.response.AdminPendingMyInfoDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.admin.dto.response.AdminUserDetailResponseDto;
@@ -1001,6 +1002,77 @@ class AdminServiceTest {
                 // then
                 assertThat(targetUser.getStatus()).isEqualTo(Status.PENDING);
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("updateUserEmail 메서드는")
+    class Describe_updateUserEmail {
+
+        @Test
+        @DisplayName("관리자가 직원 이메일을 변경하면 이메일을 저장하고 기존 리프레시 토큰을 삭제한다")
+        void it_updates_user_email_and_deletes_refresh_token() {
+            User targetUser =
+                    User.builder().id(17L).email("old@example.com").role(Role.USER).build();
+            when(userRepository.findById(17L)).thenReturn(Optional.of(targetUser));
+            when(userRepository.existsByEmail("new@example.com")).thenReturn(false);
+
+            AdminUserEmailUpdateRequestDto dto = new AdminUserEmailUpdateRequestDto();
+            dto.setEmail("  new@example.com  ");
+
+            adminService.updateUserEmail(17L, dto, adminId);
+
+            assertThat(targetUser.getEmail()).isEqualTo("new@example.com");
+            verify(refreshTokenService).deleteRefreshTokenByEmail("old@example.com");
+            verify(userRepository).save(targetUser);
+        }
+
+        @Test
+        @DisplayName("동일한 이메일이면 변경하지 않고 토큰을 삭제하지 않는다")
+        void it_does_nothing_when_email_is_same() {
+            User targetUser =
+                    User.builder().id(17L).email("same@example.com").role(Role.USER).build();
+            when(userRepository.findById(17L)).thenReturn(Optional.of(targetUser));
+
+            AdminUserEmailUpdateRequestDto dto = new AdminUserEmailUpdateRequestDto();
+            dto.setEmail("same@example.com");
+
+            adminService.updateUserEmail(17L, dto, adminId);
+
+            assertThat(targetUser.getEmail()).isEqualTo("same@example.com");
+        }
+
+        @Test
+        @DisplayName("이미 사용 중인 이메일이면 DUPLICATE_LOGIN_ID 에러를 던진다")
+        void it_throws_when_email_is_duplicated() {
+            User targetUser =
+                    User.builder().id(17L).email("old@example.com").role(Role.USER).build();
+            when(userRepository.findById(17L)).thenReturn(Optional.of(targetUser));
+            when(userRepository.existsByEmail("used@example.com")).thenReturn(true);
+
+            AdminUserEmailUpdateRequestDto dto = new AdminUserEmailUpdateRequestDto();
+            dto.setEmail("used@example.com");
+
+            assertThatThrownBy(() -> adminService.updateUserEmail(17L, dto, adminId))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.DUPLICATE_LOGIN_ID);
+        }
+
+        @Test
+        @DisplayName("관리자 권한이 없으면 NO_AUTHORITY_FOR_EMPLOYEE_MANAGEMENT 에러를 던진다")
+        void it_throws_when_admin_has_no_authority() {
+            User normalUser = new User();
+            normalUser.setRole(Role.USER);
+            when(userRepository.findById(adminId)).thenReturn(Optional.of(normalUser));
+
+            AdminUserEmailUpdateRequestDto dto = new AdminUserEmailUpdateRequestDto();
+            dto.setEmail("new@example.com");
+
+            assertThatThrownBy(() -> adminService.updateUserEmail(17L, dto, adminId))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.NO_AUTHORITY_FOR_EMPLOYEE_MANAGEMENT);
         }
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #507 

## 📝작업 내용
- 관리자 전용 직원 이메일 변경 API를 추가했습니다.
- 이메일 변경 요청 DTO를 추가하고, 이메일 필수값 및 형식 검증을 적용했습니다.
- 변경하려는 이메일이 이미 사용 중인 경우 `DUPLICATE_LOGIN_ID` 에러가 발생하도록 처리했습니다.
- 이메일 변경 시 기존 이메일 기준 Refresh Token을 삭제하여 재로그인이 필요하도록 처리했습니다.
- 기존 이메일과 동일한 이메일로 요청한 경우 별도 변경 없이 성공 처리되도록 했습니다.
- 관리자 직원 이메일 변경 서비스 테스트를 추가했습니다.

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X