### PR TITLE
feat: 전자결재 문서 조회 및 처리 API 구현

### DIFF
--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/controller/AnnualLeaveController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/controller/AnnualLeaveController.java
@@ -145,7 +145,7 @@ public class AnnualLeaveController {
                                     "senderPosition": "과장",
                                     "createdAt": "2026-05-31T15:29:04",
                                     "fileUrl": "https://...presigned-url",
-                                    "title": "6월",
+                                    "title": "2026년 6월",
                                     "company": "AWESOME"
                                 }
                                 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/dto/response/AdminAnnualLeaveDispatchItemResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/dto/response/AdminAnnualLeaveDispatchItemResponseDto.java
@@ -17,7 +17,7 @@ public class AdminAnnualLeaveDispatchItemResponseDto {
     @Schema(description = "발송 이력 ID", example = "10")
     private Long dispatchId;
 
-    @Schema(description = "아이템 제목(월)", example = "7월")
+    @Schema(description = "아이템 제목(연도/월)", example = "2026년 7월")
     private String title;
 
     @Schema(description = "보낸 파일명", example = "2026년_연차현황.xlsx")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/annualleave/service/AnnualLeaveService.java
@@ -451,7 +451,10 @@ public class AnnualLeaveService {
         if (period.month() == null) {
             return normalizeSheetName(history.getSheetName());
         }
-        return period.month() + "월";
+        if (period.year() == null) {
+            return period.month() + "월";
+        }
+        return period.year() + "년 " + period.month() + "월";
     }
 
     private DispatchPeriod resolveDispatchPeriod(AnnualLeaveDispatchHistory history) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/controller/ApprovalWorkflowController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/controller/ApprovalWorkflowController.java
@@ -14,6 +14,7 @@ import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalS
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDraftResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalInboxAllResponseDto;
+import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalRecallResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalSubmitResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalTemplateListResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.service.ApprovalWorkflowService;
@@ -66,6 +67,7 @@ import org.springframework.web.bind.annotation.RestController;
             - 임시저장 문서 상신: POST /api/approvals/drafts/{documentId}/submit
             - 바로 상신(임시저장 없이 1회 요청): POST /api/approvals/submit-direct
             - 문서 상세 조회: GET /api/approvals/{documentId}
+            - 문서 회수: POST /api/approvals/{documentId}/recall
 
             ### 권한 정보
             - 로그인 필요
@@ -602,6 +604,27 @@ public class ApprovalWorkflowController {
         ApprovalDraftResponseDto result =
                 approvalWorkflowService.upsertDraft(userDetails.getId(), upsertRequest);
         return ResponseEntity.ok(ApiResponse.onSuccess(result));
+    }
+
+    @Operation(
+            summary = "전자결재 문서 회수",
+            description =
+                    """
+                상신한 전자결재 문서를 회수합니다.
+
+                ### 회수 조건
+                - 기안자 본인만 회수할 수 있습니다.
+                - IN_PROGRESS(결재진행) 상태 문서만 회수할 수 있습니다.
+                - 회수 시 문서 상태는 RECALLED가 됩니다.
+                - 아직 승인/반려 처리되지 않은 결재선은 SKIPPED로 정리됩니다.
+                """)
+    @PostMapping("/approvals/{documentId}/recall")
+    public ResponseEntity<ApiResponse<ApprovalRecallResponseDto>> recall(
+            @PathVariable Long documentId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(
+                        approvalWorkflowService.recall(userDetails.getId(), documentId)));
     }
 
     @Operation(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/controller/ApprovalWorkflowController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/controller/ApprovalWorkflowController.java
@@ -12,6 +12,7 @@ import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalD
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalDraftUpdateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalDraftUpsertRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalSubmitRequestDto;
+import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalAttachmentResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDecisionResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDraftResponseDto;
@@ -25,6 +26,7 @@ import kr.co.awesomelead.groupware_backend.global.common.response.ApiResponse;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -34,7 +36,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -66,6 +72,8 @@ import org.springframework.web.bind.annotation.RestController;
             - 임시저장 생성: POST /api/approvals/drafts
             - 임시저장 수정: PUT /api/approvals/drafts/{documentId}
             - 임시저장 삭제: DELETE /api/approvals/drafts/{documentId}
+            - 첨부파일 추가: POST /api/approvals/{documentId}/attachments
+            - 첨부파일 삭제: DELETE /api/approvals/{documentId}/attachments/{attachmentId}
             - 임시저장 문서 상신: POST /api/approvals/drafts/{documentId}/submit
             - 바로 상신(임시저장 없이 1회 요청): POST /api/approvals/submit-direct
             - 문서 상세 조회: GET /api/approvals/{documentId}
@@ -607,6 +615,51 @@ public class ApprovalWorkflowController {
         ApprovalDraftResponseDto result =
                 approvalWorkflowService.upsertDraft(userDetails.getId(), upsertRequest);
         return ResponseEntity.ok(ApiResponse.onSuccess(result));
+    }
+
+    @Operation(
+            summary = "전자결재 첨부파일 추가",
+            description =
+                    """
+                전자결재 문서에 첨부파일을 추가합니다.
+
+                ### 사용 조건
+                - 기안자 본인만 추가할 수 있습니다.
+                - DRAFT/RECALLED/REJECTED 상태 문서만 수정할 수 있습니다.
+                - 요청 형식은 multipart/form-data 입니다.
+                - files 파트에 하나 이상의 파일을 전달합니다.
+                """)
+    @PostMapping(
+            value = "/approvals/{documentId}/attachments",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<List<ApprovalAttachmentResponseDto>>> uploadAttachments(
+            @PathVariable Long documentId,
+            @RequestPart("files") List<MultipartFile> files,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(
+                        approvalWorkflowService.uploadAttachments(
+                                userDetails.getId(), documentId, files)));
+    }
+
+    @Operation(
+            summary = "전자결재 첨부파일 삭제",
+            description =
+                    """
+                전자결재 문서의 첨부파일을 삭제합니다.
+
+                ### 사용 조건
+                - 기안자 본인만 삭제할 수 있습니다.
+                - DRAFT/RECALLED/REJECTED 상태 문서만 수정할 수 있습니다.
+                - DB 첨부파일 레코드와 S3 파일을 함께 삭제합니다.
+                """)
+    @DeleteMapping("/approvals/{documentId}/attachments/{attachmentId}")
+    public ResponseEntity<ApiResponse<Void>> deleteAttachment(
+            @PathVariable Long documentId,
+            @PathVariable Long attachmentId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        approvalWorkflowService.deleteAttachment(userDetails.getId(), documentId, attachmentId);
+        return ResponseEntity.ok(ApiResponse.onNoContent("첨부파일이 삭제되었습니다."));
     }
 
     @Operation(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/controller/ApprovalWorkflowController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/controller/ApprovalWorkflowController.java
@@ -11,6 +11,7 @@ import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalD
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalDraftUpdateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalDraftUpsertRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalSubmitRequestDto;
+import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDraftResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalInboxAllResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalSubmitResponseDto;
@@ -62,6 +63,7 @@ import org.springframework.web.bind.annotation.RestController;
             - 임시저장 수정: PUT /api/approvals/drafts/{documentId}
             - 임시저장 문서 상신: POST /api/approvals/drafts/{documentId}/submit
             - 바로 상신(임시저장 없이 1회 요청): POST /api/approvals/submit-direct
+            - 문서 상세 조회: GET /api/approvals/{documentId}
 
             ### 권한 정보
             - 로그인 필요
@@ -139,6 +141,33 @@ public class ApprovalWorkflowController {
     @GetMapping("/approval/templates")
     public ResponseEntity<ApiResponse<ApprovalTemplateListResponseDto>> getTemplates() {
         return ResponseEntity.ok(ApiResponse.onSuccess(approvalWorkflowService.getTemplateList()));
+    }
+
+    @Operation(
+            summary = "전자결재 문서 상세 조회",
+            description =
+                    """
+                전자결재 문서 1건의 상세 정보를 조회합니다.
+
+                ### 조회 권한
+                - 임시저장(DRAFT): 기안자 본인만 조회 가능
+                - 그 외 상태: 본인기안, 본인결재, 참조자, 열람권자(완결 후), 부서결재함 대상 문서 조회 가능
+
+                ### 응답 주요 필드
+                - 문서 기본정보/본문(contentDelta, contentHtml)
+                - 결재선/참조자/열람권자(lines)
+                - 첨부파일(attachments)
+                - 의견/처리 이력(actionHistories)
+                - 열람 정보(reads)
+                """)
+    @GetMapping("/approvals/{documentId}")
+    public ResponseEntity<ApiResponse<ApprovalDetailResponseDto>> getApprovalDetail(
+            @PathVariable Long documentId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(
+                        approvalWorkflowService.getApprovalDetail(
+                                userDetails.getId(), documentId)));
     }
 
     @Operation(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/controller/ApprovalWorkflowController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/controller/ApprovalWorkflowController.java
@@ -50,6 +50,7 @@ import org.springframework.web.bind.annotation.RestController;
             - 참조문서 참조문서 탭: GET /api/approvals/references
             - 참조문서 열람획득문서 탭: GET /api/approvals/references/viewer-acquired
             - 참조문서 열람부여문서 탭: GET /api/approvals/references/viewer-granted
+            - 완결문서 탭: GET /api/approvals/completed
             - 부서결재함(내 부서) 탭: GET /api/approvals/department-box
             - 결재진행 전체 탭: GET /api/approvals/inbox/all
             - 결재진행 결재하기 탭: GET /api/approvals/inbox/to-approve
@@ -459,6 +460,32 @@ public class ApprovalWorkflowController {
         return ResponseEntity.ok(
                 ApiResponse.onSuccess(
                         approvalWorkflowService.getViewerGrantedDocuments(userDetails.getId())));
+    }
+
+    @Operation(
+            summary = "완결문서 탭 조회",
+            description =
+                    """
+            현재 사용자 기준 `완결문서` 문서를 조회합니다.
+
+            ### 조회 대상
+            - 문서 상태가 APPROVED(완결)
+            - 기안자가 현재 로그인 사용자 본인인 문서
+
+            ### 응답 주요 필드
+            - 문서번호(documentNo)
+            - 기안자(drafterName)
+            - 제목(title)
+            - 결재선(approvalLines)
+            - 기안일(draftedAt)
+            - 완료일(completedAt)
+            """)
+    @GetMapping("/approvals/completed")
+    public ResponseEntity<ApiResponse<ApprovalInboxAllResponseDto>> getCompletedDocuments(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(
+                        approvalWorkflowService.getCompletedDocuments(userDetails.getId())));
     }
 
     @Operation(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/controller/ApprovalWorkflowController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/controller/ApprovalWorkflowController.java
@@ -6,11 +6,13 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 import jakarta.validation.Valid;
 
+import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalDecisionRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalDirectSubmitRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalDraftCreateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalDraftUpdateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalDraftUpsertRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalSubmitRequestDto;
+import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDecisionResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDraftResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalInboxAllResponseDto;
@@ -68,6 +70,7 @@ import org.springframework.web.bind.annotation.RestController;
             - 바로 상신(임시저장 없이 1회 요청): POST /api/approvals/submit-direct
             - 문서 상세 조회: GET /api/approvals/{documentId}
             - 문서 회수: POST /api/approvals/{documentId}/recall
+            - 결재처리(승인/반려/보류): POST /api/approvals/{documentId}/decision
 
             ### 권한 정보
             - 로그인 필요
@@ -625,6 +628,30 @@ public class ApprovalWorkflowController {
         return ResponseEntity.ok(
                 ApiResponse.onSuccess(
                         approvalWorkflowService.recall(userDetails.getId(), documentId)));
+    }
+
+    @Operation(
+            summary = "전자결재 결재처리",
+            description =
+                    """
+                결재진행 문서를 승인/반려/보류 처리합니다.
+
+                ### 처리 조건
+                - 문서 상태가 IN_PROGRESS(결재진행)이어야 합니다.
+                - 현재 로그인 사용자가 PENDING 상태의 현재 결재 대상이어야 합니다.
+                - APPROVE: 현재 결재선을 승인하고 다음 결재선으로 진행합니다.
+                - REJECT: 현재 결재선을 반려하고 문서를 REJECTED로 종료합니다.
+                - HOLD: 문서/결재선 상태는 유지하고 보류 이력만 저장합니다.
+                """)
+    @PostMapping("/approvals/{documentId}/decision")
+    public ResponseEntity<ApiResponse<ApprovalDecisionResponseDto>> decide(
+            @PathVariable Long documentId,
+            @Valid @RequestBody ApprovalDecisionRequestDto request,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(
+                        approvalWorkflowService.decide(
+                                userDetails.getId(), documentId, request)));
     }
 
     @Operation(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/controller/ApprovalWorkflowController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/controller/ApprovalWorkflowController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 import jakarta.validation.Valid;
 
+import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalCommentCreateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalDecisionRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalDirectSubmitRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalDraftCreateRequestDto;
@@ -13,6 +14,7 @@ import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalD
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalDraftUpsertRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalSubmitRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalAttachmentResponseDto;
+import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalCommentResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDecisionResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDraftResponseDto;
@@ -74,6 +76,7 @@ import java.util.List;
             - 임시저장 삭제: DELETE /api/approvals/drafts/{documentId}
             - 첨부파일 추가: POST /api/approvals/{documentId}/attachments
             - 첨부파일 삭제: DELETE /api/approvals/{documentId}/attachments/{attachmentId}
+            - 의견글 등록: POST /api/approvals/{documentId}/comments
             - 임시저장 문서 상신: POST /api/approvals/drafts/{documentId}/submit
             - 바로 상신(임시저장 없이 1회 요청): POST /api/approvals/submit-direct
             - 문서 상세 조회: GET /api/approvals/{documentId}
@@ -660,6 +663,31 @@ public class ApprovalWorkflowController {
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         approvalWorkflowService.deleteAttachment(userDetails.getId(), documentId, attachmentId);
         return ResponseEntity.ok(ApiResponse.onNoContent("첨부파일이 삭제되었습니다."));
+    }
+
+    @Operation(
+            summary = "전자결재 의견글 등록",
+            description =
+                    """
+                전자결재 문서 상세 화면의 의견글을 등록합니다.
+
+                ### 등록 조건
+                - 해당 문서 상세조회 권한이 있는 사용자만 등록할 수 있습니다.
+                - DRAFT 문서는 기안자 본인만 등록할 수 있습니다.
+                - 의견은 1000자 이하입니다.
+
+                ### 응답
+                - 등록된 의견글의 작성자/부서/직급/내용/작성일시를 반환합니다.
+                """)
+    @PostMapping("/approvals/{documentId}/comments")
+    public ResponseEntity<ApiResponse<ApprovalCommentResponseDto>> createComment(
+            @PathVariable Long documentId,
+            @Valid @RequestBody ApprovalCommentCreateRequestDto request,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(
+                        approvalWorkflowService.createComment(
+                                userDetails.getId(), documentId, request)));
     }
 
     @Operation(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/controller/ApprovalWorkflowController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/controller/ApprovalWorkflowController.java
@@ -703,8 +703,7 @@ public class ApprovalWorkflowController {
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
         return ResponseEntity.ok(
                 ApiResponse.onSuccess(
-                        approvalWorkflowService.decide(
-                                userDetails.getId(), documentId, request)));
+                        approvalWorkflowService.decide(userDetails.getId(), documentId, request)));
     }
 
     @Operation(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/controller/ApprovalWorkflowController.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/controller/ApprovalWorkflowController.java
@@ -24,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -61,6 +62,7 @@ import org.springframework.web.bind.annotation.RestController;
             - 결재진행 임시저장함 탭: GET /api/approvals/inbox/draft-box
             - 임시저장 생성: POST /api/approvals/drafts
             - 임시저장 수정: PUT /api/approvals/drafts/{documentId}
+            - 임시저장 삭제: DELETE /api/approvals/drafts/{documentId}
             - 임시저장 문서 상신: POST /api/approvals/drafts/{documentId}/submit
             - 바로 상신(임시저장 없이 1회 요청): POST /api/approvals/submit-direct
             - 문서 상세 조회: GET /api/approvals/{documentId}
@@ -600,6 +602,25 @@ public class ApprovalWorkflowController {
         ApprovalDraftResponseDto result =
                 approvalWorkflowService.upsertDraft(userDetails.getId(), upsertRequest);
         return ResponseEntity.ok(ApiResponse.onSuccess(result));
+    }
+
+    @Operation(
+            summary = "전자결재 임시저장 삭제",
+            description =
+                    """
+                임시저장 문서를 삭제합니다.
+
+                ### 삭제 조건
+                - 문서 상태가 DRAFT(임시저장)인 경우만 삭제할 수 있습니다.
+                - 기안자 본인만 삭제할 수 있습니다.
+                - 문서 결재선/첨부/열람/이력 데이터도 함께 삭제됩니다.
+                """)
+    @DeleteMapping("/approvals/drafts/{documentId}")
+    public ResponseEntity<ApiResponse<Void>> deleteDraft(
+            @PathVariable Long documentId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails) {
+        approvalWorkflowService.deleteDraft(userDetails.getId(), documentId);
+        return ResponseEntity.ok(ApiResponse.onNoContent("임시저장 문서가 삭제되었습니다."));
     }
 
     @Operation(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/request/ApprovalCommentCreateRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/request/ApprovalCommentCreateRequestDto.java
@@ -1,0 +1,20 @@
+package kr.co.awesomelead.groupware_backend.domain.approval.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Schema(description = "전자결재 의견글 등록 요청")
+public class ApprovalCommentCreateRequestDto {
+
+    @NotBlank(message = "의견 내용을 입력해주세요.")
+    @Size(max = 1000, message = "의견은 1000자 이하로 입력해주세요.")
+    @Schema(description = "의견 내용", example = "확인했습니다.")
+    private String content;
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/request/ApprovalDecisionRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/request/ApprovalDecisionRequestDto.java
@@ -16,7 +16,10 @@ import lombok.Setter;
 public class ApprovalDecisionRequestDto {
 
     @NotNull(message = "처리 액션은 필수입니다.")
-    @Schema(description = "처리 액션", example = "APPROVE", allowableValues = {"APPROVE", "REJECT", "HOLD"})
+    @Schema(
+            description = "처리 액션",
+            example = "APPROVE",
+            allowableValues = {"APPROVE", "REJECT", "HOLD"})
     private ApprovalDecisionAction action;
 
     @Size(max = 1000, message = "결재 의견은 1000자 이하로 입력해주세요.")

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/request/ApprovalDecisionRequestDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/request/ApprovalDecisionRequestDto.java
@@ -1,0 +1,25 @@
+package kr.co.awesomelead.groupware_backend.domain.approval.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import kr.co.awesomelead.groupware_backend.domain.approval.enums.ApprovalDecisionAction;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Schema(description = "전자결재 결재처리 요청")
+public class ApprovalDecisionRequestDto {
+
+    @NotNull(message = "처리 액션은 필수입니다.")
+    @Schema(description = "처리 액션", example = "APPROVE", allowableValues = {"APPROVE", "REJECT", "HOLD"})
+    private ApprovalDecisionAction action;
+
+    @Size(max = 1000, message = "결재 의견은 1000자 이하로 입력해주세요.")
+    @Schema(description = "결재 의견", example = "확인했습니다.")
+    private String comment;
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/response/ApprovalAttachmentResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/response/ApprovalAttachmentResponseDto.java
@@ -1,0 +1,44 @@
+package kr.co.awesomelead.groupware_backend.domain.approval.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "전자결재 첨부파일 응답")
+public class ApprovalAttachmentResponseDto {
+
+    @Schema(description = "첨부파일 ID", example = "1")
+    private Long attachmentId;
+
+    @Schema(description = "문서 ID", example = "10")
+    private Long documentId;
+
+    @Schema(description = "원본 파일명", example = "출장정산서.pdf")
+    private String originalFileName;
+
+    @Schema(description = "S3 파일 키")
+    private String fileKey;
+
+    @Schema(description = "파일 크기(byte)", example = "102400")
+    private Long fileSize;
+
+    @Schema(description = "브라우저 보기 URL")
+    private String viewUrl;
+
+    @Schema(description = "다운로드 URL")
+    private String downloadUrl;
+
+    @Schema(description = "업로드 사용자 ID", example = "14")
+    private Long uploadedByUserId;
+
+    @Schema(description = "업로드 사용자명", example = "고영민")
+    private String uploadedByUserName;
+
+    @Schema(description = "업로드 일시")
+    private LocalDateTime uploadedAt;
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/response/ApprovalCommentResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/response/ApprovalCommentResponseDto.java
@@ -1,0 +1,38 @@
+package kr.co.awesomelead.groupware_backend.domain.approval.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "전자결재 의견글 응답")
+public class ApprovalCommentResponseDto {
+
+    @Schema(description = "의견글 ID", example = "1")
+    private Long commentId;
+
+    @Schema(description = "문서 ID", example = "10")
+    private Long documentId;
+
+    @Schema(description = "작성자 ID", example = "14")
+    private Long writerUserId;
+
+    @Schema(description = "작성자 이름", example = "고영민")
+    private String writerUserName;
+
+    @Schema(description = "작성자 부서명", example = "경영지원부")
+    private String writerDepartmentName;
+
+    @Schema(description = "작성자 직급", example = "사원")
+    private String writerPositionName;
+
+    @Schema(description = "의견 내용", example = "확인했습니다.")
+    private String content;
+
+    @Schema(description = "작성일시")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/response/ApprovalDecisionResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/response/ApprovalDecisionResponseDto.java
@@ -1,0 +1,68 @@
+package kr.co.awesomelead.groupware_backend.domain.approval.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import kr.co.awesomelead.groupware_backend.domain.approval.enums.ApprovalDecisionAction;
+import kr.co.awesomelead.groupware_backend.domain.approval.enums.ApprovalLineStatus;
+import kr.co.awesomelead.groupware_backend.domain.approval.enums.ApprovalStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@Schema(description = "전자결재 결재처리 응답")
+public class ApprovalDecisionResponseDto {
+
+    @Schema(description = "문서 ID", example = "101")
+    private Long documentId;
+
+    @Schema(description = "문서번호", example = "기안및지출결의 경영지원부 20260108-30")
+    private String documentNo;
+
+    @Schema(description = "처리 액션", example = "APPROVE")
+    private ApprovalDecisionAction action;
+
+    @Schema(description = "처리 액션 한글 라벨", example = "승인")
+    private String actionLabel;
+
+    @Schema(description = "문서 상태", example = "IN_PROGRESS")
+    private ApprovalStatus status;
+
+    @Schema(description = "문서 상태 한글 라벨", example = "결재진행")
+    private String statusLabel;
+
+    @Schema(description = "처리된 결재 라인 ID", example = "1001")
+    private Long lineId;
+
+    @Schema(description = "처리된 결재 라인 상태", example = "APPROVED")
+    private ApprovalLineStatus lineStatus;
+
+    @Schema(description = "처리된 결재 라인 상태 한글 라벨", example = "승인")
+    private String lineStatusLabel;
+
+    @Schema(description = "다음 결재 라인 ID")
+    private Long nextLineId;
+
+    @Schema(description = "다음 결재 대상 표시명")
+    private String nextTargetName;
+
+    @Schema(description = "처리자 사용자 ID", example = "14")
+    private Long processedByUserId;
+
+    @Schema(description = "처리자 이름", example = "고영민")
+    private String processedByUserName;
+
+    @Schema(description = "처리 의견")
+    private String comment;
+
+    @Schema(description = "처리 일시")
+    private LocalDateTime processedAt;
+
+    @Schema(description = "완료 일시")
+    private LocalDateTime completedAt;
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/response/ApprovalDetailResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/response/ApprovalDetailResponseDto.java
@@ -105,6 +105,9 @@ public class ApprovalDetailResponseDto {
     @Schema(description = "의견/처리 이력")
     private List<ActionHistoryDto> actionHistories;
 
+    @Schema(description = "의견글 목록")
+    private List<CommentDto> comments;
+
     @Schema(description = "열람 정보")
     private List<ReadDto> reads;
 
@@ -183,6 +186,20 @@ public class ApprovalDetailResponseDto {
         private Long actorUserId;
         private String actorUserName;
         private String actionComment;
+        private LocalDateTime createdAt;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "문서 의견글")
+    public static class CommentDto {
+        private Long commentId;
+        private Long writerUserId;
+        private String writerUserName;
+        private String writerDepartmentName;
+        private String writerPositionName;
+        private String content;
         private LocalDateTime createdAt;
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/response/ApprovalDetailResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/response/ApprovalDetailResponseDto.java
@@ -1,0 +1,176 @@
+package kr.co.awesomelead.groupware_backend.domain.approval.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import kr.co.awesomelead.groupware_backend.domain.approval.enums.ApprovalActionType;
+import kr.co.awesomelead.groupware_backend.domain.approval.enums.ApprovalLineStatus;
+import kr.co.awesomelead.groupware_backend.domain.approval.enums.ApprovalReadRole;
+import kr.co.awesomelead.groupware_backend.domain.approval.enums.ApprovalRouteRole;
+import kr.co.awesomelead.groupware_backend.domain.approval.enums.ApprovalStatus;
+import kr.co.awesomelead.groupware_backend.domain.approval.enums.ApprovalTargetType;
+import kr.co.awesomelead.groupware_backend.domain.approval.enums.ApprovalType;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@Schema(description = "전자결재 문서 상세 응답")
+public class ApprovalDetailResponseDto {
+
+    @Schema(description = "문서 ID", example = "101")
+    private Long documentId;
+
+    @Schema(description = "문서번호", example = "기안및지출결의 경영지원부 20260108-30")
+    private String documentNo;
+
+    @Schema(description = "양식 ID", example = "1")
+    private Long templateId;
+
+    @Schema(description = "양식 코드", example = "BASIC")
+    private String templateCode;
+
+    @Schema(description = "양식명", example = "기본양식")
+    private String templateName;
+
+    @Schema(description = "문서 제목", example = "1분기 출장비 정산")
+    private String title;
+
+    @Schema(description = "문서 본문 Delta(JSON 문자열)")
+    private String contentDelta;
+
+    @Schema(description = "문서 본문 HTML")
+    private String contentHtml;
+
+    @Schema(description = "결재유형", example = "INTERNAL")
+    private ApprovalType approvalType;
+
+    @Schema(description = "결재유형 한글 라벨", example = "내부결재")
+    private String approvalTypeLabel;
+
+    @Schema(description = "문서 상태", example = "IN_PROGRESS")
+    private ApprovalStatus status;
+
+    @Schema(description = "문서 상태 한글 라벨", example = "결재진행")
+    private String statusLabel;
+
+    @Schema(description = "기안자 사용자 ID", example = "14")
+    private Long drafterUserId;
+
+    @Schema(description = "기안자 이름", example = "고영민")
+    private String drafterUserName;
+
+    @Schema(description = "기안자 부서 ID", example = "3")
+    private Long drafterDepartmentId;
+
+    @Schema(description = "기안자 부서명", example = "경영지원부")
+    private String drafterDepartmentName;
+
+    @Schema(description = "수신부서 ID(협조결재일 때)", example = "7")
+    private Long receiverDepartmentId;
+
+    @Schema(description = "수신부서명(협조결재일 때)", example = "생산본부")
+    private String receiverDepartmentName;
+
+    @Schema(description = "내 문서 여부", example = "true")
+    private Boolean mine;
+
+    @Schema(description = "상신일시")
+    private LocalDateTime submittedAt;
+
+    @Schema(description = "완료일시")
+    private LocalDateTime completedAt;
+
+    @Schema(description = "최초 생성일시")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "최종 수정일시")
+    private LocalDateTime modifiedAt;
+
+    @Schema(description = "결재선/합의/참조/열람/수신부서 라인")
+    private List<LineDto> lines;
+
+    @Schema(description = "첨부파일 목록")
+    private List<AttachmentDto> attachments;
+
+    @Schema(description = "의견/처리 이력")
+    private List<ActionHistoryDto> actionHistories;
+
+    @Schema(description = "열람 정보")
+    private List<ReadDto> reads;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "문서 라인 상세")
+    public static class LineDto {
+        private Long lineId;
+        private ApprovalRouteRole role;
+        private String roleLabel;
+        private ApprovalTargetType targetType;
+        private Long targetUserId;
+        private Long targetDepartmentId;
+        private String targetName;
+        private Integer sequenceNo;
+        private Boolean required;
+        private ApprovalLineStatus lineStatus;
+        private String lineStatusLabel;
+        private Long processedByUserId;
+        private String processedByUserName;
+        private String processedComment;
+        private LocalDateTime processedAt;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "문서 첨부파일")
+    public static class AttachmentDto {
+        private Long attachmentId;
+        private String originalFileName;
+        private String fileKey;
+        private Long fileSize;
+        private String viewUrl;
+        private String downloadUrl;
+        private Long uploadedByUserId;
+        private String uploadedByUserName;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "문서 처리 이력")
+    public static class ActionHistoryDto {
+        private Long historyId;
+        private ApprovalActionType actionType;
+        private String actionTypeLabel;
+        private ApprovalStatus fromStatus;
+        private String fromStatusLabel;
+        private ApprovalStatus toStatus;
+        private String toStatusLabel;
+        private Long actorUserId;
+        private String actorUserName;
+        private String actionComment;
+        private LocalDateTime createdAt;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "문서 열람 정보")
+    public static class ReadDto {
+        private Long readId;
+        private ApprovalReadRole readRole;
+        private ApprovalTargetType targetType;
+        private Long targetUserId;
+        private Long targetDepartmentId;
+        private String targetName;
+        private Boolean read;
+        private LocalDateTime readAt;
+    }
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/response/ApprovalDetailResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/response/ApprovalDetailResponseDto.java
@@ -14,6 +14,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -95,6 +96,9 @@ public class ApprovalDetailResponseDto {
     @Schema(description = "결재선/합의/참조/열람/수신부서 라인")
     private List<LineDto> lines;
 
+    @Schema(description = "결재칸 표시 정보")
+    private List<ApprovalBoxDto> approvalBoxes;
+
     @Schema(description = "첨부파일 목록")
     private List<AttachmentDto> attachments;
 
@@ -124,6 +128,29 @@ public class ApprovalDetailResponseDto {
         private String processedByUserName;
         private String processedComment;
         private LocalDateTime processedAt;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "결재칸 표시 정보")
+    public static class ApprovalBoxDto {
+        private Long lineId;
+        private ApprovalRouteRole role;
+        private String type;
+        private String label;
+        private Long userId;
+        private String userName;
+        private String departmentName;
+        private String positionName;
+        private Integer sequenceNo;
+        private ApprovalLineStatus lineStatus;
+        private String lineStatusLabel;
+        private String signatureImageUrl;
+        private LocalDate processedDate;
+        private LocalDateTime processedAt;
+        private String displayDate;
+        private String displayText;
     }
 
     @Getter

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/response/ApprovalRecallResponseDto.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/dto/response/ApprovalRecallResponseDto.java
@@ -1,0 +1,36 @@
+package kr.co.awesomelead.groupware_backend.domain.approval.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import kr.co.awesomelead.groupware_backend.domain.approval.enums.ApprovalStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@Schema(description = "전자결재 문서 회수 응답")
+public class ApprovalRecallResponseDto {
+
+    @Schema(description = "문서 ID", example = "101")
+    private Long documentId;
+
+    @Schema(description = "문서번호", example = "기안및지출결의 경영지원부 20260108-30")
+    private String documentNo;
+
+    @Schema(description = "문서 상태", example = "RECALLED")
+    private ApprovalStatus status;
+
+    @Schema(description = "문서 상태 한글 라벨", example = "회수")
+    private String statusLabel;
+
+    @Schema(description = "제목", example = "국외출장여비정산서")
+    private String title;
+
+    @Schema(description = "회수일시")
+    private LocalDateTime recalledAt;
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/entity/ApprovalComment.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/entity/ApprovalComment.java
@@ -1,0 +1,45 @@
+package kr.co.awesomelead.groupware_backend.domain.approval.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
+import kr.co.awesomelead.groupware_backend.global.common.entity.BaseTimeEntity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "approval_comments")
+public class ApprovalComment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "document_id", nullable = false)
+    private ApprovalDocument document;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_user_id", nullable = false)
+    private User writerUser;
+
+    @Column(nullable = false, length = 1000)
+    private String content;
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/entity/ApprovalDocument.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/entity/ApprovalDocument.java
@@ -106,6 +106,10 @@ public class ApprovalDocument extends BaseTimeEntity {
 
     @Builder.Default
     @OneToMany(mappedBy = "document")
+    private List<ApprovalComment> comments = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "document")
     private List<ApprovalAttachment> attachments = new ArrayList<>();
 
     @Builder.Default

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/enums/ApprovalDecisionAction.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/enums/ApprovalDecisionAction.java
@@ -5,14 +5,10 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public enum ApprovalActionType {
-    SAVE_DRAFT("임시저장"),
-    SUBMIT("상신"),
+public enum ApprovalDecisionAction {
     APPROVE("승인"),
     REJECT("반려"),
-    HOLD("보류"),
-    RECALL("회수"),
-    RESUBMIT("재상신");
+    HOLD("보류");
 
     private final String description;
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/repository/ApprovalActionHistoryRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/repository/ApprovalActionHistoryRepository.java
@@ -10,4 +10,6 @@ public interface ApprovalActionHistoryRepository
         extends JpaRepository<ApprovalActionHistory, Long> {
 
     List<ApprovalActionHistory> findByDocumentIdOrderByCreatedAtAscIdAsc(Long documentId);
+
+    void deleteByDocumentId(Long documentId);
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/repository/ApprovalAttachmentRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/repository/ApprovalAttachmentRepository.java
@@ -5,10 +5,13 @@ import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalAttach
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ApprovalAttachmentRepository extends JpaRepository<ApprovalAttachment, Long> {
 
     List<ApprovalAttachment> findByDocumentIdOrderByIdAsc(Long documentId);
+
+    Optional<ApprovalAttachment> findByIdAndDocumentId(Long id, Long documentId);
 
     void deleteByDocumentId(Long documentId);
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/repository/ApprovalAttachmentRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/repository/ApprovalAttachmentRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 public interface ApprovalAttachmentRepository extends JpaRepository<ApprovalAttachment, Long> {
 
     List<ApprovalAttachment> findByDocumentIdOrderByIdAsc(Long documentId);
+
+    void deleteByDocumentId(Long documentId);
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/repository/ApprovalCommentRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/repository/ApprovalCommentRepository.java
@@ -1,0 +1,14 @@
+package kr.co.awesomelead.groupware_backend.domain.approval.repository;
+
+import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalComment;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ApprovalCommentRepository extends JpaRepository<ApprovalComment, Long> {
+
+    List<ApprovalComment> findByDocumentIdOrderByCreatedAtAscIdAsc(Long documentId);
+
+    void deleteByDocumentId(Long documentId);
+}

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/repository/ApprovalDocumentReadRepository.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/repository/ApprovalDocumentReadRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 public interface ApprovalDocumentReadRepository extends JpaRepository<ApprovalDocumentRead, Long> {
 
     List<ApprovalDocumentRead> findByDocumentIdOrderByIdAsc(Long documentId);
+
+    void deleteByDocumentId(Long documentId);
 }

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalWorkflowService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalWorkflowService.java
@@ -1,11 +1,13 @@
 package kr.co.awesomelead.groupware_backend.domain.approval.service;
 
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalDecisionRequestDto;
+import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalCommentCreateRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalDirectSubmitRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalDraftUpsertRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalLineRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalSubmitRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalAttachmentResponseDto;
+import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalCommentResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDecisionResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDraftResponseDto;
@@ -15,6 +17,7 @@ import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.Approval
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalTemplateListResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalActionHistory;
 import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalAttachment;
+import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalComment;
 import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalDocument;
 import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalDocumentLine;
 import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalDocumentRead;
@@ -31,6 +34,7 @@ import kr.co.awesomelead.groupware_backend.domain.approval.enums.ApprovalTargetT
 import kr.co.awesomelead.groupware_backend.domain.approval.enums.ApprovalType;
 import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalActionHistoryRepository;
 import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalAttachmentRepository;
+import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalCommentRepository;
 import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalDocumentLineRepository;
 import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalDocumentReadRepository;
 import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalDocumentRepository;
@@ -75,6 +79,7 @@ public class ApprovalWorkflowService {
     private final ApprovalDocumentLineRepository approvalDocumentLineRepository;
     private final ApprovalActionHistoryRepository approvalActionHistoryRepository;
     private final ApprovalAttachmentRepository approvalAttachmentRepository;
+    private final ApprovalCommentRepository approvalCommentRepository;
     private final ApprovalDocumentReadRepository approvalDocumentReadRepository;
     private final ApprovalPersonalSettingRepository approvalPersonalSettingRepository;
     private final UserRepository userRepository;
@@ -132,6 +137,8 @@ public class ApprovalWorkflowService {
         List<ApprovalActionHistory> actionHistories =
                 approvalActionHistoryRepository.findByDocumentIdOrderByCreatedAtAscIdAsc(
                         documentId);
+        List<ApprovalComment> comments =
+                approvalCommentRepository.findByDocumentIdOrderByCreatedAtAscIdAsc(documentId);
         List<ApprovalDocumentRead> reads =
                 approvalDocumentReadRepository.findByDocumentIdOrderByIdAsc(documentId);
 
@@ -172,6 +179,7 @@ public class ApprovalWorkflowService {
                 .approvalBoxes(toApprovalBoxDtos(document, lines))
                 .attachments(toAttachmentDtos(attachments))
                 .actionHistories(toActionHistoryDtos(actionHistories))
+                .comments(toCommentDtos(comments))
                 .reads(toReadDtos(reads))
                 .build();
     }
@@ -445,10 +453,35 @@ public class ApprovalWorkflowService {
         }
 
         approvalActionHistoryRepository.deleteByDocumentId(documentId);
+        approvalCommentRepository.deleteByDocumentId(documentId);
         approvalDocumentReadRepository.deleteByDocumentId(documentId);
         approvalAttachmentRepository.deleteByDocumentId(documentId);
         approvalDocumentLineRepository.deleteByDocumentId(documentId);
         approvalDocumentRepository.delete(document);
+    }
+
+    @Transactional
+    public ApprovalCommentResponseDto createComment(
+            Long userId, Long documentId, ApprovalCommentCreateRequestDto request) {
+        User writer = getUser(userId);
+        Long departmentId = writer.getDepartment() != null ? writer.getDepartment().getId() : null;
+        ApprovalDocument document =
+                approvalDocumentRepository
+                        .findById(documentId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.APPROVAL_NOT_FOUND));
+        if (!canReadDocumentDetail(document, userId, departmentId)) {
+            throw new CustomException(ErrorCode.NOT_APPROVER);
+        }
+
+        ApprovalComment comment =
+                approvalCommentRepository.save(
+                        ApprovalComment.builder()
+                                .document(document)
+                                .writerUser(writer)
+                                .content(request.getContent().strip())
+                                .build());
+
+        return toCommentResponseDto(comment);
     }
 
     @Transactional
@@ -1044,6 +1077,39 @@ public class ApprovalWorkflowService {
                 .actorUserName(actorUser != null ? actorUser.getDisplayName() : null)
                 .actionComment(history.getActionComment())
                 .createdAt(history.getCreatedAt())
+                .build();
+    }
+
+    private List<ApprovalDetailResponseDto.CommentDto> toCommentDtos(
+            List<ApprovalComment> comments) {
+        return comments.stream().map(this::toCommentDto).toList();
+    }
+
+    private ApprovalDetailResponseDto.CommentDto toCommentDto(ApprovalComment comment) {
+        User writer = comment.getWriterUser();
+        return ApprovalDetailResponseDto.CommentDto.builder()
+                .commentId(comment.getId())
+                .writerUserId(writer != null ? writer.getId() : null)
+                .writerUserName(writer != null ? writer.getDisplayName() : null)
+                .writerDepartmentName(writer != null ? toDepartmentName(writer.getDepartment()) : null)
+                .writerPositionName(toPositionName(writer))
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .build();
+    }
+
+    private ApprovalCommentResponseDto toCommentResponseDto(ApprovalComment comment) {
+        User writer = comment.getWriterUser();
+        ApprovalDocument document = comment.getDocument();
+        return ApprovalCommentResponseDto.builder()
+                .commentId(comment.getId())
+                .documentId(document != null ? document.getId() : null)
+                .writerUserId(writer != null ? writer.getId() : null)
+                .writerUserName(writer != null ? writer.getDisplayName() : null)
+                .writerDepartmentName(writer != null ? toDepartmentName(writer.getDepartment()) : null)
+                .writerPositionName(toPositionName(writer))
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
                 .build();
     }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalWorkflowService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalWorkflowService.java
@@ -5,9 +5,9 @@ import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalD
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalDraftUpsertRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalLineRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalSubmitRequestDto;
-import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDetailResponseDto;
-import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDecisionResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalAttachmentResponseDto;
+import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDecisionResponseDto;
+import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDraftResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalInboxAllResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalRecallResponseDto;
@@ -486,9 +486,7 @@ public class ApprovalWorkflowService {
                 approvalAttachmentRepository
                         .findByIdAndDocumentId(attachmentId, documentId)
                         .orElseThrow(
-                                () ->
-                                        new CustomException(
-                                                ErrorCode.APPROVAL_ATTACHMENT_NOT_FOUND));
+                                () -> new CustomException(ErrorCode.APPROVAL_ATTACHMENT_NOT_FOUND));
 
         approvalAttachmentRepository.delete(attachment);
         safeDeleteFile(attachment.getS3Key());
@@ -856,8 +854,7 @@ public class ApprovalWorkflowService {
                         s3Service.getPresignedDownloadUrl(
                                 attachment.getS3Key(), attachment.getOriginalFileName()))
                 .uploadedByUserId(uploadedByUser != null ? uploadedByUser.getId() : null)
-                .uploadedByUserName(
-                        uploadedByUser != null ? uploadedByUser.getDisplayName() : null)
+                .uploadedByUserName(uploadedByUser != null ? uploadedByUser.getDisplayName() : null)
                 .build();
     }
 
@@ -875,8 +872,7 @@ public class ApprovalWorkflowService {
                         s3Service.getPresignedDownloadUrl(
                                 attachment.getS3Key(), attachment.getOriginalFileName()))
                 .uploadedByUserId(uploadedByUser != null ? uploadedByUser.getId() : null)
-                .uploadedByUserName(
-                        uploadedByUser != null ? uploadedByUser.getDisplayName() : null)
+                .uploadedByUserName(uploadedByUser != null ? uploadedByUser.getDisplayName() : null)
                 .uploadedAt(attachment.getCreatedAt())
                 .build();
     }
@@ -1613,7 +1609,9 @@ public class ApprovalWorkflowService {
     }
 
     private String toOriginalFileName(MultipartFile file) {
-        return StringUtils.hasText(file.getOriginalFilename()) ? file.getOriginalFilename() : "file";
+        return StringUtils.hasText(file.getOriginalFilename())
+                ? file.getOriginalFilename()
+                : "file";
     }
 
     private void safeDeleteFile(String fileKey) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalWorkflowService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalWorkflowService.java
@@ -44,6 +44,7 @@ import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalTe
 import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalTemplateRepository;
 import kr.co.awesomelead.groupware_backend.domain.department.entity.Department;
 import kr.co.awesomelead.groupware_backend.domain.department.repository.DepartmentRepository;
+import kr.co.awesomelead.groupware_backend.domain.notification.service.NotificationService;
 import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
 import kr.co.awesomelead.groupware_backend.global.error.CustomException;
@@ -64,6 +65,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -85,6 +87,7 @@ public class ApprovalWorkflowService {
     private final UserRepository userRepository;
     private final DepartmentRepository departmentRepository;
     private final S3Service s3Service;
+    private final NotificationService notificationService;
 
     @Transactional(readOnly = true)
     public ApprovalTemplateListResponseDto getTemplateList() {
@@ -647,6 +650,8 @@ public class ApprovalWorkflowService {
                         .actionComment(comment)
                         .build());
 
+        sendDecisionNotification(action, document, nextLine, lines, comment);
+
         return ApprovalDecisionResponseDto.builder()
                 .documentId(document.getId())
                 .documentNo(document.getDocumentNo())
@@ -738,6 +743,8 @@ public class ApprovalWorkflowService {
                         .actorUser(actor)
                         .build());
 
+        sendSubmitNotification(document, lines);
+
         return ApprovalSubmitResponseDto.builder()
                 .documentId(document.getId())
                 .documentNo(document.getDocumentNo())
@@ -824,6 +831,94 @@ public class ApprovalWorkflowService {
             case REJECT -> ApprovalActionType.REJECT;
             case HOLD -> ApprovalActionType.HOLD;
         };
+    }
+
+    private void sendSubmitNotification(
+            ApprovalDocument document, List<ApprovalDocumentLine> lines) {
+        List<Long> firstApproverIds =
+                lines.stream()
+                        .filter(line -> isProcessingRole(line.getRole()))
+                        .filter(line -> line.getLineStatus() == ApprovalLineStatus.PENDING)
+                        .sorted(this::compareLineOrder)
+                        .findFirst()
+                        .map(this::resolveLineTargetUserIds)
+                        .orElse(List.of());
+        if (firstApproverIds.isEmpty()) {
+            return;
+        }
+
+        Long firstApproverId = firstApproverIds.get(0);
+        List<Long> referrerIds = resolveRoleTargetUserIds(lines, ApprovalRouteRole.REFERENCE);
+        notificationService.sendApprovalCreatedAlert(
+                document.getId(), document.getTitle(), firstApproverId, referrerIds);
+
+        firstApproverIds.stream()
+                .skip(1)
+                .forEach(
+                        approverId ->
+                                notificationService.sendApprovalNextStepAlert(
+                                        approverId, document.getId(), document.getTitle()));
+    }
+
+    private void sendDecisionNotification(
+            ApprovalDecisionAction action,
+            ApprovalDocument document,
+            ApprovalDocumentLine nextLine,
+            List<ApprovalDocumentLine> lines,
+            String comment) {
+        if (action == ApprovalDecisionAction.APPROVE) {
+            if (nextLine != null) {
+                resolveLineTargetUserIds(nextLine)
+                        .forEach(
+                                approverId ->
+                                        notificationService.sendApprovalNextStepAlert(
+                                                approverId,
+                                                document.getId(),
+                                                document.getTitle()));
+                return;
+            }
+
+            Long drafterId =
+                    document.getDrafterUser() != null ? document.getDrafterUser().getId() : null;
+            if (drafterId == null) {
+                return;
+            }
+            List<Long> viewerIds =
+                    resolveRoleTargetUserIds(lines, ApprovalRouteRole.VIEWER).stream()
+                            .filter(viewerId -> !viewerId.equals(drafterId))
+                            .toList();
+            notificationService.sendApprovalFinallyApprovedAlert(
+                    document.getId(), document.getTitle(), drafterId, viewerIds);
+            return;
+        }
+
+        if (action == ApprovalDecisionAction.REJECT && document.getDrafterUser() != null) {
+            notificationService.sendApprovalRejectedAlert(
+                    document.getDrafterUser().getId(),
+                    document.getId(),
+                    document.getTitle(),
+                    comment != null ? comment : "");
+        }
+    }
+
+    private List<Long> resolveRoleTargetUserIds(
+            List<ApprovalDocumentLine> lines, ApprovalRouteRole role) {
+        return lines.stream()
+                .filter(line -> line.getRole() == role)
+                .flatMap(line -> resolveLineTargetUserIds(line).stream())
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+    }
+
+    private List<Long> resolveLineTargetUserIds(ApprovalDocumentLine line) {
+        if (line.getTargetType() == ApprovalTargetType.USER) {
+            return line.getTargetUser() != null ? List.of(line.getTargetUser().getId()) : List.of();
+        }
+        if (line.getTargetDepartment() == null) {
+            return List.of();
+        }
+        return userRepository.findAllIdsByDepartmentId(line.getTargetDepartment().getId());
     }
 
     private String normalizeComment(String comment) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalWorkflowService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalWorkflowService.java
@@ -7,6 +7,7 @@ import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalL
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalSubmitRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDecisionResponseDto;
+import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalAttachmentResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDraftResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalInboxAllResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalRecallResponseDto;
@@ -48,7 +49,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -441,6 +444,57 @@ public class ApprovalWorkflowService {
     }
 
     @Transactional
+    public List<ApprovalAttachmentResponseDto> uploadAttachments(
+            Long userId, Long documentId, List<MultipartFile> files) {
+        User uploader = getUser(userId);
+        ApprovalDocument document = getWritableDocumentByDrafter(documentId, userId);
+        if (files == null || files.stream().allMatch(file -> file == null || file.isEmpty())) {
+            throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+        }
+
+        List<ApprovalAttachment> attachments = new ArrayList<>();
+        for (MultipartFile file : files) {
+            if (file == null || file.isEmpty()) {
+                continue;
+            }
+            String s3Key;
+            try {
+                s3Key = s3Service.uploadFile(file);
+            } catch (IOException e) {
+                throw new CustomException(ErrorCode.FILE_UPLOAD_ERROR);
+            }
+
+            attachments.add(
+                    ApprovalAttachment.builder()
+                            .document(document)
+                            .originalFileName(toOriginalFileName(file))
+                            .s3Key(s3Key)
+                            .fileSize(file.getSize())
+                            .uploadedByUser(uploader)
+                            .build());
+        }
+
+        return approvalAttachmentRepository.saveAll(attachments).stream()
+                .map(this::toAttachmentResponseDto)
+                .toList();
+    }
+
+    @Transactional
+    public void deleteAttachment(Long userId, Long documentId, Long attachmentId) {
+        getWritableDocumentByDrafter(documentId, userId);
+        ApprovalAttachment attachment =
+                approvalAttachmentRepository
+                        .findByIdAndDocumentId(attachmentId, documentId)
+                        .orElseThrow(
+                                () ->
+                                        new CustomException(
+                                                ErrorCode.APPROVAL_ATTACHMENT_NOT_FOUND));
+
+        approvalAttachmentRepository.delete(attachment);
+        safeDeleteFile(attachment.getS3Key());
+    }
+
+    @Transactional
     public ApprovalRecallResponseDto recall(Long userId, Long documentId) {
         User actor = getUser(userId);
         ApprovalDocument document =
@@ -804,6 +858,26 @@ public class ApprovalWorkflowService {
                 .uploadedByUserId(uploadedByUser != null ? uploadedByUser.getId() : null)
                 .uploadedByUserName(
                         uploadedByUser != null ? uploadedByUser.getDisplayName() : null)
+                .build();
+    }
+
+    private ApprovalAttachmentResponseDto toAttachmentResponseDto(ApprovalAttachment attachment) {
+        User uploadedByUser = attachment.getUploadedByUser();
+        ApprovalDocument document = attachment.getDocument();
+        return ApprovalAttachmentResponseDto.builder()
+                .attachmentId(attachment.getId())
+                .documentId(document != null ? document.getId() : null)
+                .originalFileName(attachment.getOriginalFileName())
+                .fileKey(attachment.getS3Key())
+                .fileSize(attachment.getFileSize())
+                .viewUrl(s3Service.getProxyViewUrl(attachment.getS3Key()))
+                .downloadUrl(
+                        s3Service.getPresignedDownloadUrl(
+                                attachment.getS3Key(), attachment.getOriginalFileName()))
+                .uploadedByUserId(uploadedByUser != null ? uploadedByUser.getId() : null)
+                .uploadedByUserName(
+                        uploadedByUser != null ? uploadedByUser.getDisplayName() : null)
+                .uploadedAt(attachment.getCreatedAt())
                 .build();
     }
 
@@ -1519,6 +1593,34 @@ public class ApprovalWorkflowService {
             return null;
         }
         return department.getName().getDescription();
+    }
+
+    private ApprovalDocument getWritableDocumentByDrafter(Long documentId, Long userId) {
+        ApprovalDocument document =
+                approvalDocumentRepository
+                        .findByIdAndDrafterUserId(documentId, userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.APPROVAL_NOT_FOUND));
+        if (!isWritableDocumentStatus(document.getStatus())) {
+            throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+        }
+        return document;
+    }
+
+    private boolean isWritableDocumentStatus(ApprovalStatus status) {
+        return status == ApprovalStatus.DRAFT
+                || status == ApprovalStatus.RECALLED
+                || status == ApprovalStatus.REJECTED;
+    }
+
+    private String toOriginalFileName(MultipartFile file) {
+        return StringUtils.hasText(file.getOriginalFilename()) ? file.getOriginalFilename() : "file";
+    }
+
+    private void safeDeleteFile(String fileKey) {
+        try {
+            s3Service.deleteFile(fileKey);
+        } catch (Exception ignored) {
+        }
     }
 
     private User getUser(Long userId) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalWorkflowService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalWorkflowService.java
@@ -872,9 +872,7 @@ public class ApprovalWorkflowService {
                         .forEach(
                                 approverId ->
                                         notificationService.sendApprovalNextStepAlert(
-                                                approverId,
-                                                document.getId(),
-                                                document.getTitle()));
+                                                approverId, document.getId(), document.getTitle()));
                 return;
             }
 

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalWorkflowService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalWorkflowService.java
@@ -862,7 +862,9 @@ public class ApprovalWorkflowService {
             ApprovalDocument document) {
         User drafter = document.getDrafterUser();
         LocalDateTime draftedAt =
-                document.getSubmittedAt() != null ? document.getSubmittedAt() : document.getCreatedAt();
+                document.getSubmittedAt() != null
+                        ? document.getSubmittedAt()
+                        : document.getCreatedAt();
         LocalDate draftedDate = draftedAt != null ? draftedAt.toLocalDate() : null;
         return ApprovalDetailResponseDto.ApprovalBoxDto.builder()
                 .type("DRAFT")
@@ -880,9 +882,11 @@ public class ApprovalWorkflowService {
                 .build();
     }
 
-    private ApprovalDetailResponseDto.ApprovalBoxDto toApprovalBoxDto(
-            ApprovalDocumentLine line) {
-        User displayUser = line.getProcessedByUser() != null ? line.getProcessedByUser() : line.getTargetUser();
+    private ApprovalDetailResponseDto.ApprovalBoxDto toApprovalBoxDto(ApprovalDocumentLine line) {
+        User displayUser =
+                line.getProcessedByUser() != null
+                        ? line.getProcessedByUser()
+                        : line.getTargetUser();
         LocalDate processedDate =
                 line.getProcessedAt() != null ? line.getProcessedAt().toLocalDate() : null;
         String label = toApprovalBoxLabel(line);

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalWorkflowService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalWorkflowService.java
@@ -259,6 +259,20 @@ public class ApprovalWorkflowService {
     }
 
     @Transactional(readOnly = true)
+    public ApprovalInboxAllResponseDto getCompletedDocuments(Long userId) {
+        User user = getUser(userId);
+        Long departmentId = user.getDepartment() != null ? user.getDepartment().getId() : null;
+
+        List<ApprovalInboxAllResponseDto.DocumentDto> documents =
+                approvalDocumentRepository.findAllWithLinesOrderByIdDesc().stream()
+                        .filter(document -> isCompletedDocument(document, userId, departmentId))
+                        .map(document -> toInboxDocumentDto(document, userId, departmentId))
+                        .toList();
+
+        return ApprovalInboxAllResponseDto.builder().documents(documents).build();
+    }
+
+    @Transactional(readOnly = true)
     public ApprovalInboxAllResponseDto getDepartmentBox(Long userId) {
         User user = getUser(userId);
         if (user.getDepartment() == null) {
@@ -546,6 +560,13 @@ public class ApprovalWorkflowService {
         }
         return document.getLines().stream()
                 .anyMatch(line -> line.getRole() == ApprovalRouteRole.VIEWER);
+    }
+
+    private boolean isCompletedDocument(ApprovalDocument document, Long userId, Long departmentId) {
+        if (document.getStatus() != ApprovalStatus.APPROVED) {
+            return false;
+        }
+        return isDraftedByMe(document, userId);
     }
 
     private boolean isDepartmentBoxDocument(ApprovalDocument document, Long departmentId) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalWorkflowService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalWorkflowService.java
@@ -18,6 +18,7 @@ import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalAttach
 import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalDocument;
 import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalDocumentLine;
 import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalDocumentRead;
+import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalPersonalSetting;
 import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalTemplate;
 import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalTemplateCategory;
 import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalTemplateLine;
@@ -33,6 +34,7 @@ import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalAt
 import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalDocumentLineRepository;
 import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalDocumentReadRepository;
 import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalDocumentRepository;
+import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalPersonalSettingRepository;
 import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalTemplateCategoryRepository;
 import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalTemplateLineRepository;
 import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalTemplateRepository;
@@ -52,6 +54,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -62,6 +65,9 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ApprovalWorkflowService {
 
+    private static final DateTimeFormatter APPROVAL_BOX_DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("MM/dd");
+
     private final ApprovalTemplateCategoryRepository approvalTemplateCategoryRepository;
     private final ApprovalTemplateRepository approvalTemplateRepository;
     private final ApprovalTemplateLineRepository approvalTemplateLineRepository;
@@ -70,6 +76,7 @@ public class ApprovalWorkflowService {
     private final ApprovalActionHistoryRepository approvalActionHistoryRepository;
     private final ApprovalAttachmentRepository approvalAttachmentRepository;
     private final ApprovalDocumentReadRepository approvalDocumentReadRepository;
+    private final ApprovalPersonalSettingRepository approvalPersonalSettingRepository;
     private final UserRepository userRepository;
     private final DepartmentRepository departmentRepository;
     private final S3Service s3Service;
@@ -162,6 +169,7 @@ public class ApprovalWorkflowService {
                 .createdAt(document.getCreatedAt())
                 .modifiedAt(document.getModifiedAt())
                 .lines(toDetailLineDtos(lines))
+                .approvalBoxes(toApprovalBoxDtos(document, lines))
                 .attachments(toAttachmentDtos(attachments))
                 .actionHistories(toActionHistoryDtos(actionHistories))
                 .reads(toReadDtos(reads))
@@ -835,6 +843,132 @@ public class ApprovalWorkflowService {
                 .processedComment(line.getProcessedComment())
                 .processedAt(line.getProcessedAt())
                 .build();
+    }
+
+    private List<ApprovalDetailResponseDto.ApprovalBoxDto> toApprovalBoxDtos(
+            ApprovalDocument document, List<ApprovalDocumentLine> lines) {
+        List<ApprovalDetailResponseDto.ApprovalBoxDto> approvalBoxes = new ArrayList<>();
+        approvalBoxes.add(toDraftApprovalBoxDto(document));
+        approvalBoxes.addAll(
+                lines.stream()
+                        .filter(line -> isApprovalBoxRole(line.getRole()))
+                        .sorted(this::compareLineOrder)
+                        .map(this::toApprovalBoxDto)
+                        .toList());
+        return approvalBoxes;
+    }
+
+    private ApprovalDetailResponseDto.ApprovalBoxDto toDraftApprovalBoxDto(
+            ApprovalDocument document) {
+        User drafter = document.getDrafterUser();
+        LocalDateTime draftedAt =
+                document.getSubmittedAt() != null ? document.getSubmittedAt() : document.getCreatedAt();
+        LocalDate draftedDate = draftedAt != null ? draftedAt.toLocalDate() : null;
+        return ApprovalDetailResponseDto.ApprovalBoxDto.builder()
+                .type("DRAFT")
+                .label("기안")
+                .userId(drafter != null ? drafter.getId() : null)
+                .userName(drafter != null ? drafter.getDisplayName() : null)
+                .departmentName(drafter != null ? toDepartmentName(drafter.getDepartment()) : null)
+                .positionName(toPositionName(drafter))
+                .sequenceNo(0)
+                .signatureImageUrl(toSignatureImageUrl(drafter))
+                .processedDate(draftedDate)
+                .processedAt(draftedAt)
+                .displayDate(toApprovalBoxDisplayDate(draftedDate))
+                .displayText(toApprovalBoxDisplayText("기안", draftedDate))
+                .build();
+    }
+
+    private ApprovalDetailResponseDto.ApprovalBoxDto toApprovalBoxDto(
+            ApprovalDocumentLine line) {
+        User displayUser = line.getProcessedByUser() != null ? line.getProcessedByUser() : line.getTargetUser();
+        LocalDate processedDate =
+                line.getProcessedAt() != null ? line.getProcessedAt().toLocalDate() : null;
+        String label = toApprovalBoxLabel(line);
+        String displayLabel = toApprovalBoxDisplayLabel(line, label);
+        boolean signed = isSignedApprovalBox(line);
+
+        return ApprovalDetailResponseDto.ApprovalBoxDto.builder()
+                .lineId(line.getId())
+                .role(line.getRole())
+                .type(line.getRole() != null ? line.getRole().name() : null)
+                .label(label)
+                .userId(displayUser != null ? displayUser.getId() : null)
+                .userName(displayUser != null ? displayUser.getDisplayName() : null)
+                .departmentName(
+                        displayUser != null
+                                ? toDepartmentName(displayUser.getDepartment())
+                                : toDepartmentName(line.getTargetDepartment()))
+                .positionName(toPositionName(displayUser))
+                .sequenceNo(line.getSequenceNo())
+                .lineStatus(line.getLineStatus())
+                .lineStatusLabel(
+                        line.getLineStatus() != null ? line.getLineStatus().getDescription() : null)
+                .signatureImageUrl(signed ? toSignatureImageUrl(displayUser) : null)
+                .processedDate(signed ? processedDate : null)
+                .processedAt(signed ? line.getProcessedAt() : null)
+                .displayDate(signed ? toApprovalBoxDisplayDate(processedDate) : null)
+                .displayText(signed ? toApprovalBoxDisplayText(displayLabel, processedDate) : null)
+                .build();
+    }
+
+    private boolean isApprovalBoxRole(ApprovalRouteRole role) {
+        return role == ApprovalRouteRole.APPROVAL_LINE
+                || role == ApprovalRouteRole.AGREEMENT_REQUIRED
+                || role == ApprovalRouteRole.AGREEMENT_OPTIONAL
+                || role == ApprovalRouteRole.RECEIVER_DEPARTMENT;
+    }
+
+    private boolean isSignedApprovalBox(ApprovalDocumentLine line) {
+        return line.getProcessedAt() != null
+                && (line.getLineStatus() == ApprovalLineStatus.APPROVED
+                        || line.getLineStatus() == ApprovalLineStatus.REJECTED);
+    }
+
+    private String toApprovalBoxLabel(ApprovalDocumentLine line) {
+        if (line.getRole() == ApprovalRouteRole.AGREEMENT_REQUIRED
+                || line.getRole() == ApprovalRouteRole.AGREEMENT_OPTIONAL) {
+            return "합의";
+        }
+        if (line.getRole() == ApprovalRouteRole.RECEIVER_DEPARTMENT) {
+            return "수신";
+        }
+        return "승인";
+    }
+
+    private String toApprovalBoxDisplayLabel(ApprovalDocumentLine line, String defaultLabel) {
+        if (line.getLineStatus() == ApprovalLineStatus.REJECTED) {
+            return "반려";
+        }
+        return defaultLabel;
+    }
+
+    private String toApprovalBoxDisplayDate(LocalDate date) {
+        return date != null ? date.format(APPROVAL_BOX_DATE_FORMATTER) : null;
+    }
+
+    private String toApprovalBoxDisplayText(String label, LocalDate date) {
+        String displayDate = toApprovalBoxDisplayDate(date);
+        return displayDate != null ? label + " " + displayDate : label;
+    }
+
+    private String toSignatureImageUrl(User user) {
+        if (user == null) {
+            return null;
+        }
+        return approvalPersonalSettingRepository
+                .findByUserId(user.getId())
+                .map(ApprovalPersonalSetting::getSignatureImageKey)
+                .filter(StringUtils::hasText)
+                .map(s3Service::getPresignedViewUrl)
+                .orElse(null);
+    }
+
+    private String toPositionName(User user) {
+        return user != null && user.getPosition() != null
+                ? user.getPosition().getDescription()
+                : null;
     }
 
     private List<ApprovalDetailResponseDto.AttachmentDto> toAttachmentDtos(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalWorkflowService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalWorkflowService.java
@@ -420,6 +420,23 @@ public class ApprovalWorkflowService {
     }
 
     @Transactional
+    public void deleteDraft(Long userId, Long documentId) {
+        ApprovalDocument document =
+                approvalDocumentRepository
+                        .findByIdAndDrafterUserId(documentId, userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.APPROVAL_NOT_FOUND));
+        if (document.getStatus() != ApprovalStatus.DRAFT) {
+            throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+        }
+
+        approvalActionHistoryRepository.deleteByDocumentId(documentId);
+        approvalDocumentReadRepository.deleteByDocumentId(documentId);
+        approvalAttachmentRepository.deleteByDocumentId(documentId);
+        approvalDocumentLineRepository.deleteByDocumentId(documentId);
+        approvalDocumentRepository.delete(document);
+    }
+
+    @Transactional
     public ApprovalSubmitResponseDto submit(
             Long userId, Long documentId, ApprovalSubmitRequestDto request) {
         User actor = getUser(userId);

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalWorkflowService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalWorkflowService.java
@@ -1,10 +1,12 @@
 package kr.co.awesomelead.groupware_backend.domain.approval.service;
 
+import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalDecisionRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalDirectSubmitRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalDraftUpsertRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalLineRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalSubmitRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDetailResponseDto;
+import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDecisionResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDraftResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalInboxAllResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalRecallResponseDto;
@@ -19,6 +21,7 @@ import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalTempla
 import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalTemplateCategory;
 import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalTemplateLine;
 import kr.co.awesomelead.groupware_backend.domain.approval.enums.ApprovalActionType;
+import kr.co.awesomelead.groupware_backend.domain.approval.enums.ApprovalDecisionAction;
 import kr.co.awesomelead.groupware_backend.domain.approval.enums.ApprovalLineStatus;
 import kr.co.awesomelead.groupware_backend.domain.approval.enums.ApprovalRouteRole;
 import kr.co.awesomelead.groupware_backend.domain.approval.enums.ApprovalStatus;
@@ -484,6 +487,94 @@ public class ApprovalWorkflowService {
     }
 
     @Transactional
+    public ApprovalDecisionResponseDto decide(
+            Long userId, Long documentId, ApprovalDecisionRequestDto request) {
+        User actor = getUser(userId);
+        ApprovalDocument document =
+                approvalDocumentRepository
+                        .findById(documentId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.APPROVAL_NOT_FOUND));
+        if (document.getStatus() != ApprovalStatus.IN_PROGRESS) {
+            throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+        }
+
+        Long departmentId = actor.getDepartment() != null ? actor.getDepartment().getId() : null;
+        List<ApprovalDocumentLine> lines =
+                approvalDocumentLineRepository.findByDocumentIdOrderBySequenceNoAscIdAsc(
+                        documentId);
+        ApprovalDocumentLine currentLine =
+                lines.stream()
+                        .filter(line -> line.getLineStatus() == ApprovalLineStatus.PENDING)
+                        .findFirst()
+                        .orElseThrow(() -> new CustomException(ErrorCode.NOT_YOUR_TURN));
+        if (!isMyProcessingLine(currentLine, userId, departmentId)) {
+            throw new CustomException(ErrorCode.NOT_APPROVER);
+        }
+
+        ApprovalDecisionAction action = request.getAction();
+        String comment = normalizeComment(request.getComment());
+        LocalDateTime processedAt = LocalDateTime.now();
+        ApprovalDocumentLine nextLine = null;
+        ApprovalStatus fromStatus = document.getStatus();
+
+        if (action == ApprovalDecisionAction.APPROVE) {
+            currentLine.setLineStatus(ApprovalLineStatus.APPROVED);
+            currentLine.setProcessedByUser(actor);
+            currentLine.setProcessedComment(comment);
+            currentLine.setProcessedAt(processedAt);
+            nextLine = activateNextProcessingLine(lines, currentLine);
+            if (nextLine == null) {
+                document.setStatus(ApprovalStatus.APPROVED);
+                document.setCompletedAt(processedAt);
+            }
+        } else if (action == ApprovalDecisionAction.REJECT) {
+            currentLine.setLineStatus(ApprovalLineStatus.REJECTED);
+            currentLine.setProcessedByUser(actor);
+            currentLine.setProcessedComment(comment);
+            currentLine.setProcessedAt(processedAt);
+            document.setStatus(ApprovalStatus.REJECTED);
+            document.setCompletedAt(processedAt);
+            skipWaitingProcessingLines(lines, currentLine);
+        } else if (action == ApprovalDecisionAction.HOLD) {
+            currentLine.setProcessedComment(comment);
+        } else {
+            throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+        }
+
+        approvalDocumentLineRepository.saveAll(lines);
+        approvalDocumentRepository.save(document);
+        approvalActionHistoryRepository.save(
+                ApprovalActionHistory.builder()
+                        .document(document)
+                        .documentLine(currentLine)
+                        .actionType(toActionType(action))
+                        .fromStatus(fromStatus)
+                        .toStatus(document.getStatus())
+                        .actorUser(actor)
+                        .actionComment(comment)
+                        .build());
+
+        return ApprovalDecisionResponseDto.builder()
+                .documentId(document.getId())
+                .documentNo(document.getDocumentNo())
+                .action(action)
+                .actionLabel(action.getDescription())
+                .status(document.getStatus())
+                .statusLabel(document.getStatus().getDescription())
+                .lineId(currentLine.getId())
+                .lineStatus(currentLine.getLineStatus())
+                .lineStatusLabel(currentLine.getLineStatus().getDescription())
+                .nextLineId(nextLine != null ? nextLine.getId() : null)
+                .nextTargetName(nextLine != null ? nextLine.getTargetNameSnapshot() : null)
+                .processedByUserId(actor.getId())
+                .processedByUserName(actor.getDisplayName())
+                .comment(comment)
+                .processedAt(processedAt)
+                .completedAt(document.getCompletedAt())
+                .build();
+    }
+
+    @Transactional
     public ApprovalSubmitResponseDto submit(
             Long userId, Long documentId, ApprovalSubmitRequestDto request) {
         User actor = getUser(userId);
@@ -598,6 +689,62 @@ public class ApprovalWorkflowService {
         submitRequest.setLines(request.getLines());
 
         return submit(userId, draftResult.getDocumentId(), submitRequest);
+    }
+
+    private ApprovalDocumentLine activateNextProcessingLine(
+            List<ApprovalDocumentLine> lines, ApprovalDocumentLine currentLine) {
+        List<ApprovalDocumentLine> processingLines =
+                lines.stream()
+                        .filter(line -> isProcessingRole(line.getRole()))
+                        .sorted(this::compareLineOrder)
+                        .toList();
+
+        boolean afterCurrent = false;
+        for (ApprovalDocumentLine line : processingLines) {
+            if (line.getId().equals(currentLine.getId())) {
+                afterCurrent = true;
+                continue;
+            }
+            if (afterCurrent && line.getLineStatus() == ApprovalLineStatus.WAITING) {
+                line.setLineStatus(ApprovalLineStatus.PENDING);
+                return line;
+            }
+        }
+        return null;
+    }
+
+    private void skipWaitingProcessingLines(
+            List<ApprovalDocumentLine> lines, ApprovalDocumentLine currentLine) {
+        lines.stream()
+                .filter(line -> isProcessingRole(line.getRole()))
+                .filter(line -> !line.getId().equals(currentLine.getId()))
+                .filter(
+                        line ->
+                                line.getLineStatus() == ApprovalLineStatus.WAITING
+                                        || line.getLineStatus() == ApprovalLineStatus.PENDING)
+                .forEach(line -> line.setLineStatus(ApprovalLineStatus.SKIPPED));
+    }
+
+    private ApprovalActionType toActionType(ApprovalDecisionAction action) {
+        return switch (action) {
+            case APPROVE -> ApprovalActionType.APPROVE;
+            case REJECT -> ApprovalActionType.REJECT;
+            case HOLD -> ApprovalActionType.HOLD;
+        };
+    }
+
+    private String normalizeComment(String comment) {
+        return StringUtils.hasText(comment) ? comment.strip() : null;
+    }
+
+    private int compareLineOrder(ApprovalDocumentLine left, ApprovalDocumentLine right) {
+        int sequenceCompare =
+                Comparator.nullsLast(Integer::compareTo)
+                        .compare(left.getSequenceNo(), right.getSequenceNo());
+        if (sequenceCompare != 0) {
+            return sequenceCompare;
+        }
+        return Comparator.nullsLast(Long::compareTo).compare(left.getId(), right.getId());
     }
 
     private List<ApprovalDetailResponseDto.LineDto> toDetailLineDtos(

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalWorkflowService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalWorkflowService.java
@@ -7,6 +7,7 @@ import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalS
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDraftResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalInboxAllResponseDto;
+import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalRecallResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalSubmitResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalTemplateListResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalActionHistory;
@@ -434,6 +435,52 @@ public class ApprovalWorkflowService {
         approvalAttachmentRepository.deleteByDocumentId(documentId);
         approvalDocumentLineRepository.deleteByDocumentId(documentId);
         approvalDocumentRepository.delete(document);
+    }
+
+    @Transactional
+    public ApprovalRecallResponseDto recall(Long userId, Long documentId) {
+        User actor = getUser(userId);
+        ApprovalDocument document =
+                approvalDocumentRepository
+                        .findByIdAndDrafterUserIdWithLines(documentId, userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.APPROVAL_NOT_FOUND));
+        ApprovalStatus fromStatus = document.getStatus();
+        if (fromStatus != ApprovalStatus.IN_PROGRESS) {
+            throw new CustomException(ErrorCode.INVALID_ARGUMENT);
+        }
+
+        document.setStatus(ApprovalStatus.RECALLED);
+        document.setCompletedAt(LocalDateTime.now());
+        approvalDocumentRepository.save(document);
+
+        List<ApprovalDocumentLine> lines =
+                approvalDocumentLineRepository.findByDocumentIdOrderBySequenceNoAscIdAsc(
+                        documentId);
+        lines.stream()
+                .filter(
+                        line ->
+                                line.getLineStatus() == ApprovalLineStatus.WAITING
+                                        || line.getLineStatus() == ApprovalLineStatus.PENDING)
+                .forEach(line -> line.setLineStatus(ApprovalLineStatus.SKIPPED));
+        approvalDocumentLineRepository.saveAll(lines);
+
+        approvalActionHistoryRepository.save(
+                ApprovalActionHistory.builder()
+                        .document(document)
+                        .actionType(ApprovalActionType.RECALL)
+                        .fromStatus(fromStatus)
+                        .toStatus(ApprovalStatus.RECALLED)
+                        .actorUser(actor)
+                        .build());
+
+        return ApprovalRecallResponseDto.builder()
+                .documentId(document.getId())
+                .documentNo(document.getDocumentNo())
+                .status(document.getStatus())
+                .statusLabel(document.getStatus().getDescription())
+                .title(document.getTitle())
+                .recalledAt(document.getCompletedAt())
+                .build();
     }
 
     @Transactional

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalWorkflowService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalWorkflowService.java
@@ -1,7 +1,7 @@
 package kr.co.awesomelead.groupware_backend.domain.approval.service;
 
-import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalDecisionRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalCommentCreateRequestDto;
+import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalDecisionRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalDirectSubmitRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalDraftUpsertRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalLineRequestDto;
@@ -1091,7 +1091,8 @@ public class ApprovalWorkflowService {
                 .commentId(comment.getId())
                 .writerUserId(writer != null ? writer.getId() : null)
                 .writerUserName(writer != null ? writer.getDisplayName() : null)
-                .writerDepartmentName(writer != null ? toDepartmentName(writer.getDepartment()) : null)
+                .writerDepartmentName(
+                        writer != null ? toDepartmentName(writer.getDepartment()) : null)
                 .writerPositionName(toPositionName(writer))
                 .content(comment.getContent())
                 .createdAt(comment.getCreatedAt())
@@ -1106,7 +1107,8 @@ public class ApprovalWorkflowService {
                 .documentId(document != null ? document.getId() : null)
                 .writerUserId(writer != null ? writer.getId() : null)
                 .writerUserName(writer != null ? writer.getDisplayName() : null)
-                .writerDepartmentName(writer != null ? toDepartmentName(writer.getDepartment()) : null)
+                .writerDepartmentName(
+                        writer != null ? toDepartmentName(writer.getDepartment()) : null)
                 .writerPositionName(toPositionName(writer))
                 .content(comment.getContent())
                 .createdAt(comment.getCreatedAt())

--- a/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalWorkflowService.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/domain/approval/service/ApprovalWorkflowService.java
@@ -4,13 +4,16 @@ import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalD
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalDraftUpsertRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalLineRequestDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.request.ApprovalSubmitRequestDto;
+import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDetailResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalDraftResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalInboxAllResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalSubmitResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.dto.response.ApprovalTemplateListResponseDto;
 import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalActionHistory;
+import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalAttachment;
 import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalDocument;
 import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalDocumentLine;
+import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalDocumentRead;
 import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalTemplate;
 import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalTemplateCategory;
 import kr.co.awesomelead.groupware_backend.domain.approval.entity.ApprovalTemplateLine;
@@ -21,7 +24,9 @@ import kr.co.awesomelead.groupware_backend.domain.approval.enums.ApprovalStatus;
 import kr.co.awesomelead.groupware_backend.domain.approval.enums.ApprovalTargetType;
 import kr.co.awesomelead.groupware_backend.domain.approval.enums.ApprovalType;
 import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalActionHistoryRepository;
+import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalAttachmentRepository;
 import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalDocumentLineRepository;
+import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalDocumentReadRepository;
 import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalDocumentRepository;
 import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalTemplateCategoryRepository;
 import kr.co.awesomelead.groupware_backend.domain.approval.repository.ApprovalTemplateLineRepository;
@@ -32,6 +37,7 @@ import kr.co.awesomelead.groupware_backend.domain.user.entity.User;
 import kr.co.awesomelead.groupware_backend.domain.user.repository.UserRepository;
 import kr.co.awesomelead.groupware_backend.global.error.CustomException;
 import kr.co.awesomelead.groupware_backend.global.error.ErrorCode;
+import kr.co.awesomelead.groupware_backend.global.infra.s3.service.S3Service;
 
 import lombok.RequiredArgsConstructor;
 
@@ -55,8 +61,11 @@ public class ApprovalWorkflowService {
     private final ApprovalDocumentRepository approvalDocumentRepository;
     private final ApprovalDocumentLineRepository approvalDocumentLineRepository;
     private final ApprovalActionHistoryRepository approvalActionHistoryRepository;
+    private final ApprovalAttachmentRepository approvalAttachmentRepository;
+    private final ApprovalDocumentReadRepository approvalDocumentReadRepository;
     private final UserRepository userRepository;
     private final DepartmentRepository departmentRepository;
+    private final S3Service s3Service;
 
     @Transactional(readOnly = true)
     public ApprovalTemplateListResponseDto getTemplateList() {
@@ -86,6 +95,70 @@ public class ApprovalWorkflowService {
                         .toList();
 
         return ApprovalTemplateListResponseDto.builder().categories(categoryDtos).build();
+    }
+
+    @Transactional(readOnly = true)
+    public ApprovalDetailResponseDto getApprovalDetail(Long userId, Long documentId) {
+        User user = getUser(userId);
+        Long departmentId = user.getDepartment() != null ? user.getDepartment().getId() : null;
+        ApprovalDocument document =
+                approvalDocumentRepository
+                        .findById(documentId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.APPROVAL_NOT_FOUND));
+
+        if (!canReadDocumentDetail(document, userId, departmentId)) {
+            throw new CustomException(ErrorCode.NOT_APPROVER);
+        }
+
+        List<ApprovalDocumentLine> lines =
+                approvalDocumentLineRepository.findByDocumentIdOrderBySequenceNoAscIdAsc(
+                        documentId);
+        List<ApprovalAttachment> attachments =
+                approvalAttachmentRepository.findByDocumentIdOrderByIdAsc(documentId);
+        List<ApprovalActionHistory> actionHistories =
+                approvalActionHistoryRepository.findByDocumentIdOrderByCreatedAtAscIdAsc(
+                        documentId);
+        List<ApprovalDocumentRead> reads =
+                approvalDocumentReadRepository.findByDocumentIdOrderByIdAsc(documentId);
+
+        User drafterUser = document.getDrafterUser();
+        Department drafterDepartment = document.getDrafterDepartment();
+        Department receiverDepartment = document.getReceiverDepartment();
+
+        return ApprovalDetailResponseDto.builder()
+                .documentId(document.getId())
+                .documentNo(document.getDocumentNo())
+                .templateId(document.getTemplate() != null ? document.getTemplate().getId() : null)
+                .templateCode(document.getTemplateCodeSnapshot())
+                .templateName(document.getTemplateNameSnapshot())
+                .title(document.getTitle())
+                .contentDelta(document.getContentDelta())
+                .contentHtml(document.getContentHtml())
+                .approvalType(document.getApprovalType())
+                .approvalTypeLabel(
+                        document.getApprovalType() != null
+                                ? document.getApprovalType().getDescription()
+                                : null)
+                .status(document.getStatus())
+                .statusLabel(
+                        document.getStatus() != null ? document.getStatus().getDescription() : null)
+                .drafterUserId(drafterUser != null ? drafterUser.getId() : null)
+                .drafterUserName(drafterUser != null ? drafterUser.getDisplayName() : null)
+                .drafterDepartmentId(drafterDepartment != null ? drafterDepartment.getId() : null)
+                .drafterDepartmentName(toDepartmentName(drafterDepartment))
+                .receiverDepartmentId(
+                        receiverDepartment != null ? receiverDepartment.getId() : null)
+                .receiverDepartmentName(toDepartmentName(receiverDepartment))
+                .mine(drafterUser != null && userId.equals(drafterUser.getId()))
+                .submittedAt(document.getSubmittedAt())
+                .completedAt(document.getCompletedAt())
+                .createdAt(document.getCreatedAt())
+                .modifiedAt(document.getModifiedAt())
+                .lines(toDetailLineDtos(lines))
+                .attachments(toAttachmentDtos(attachments))
+                .actionHistories(toActionHistoryDtos(actionHistories))
+                .reads(toReadDtos(reads))
+                .build();
     }
 
     @Transactional(readOnly = true)
@@ -463,6 +536,122 @@ public class ApprovalWorkflowService {
         return submit(userId, draftResult.getDocumentId(), submitRequest);
     }
 
+    private List<ApprovalDetailResponseDto.LineDto> toDetailLineDtos(
+            List<ApprovalDocumentLine> lines) {
+        return lines.stream()
+                .sorted(
+                        Comparator.comparing(
+                                        ApprovalDocumentLine::getSequenceNo,
+                                        Comparator.nullsLast(Integer::compareTo))
+                                .thenComparing(ApprovalDocumentLine::getId))
+                .map(this::toDetailLineDto)
+                .toList();
+    }
+
+    private ApprovalDetailResponseDto.LineDto toDetailLineDto(ApprovalDocumentLine line) {
+        User processedByUser = line.getProcessedByUser();
+        return ApprovalDetailResponseDto.LineDto.builder()
+                .lineId(line.getId())
+                .role(line.getRole())
+                .roleLabel(line.getRole() != null ? line.getRole().getDescription() : null)
+                .targetType(line.getTargetType())
+                .targetUserId(line.getTargetUser() != null ? line.getTargetUser().getId() : null)
+                .targetDepartmentId(
+                        line.getTargetDepartment() != null
+                                ? line.getTargetDepartment().getId()
+                                : null)
+                .targetName(line.getTargetNameSnapshot())
+                .sequenceNo(line.getSequenceNo())
+                .required(line.getIsRequired())
+                .lineStatus(line.getLineStatus())
+                .lineStatusLabel(
+                        line.getLineStatus() != null ? line.getLineStatus().getDescription() : null)
+                .processedByUserId(processedByUser != null ? processedByUser.getId() : null)
+                .processedByUserName(
+                        processedByUser != null ? processedByUser.getDisplayName() : null)
+                .processedComment(line.getProcessedComment())
+                .processedAt(line.getProcessedAt())
+                .build();
+    }
+
+    private List<ApprovalDetailResponseDto.AttachmentDto> toAttachmentDtos(
+            List<ApprovalAttachment> attachments) {
+        return attachments.stream().map(this::toAttachmentDto).toList();
+    }
+
+    private ApprovalDetailResponseDto.AttachmentDto toAttachmentDto(ApprovalAttachment attachment) {
+        User uploadedByUser = attachment.getUploadedByUser();
+        return ApprovalDetailResponseDto.AttachmentDto.builder()
+                .attachmentId(attachment.getId())
+                .originalFileName(attachment.getOriginalFileName())
+                .fileKey(attachment.getS3Key())
+                .fileSize(attachment.getFileSize())
+                .viewUrl(s3Service.getProxyViewUrl(attachment.getS3Key()))
+                .downloadUrl(
+                        s3Service.getPresignedDownloadUrl(
+                                attachment.getS3Key(), attachment.getOriginalFileName()))
+                .uploadedByUserId(uploadedByUser != null ? uploadedByUser.getId() : null)
+                .uploadedByUserName(
+                        uploadedByUser != null ? uploadedByUser.getDisplayName() : null)
+                .build();
+    }
+
+    private List<ApprovalDetailResponseDto.ActionHistoryDto> toActionHistoryDtos(
+            List<ApprovalActionHistory> actionHistories) {
+        return actionHistories.stream().map(this::toActionHistoryDto).toList();
+    }
+
+    private ApprovalDetailResponseDto.ActionHistoryDto toActionHistoryDto(
+            ApprovalActionHistory history) {
+        User actorUser = history.getActorUser();
+        return ApprovalDetailResponseDto.ActionHistoryDto.builder()
+                .historyId(history.getId())
+                .actionType(history.getActionType())
+                .actionTypeLabel(
+                        history.getActionType() != null
+                                ? history.getActionType().getDescription()
+                                : null)
+                .fromStatus(history.getFromStatus())
+                .fromStatusLabel(
+                        history.getFromStatus() != null
+                                ? history.getFromStatus().getDescription()
+                                : null)
+                .toStatus(history.getToStatus())
+                .toStatusLabel(
+                        history.getToStatus() != null
+                                ? history.getToStatus().getDescription()
+                                : null)
+                .actorUserId(actorUser != null ? actorUser.getId() : null)
+                .actorUserName(actorUser != null ? actorUser.getDisplayName() : null)
+                .actionComment(history.getActionComment())
+                .createdAt(history.getCreatedAt())
+                .build();
+    }
+
+    private List<ApprovalDetailResponseDto.ReadDto> toReadDtos(List<ApprovalDocumentRead> reads) {
+        return reads.stream().map(this::toReadDto).toList();
+    }
+
+    private ApprovalDetailResponseDto.ReadDto toReadDto(ApprovalDocumentRead read) {
+        return ApprovalDetailResponseDto.ReadDto.builder()
+                .readId(read.getId())
+                .readRole(read.getReadRole())
+                .targetType(read.getTargetType())
+                .targetUserId(read.getTargetUser() != null ? read.getTargetUser().getId() : null)
+                .targetDepartmentId(
+                        read.getTargetDepartment() != null
+                                ? read.getTargetDepartment().getId()
+                                : null)
+                .targetName(
+                        toTargetName(
+                                read.getTargetType(),
+                                read.getTargetUser(),
+                                read.getTargetDepartment()))
+                .read(read.getIsRead())
+                .readAt(read.getReadAt())
+                .build();
+    }
+
     private ApprovalTemplateListResponseDto.TemplateDto toTemplateDto(ApprovalTemplate template) {
         List<ApprovalTemplateLine> lines =
                 approvalTemplateLineRepository.findByTemplateIdOrderBySequenceNoAscIdAsc(
@@ -512,6 +701,19 @@ public class ApprovalWorkflowService {
                 || isBeforeMyTurnDocument(document, userId, departmentId)
                 || isProcessedByMeDocument(document, userId, departmentId)
                 || isRejectedOrRecalledDocument(document, userId, departmentId);
+    }
+
+    private boolean canReadDocumentDetail(
+            ApprovalDocument document, Long userId, Long departmentId) {
+        if (document.getStatus() == ApprovalStatus.DRAFT) {
+            return isDraftedByMe(document, userId);
+        }
+        return isDraftedByMe(document, userId)
+                || isMyApprovalDocument(document, userId, departmentId)
+                || isReferenceDocument(document, userId, departmentId)
+                || isViewerAcquiredDocument(document, userId, departmentId)
+                || isViewerGrantedDocument(document, userId)
+                || (departmentId != null && isDepartmentBoxDocument(document, departmentId));
     }
 
     private boolean isDraftBoxDocument(ApprovalDocument document, Long userId) {
@@ -1099,6 +1301,13 @@ public class ApprovalWorkflowService {
             return "[" + departmentName + "] " + name + " (" + position + ")";
         }
         return "[" + departmentName + "] " + name;
+    }
+
+    private String toDepartmentName(Department department) {
+        if (department == null || department.getName() == null) {
+            return null;
+        }
+        return department.getName().getDescription();
     }
 
     private User getUser(Long userId) {

--- a/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
+++ b/src/main/java/kr/co/awesomelead/groupware_backend/global/error/ErrorCode.java
@@ -147,6 +147,7 @@ public enum ErrorCode {
     APPROVAL_TEMPLATE_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 전자결재 양식구분을 찾을 수 없습니다."),
     APPROVAL_TEMPLATE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 전자결재 양식을 찾을 수 없습니다."),
     SAVED_APPROVAL_LINE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 저장 결재선을 찾을 수 없습니다."),
+    APPROVAL_ATTACHMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 전자결재 첨부파일을 찾을 수 없습니다."),
 
     // 409 Conflict
     DUPLICATED_SIGNUP_REQUEST(HttpStatus.CONFLICT, "이미 처리된 가입 요청입니다."),

--- a/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
+++ b/src/test/java/kr/co/awesomelead/groupware_backend/domain/annualleave/AnnualLeaveServiceTest.java
@@ -384,7 +384,7 @@ public class AnnualLeaveServiceTest {
             assertThat(result.get(0).getTitle()).isEqualTo("2026년");
             assertThat(result.get(0).getTotalCount()).isEqualTo(3);
             assertThat(result.get(0).getItems().get(0).getDispatchId()).isEqualTo(10L);
-            assertThat(result.get(0).getItems().get(0).getTitle()).isEqualTo("6월");
+            assertThat(result.get(0).getItems().get(0).getTitle()).isEqualTo("2026년 6월");
             assertThat(result.get(0).getItems().get(0).getOriginalFileName())
                     .isEqualTo("2026_연차현황.xlsx");
             assertThat(result.get(0).getItems().get(0).getSheetName()).isEqualTo("2026-06");
@@ -393,12 +393,12 @@ public class AnnualLeaveServiceTest {
                     .isEqualTo(LocalDateTime.of(2026, 6, 1, 9, 0));
             assertThat(result.get(0).getItems().get(0).getSenderName()).isEqualTo("테스트 업로더");
             assertThat(result.get(0).getItems().get(0).getSenderPosition()).isEqualTo("과장");
-            assertThat(result.get(0).getItems().get(1).getTitle()).isEqualTo("6월");
+            assertThat(result.get(0).getItems().get(1).getTitle()).isEqualTo("2026년 6월");
             assertThat(result.get(0).getItems().get(1).getOriginalFileName())
                     .isEqualTo("2026_연차현황_수정본.xlsx");
             assertThat(result.get(0).getItems().get(0).getFileUrl())
                     .isEqualTo("https://example.com/annual-leave-2026-06-first");
-            assertThat(result.get(0).getItems().get(2).getTitle()).isEqualTo("7월");
+            assertThat(result.get(0).getItems().get(2).getTitle()).isEqualTo("2026년 7월");
             assertThat(result.get(0).getItems().get(2).getFileUrl())
                     .isEqualTo("https://example.com/annual-leave-2026-07-first");
         }
@@ -687,7 +687,7 @@ public class AnnualLeaveServiceTest {
             assertThat(result.getSenderPosition()).isEqualTo("과장");
             assertThat(result.getFileUrl())
                     .isEqualTo("https://example.com/annual-leave-2026-06-first");
-            assertThat(result.getTitle()).isEqualTo("6월");
+            assertThat(result.getTitle()).isEqualTo("2026년 6월");
             assertThat(result.getCompany()).isEqualTo(Company.AWESOME);
         }
     }
@@ -1410,7 +1410,7 @@ public class AnnualLeaveServiceTest {
             @DisplayName("각각 올바른 값을 반환한다")
             void it_returns_title_and_company() {
                 // given
-                String expectedTitle = "7월";
+                String expectedTitle = "2026년 7월";
                 Company expectedCompany = Company.AWESOME;
 
                 // when
@@ -1452,7 +1452,7 @@ public class AnnualLeaveServiceTest {
                 AdminAnnualLeaveDispatchItemResponseDto dto =
                         AdminAnnualLeaveDispatchItemResponseDto.builder()
                                 .dispatchId(10L)
-                                .title("7월")
+                                .title("2026년 7월")
                                 .originalFileName("2026_연차현황.xlsx")
                                 .sheetName("2026-07")
                                 .company(expectedCompany)


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #512 

## 📝작업 내용
- 완결문서 목록 조회 API를 추가했습니다.
- 전자결재 문서 상세 조회 API를 추가하고 결재선, 첨부파일, 처리 이력, 열람 정보를 응답하도록 구현했습니다.
- 임시저장 문서 삭제 API를 추가했습니다.
- 결재진행 문서 회수 API를 추가했습니다.
- 승인/반려/보류 결재처리 API를 추가했습니다.
- 전자결재 첨부파일 추가/삭제 API를 추가했습니다.
- 문서 상세 응답에 결재칸 표시용 정보(`approvalBoxes`)를 추가했습니다.
  - 기안/승인/합의/반려 라벨
  - 처리일자
  - 서명이미지 URL
  - 결재칸 표시 문구
- 전자결재 의견글 등록 API를 추가하고 상세 응답에 의견글 목록을 포함했습니다.
- 전자결재 워크플로우에 알림 발송을 연동했습니다.
  - 상신: 첫 결재자, 참조자
  - 승인: 다음 결재자
  - 최종 승인: 기안자, 열람권자
  - 반려: 기안자
  - 부서 대상 라인은 부서 사용자 목록으로 풀어서 알림 발송
- 관리자 연차 발송 목록 응답의 `title`에 연도를 포함하도록 수정했습니다.
  - 예: `6월` -> `2026년 6월`

## 📸 스크린샷 (선택)

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
X